### PR TITLE
enhance: harden streaming recovery state handling

### DIFF
--- a/internal/streamingnode/server/wal/vchannel/manager.go
+++ b/internal/streamingnode/server/wal/vchannel/manager.go
@@ -54,12 +54,9 @@ type PChannelRecoveryManager struct {
 	pchannel string
 	modules  *typeutil.ConcurrentMap[string, *VChannelRecoveryModule]
 
-	segmentsByVChannel map[string]map[int64]*streamingpb.SegmentAssignmentMeta
-	dirtyMu            sync.Mutex
-	dirtyModules       map[string]*VChannelRecoveryModule
-	// frontierMu serializes generation checks with both cached frontier updates.
-	frontierMu            sync.Mutex
-	frontierGenerations   map[string]uint64
+	segmentsByVChannel    map[string]map[int64]*streamingpb.SegmentAssignmentMeta
+	dirtyMu               sync.Mutex
+	dirtyModules          map[string]*VChannelRecoveryModule
 	durableFrontiers      *minimumFrontierIndex[string]
 	materializedFrontiers *minimumFrontierIndex[string]
 
@@ -80,7 +77,6 @@ func NewPChannelRecoveryManager(config PChannelManagerConfig) (*PChannelRecovery
 		modules:               typeutil.NewConcurrentMap[string, *VChannelRecoveryModule](),
 		segmentsByVChannel:    segmentsByVChannel,
 		dirtyModules:          make(map[string]*VChannelRecoveryModule),
-		frontierGenerations:   make(map[string]uint64),
 		durableFrontiers:      newMinimumFrontierIndex[string](),
 		materializedFrontiers: newMinimumFrontierIndex[string](),
 		config:                config,
@@ -414,7 +410,7 @@ func (m *PChannelRecoveryManager) newModule(vchannel string) (*VChannelRecoveryM
 			m.markModuleUpdatedByVChannel(vchannel)
 		},
 	}
-	module, err := NewModule(ModuleConfig{
+	return NewModule(ModuleConfig{
 		PChannel:                   m.pchannel,
 		VChannel:                   vchannel,
 		VChannelMeta:               m.config.VChannelMetas[vchannel],
@@ -437,19 +433,19 @@ func (m *PChannelRecoveryManager) newModule(vchannel string) (*VChannelRecoveryM
 		QueryViewLoadInfoProvider:  m.config.QueryViewLoadInfoProvider,
 		NodeScheduler:              m.config.NodeScheduler,
 		QueryRuntimeDispatcher:     m.queryDispatcher,
+		OnFrontierUpdated:          func() { m.refreshModuleFrontiersByVChannel(vchannel) },
 	})
-	if err != nil {
-		return nil, err
-	}
-	module.onFrontierUpdated = func(snapshot moduleFrontierSnapshot) {
-		m.updateModuleFrontiers(module, snapshot)
-	}
-	return module, nil
 }
 
 func (m *PChannelRecoveryManager) markModuleUpdatedByVChannel(vchannel string) {
 	if module := m.Module(vchannel); module != nil {
 		m.markModuleUpdated(module)
+	}
+}
+
+func (m *PChannelRecoveryManager) refreshModuleFrontiersByVChannel(vchannel string) {
+	if module := m.Module(vchannel); module != nil {
+		m.refreshModuleFrontiers(module)
 	}
 }
 
@@ -479,21 +475,8 @@ func (m *PChannelRecoveryManager) refreshModuleFrontiers(module *VChannelRecover
 	if module == nil {
 		return
 	}
-	m.updateModuleFrontiers(module, module.frontierSnapshot())
-}
-
-func (m *PChannelRecoveryManager) updateModuleFrontiers(module *VChannelRecoveryModule, snapshot moduleFrontierSnapshot) {
-	if module == nil || m.Module(module.vchannel) != module {
-		return
-	}
-	m.frontierMu.Lock()
-	defer m.frontierMu.Unlock()
-	if generation := m.frontierGenerations[module.vchannel]; snapshot.generation <= generation {
-		return
-	}
-	m.frontierGenerations[module.vchannel] = snapshot.generation
-	m.durableFrontiers.Update(module.vchannel, snapshot.durableTimeTick)
-	m.materializedFrontiers.Update(module.vchannel, snapshot.materializedTimeTick)
+	m.durableFrontiers.Update(module.vchannel, module.dataFrontierTimeTick(moduleapi.DataProgressDurable))
+	m.materializedFrontiers.Update(module.vchannel, module.dataFrontierTimeTick(moduleapi.DataProgressMaterialized))
 }
 
 type dirtyTrackingNotifier struct {

--- a/internal/streamingnode/server/wal/vchannel/manager.go
+++ b/internal/streamingnode/server/wal/vchannel/manager.go
@@ -49,12 +49,18 @@ type PChannelManagerConfig struct {
 	NodeScheduler              nodescheduler.Scheduler
 }
 
+type initialVChannelState struct {
+	vchannelMeta              *streamingpb.VChannelMeta
+	segments                  map[int64]*streamingpb.SegmentAssignmentMeta
+	segmentDataVersionSummary *streamingpb.SegmentDataVersionSummary
+	transformLogMeta          *streamingpb.VChannelTransformLogMeta
+}
+
 // PChannelRecoveryManager owns all vchannel recovery modules on one pchannel.
 type PChannelRecoveryManager struct {
 	pchannel string
 	modules  *typeutil.ConcurrentMap[string, *VChannelRecoveryModule]
 
-	segmentsByVChannel    map[string]map[int64]*streamingpb.SegmentAssignmentMeta
 	dirtyMu               sync.Mutex
 	dirtyModules          map[string]*VChannelRecoveryModule
 	durableFrontiers      *minimumFrontierIndex[string]
@@ -71,12 +77,14 @@ func NewPChannelRecoveryManager(config PChannelManagerConfig) (*PChannelRecovery
 	if config.PChannel == "" {
 		return nil, merr.WrapErrServiceInternalMsg("pchannel recovery manager pchannel is empty")
 	}
-	segmentsByVChannel := groupSegmentsByVChannel(config.Segments)
+	initialStates := buildInitialVChannelStates(config)
+	config.VChannelMetas = nil
 	config.Segments = nil
+	config.SegmentDataVersionSummary = nil
+	config.TransformLogMetas = nil
 	manager := &PChannelRecoveryManager{
 		pchannel:              config.PChannel,
 		modules:               typeutil.NewConcurrentMap[string, *VChannelRecoveryModule](),
-		segmentsByVChannel:    segmentsByVChannel,
 		dirtyModules:          make(map[string]*VChannelRecoveryModule),
 		durableFrontiers:      newMinimumFrontierIndex[string](),
 		materializedFrontiers: newMinimumFrontierIndex[string](),
@@ -90,8 +98,8 @@ func NewPChannelRecoveryManager(config PChannelManagerConfig) (*PChannelRecovery
 		return nil, err
 	}
 	manager.queryTransformLogStream = queryTransformLogStream
-	for _, vchannel := range manager.initialVChannels(config) {
-		module, err := manager.newModule(vchannel)
+	for _, vchannel := range sortedInitialVChannels(initialStates) {
+		module, err := manager.newModule(vchannel, initialStates[vchannel])
 		if err != nil {
 			manager.Close()
 			return nil, err
@@ -103,41 +111,47 @@ func NewPChannelRecoveryManager(config PChannelManagerConfig) (*PChannelRecovery
 	return manager, nil
 }
 
-func (m *PChannelRecoveryManager) initialVChannels(config PChannelManagerConfig) []string {
-	index := make(map[string]struct{})
-	for vchannel := range config.VChannelMetas {
-		index[vchannel] = struct{}{}
+// buildInitialVChannelStates groups recovered metadata once so creating each
+// vchannel module does not rescan every recovered segment.
+func buildInitialVChannelStates(config PChannelManagerConfig) map[string]initialVChannelState {
+	states := make(map[string]initialVChannelState, len(config.VChannelMetas))
+	for vchannel, meta := range config.VChannelMetas {
+		state := states[vchannel]
+		state.vchannelMeta = meta
+		states[vchannel] = state
 	}
-	for vchannel := range m.segmentsByVChannel {
-		index[vchannel] = struct{}{}
-	}
-	for vchannel := range config.SegmentDataVersionSummary {
-		index[vchannel] = struct{}{}
-	}
-	for vchannel := range config.TransformLogMetas {
-		index[vchannel] = struct{}{}
-	}
-	vchannels := make([]string, 0, len(index))
-	for vchannel := range index {
-		vchannels = append(vchannels, vchannel)
-	}
-	sort.Strings(vchannels)
-	return vchannels
-}
-
-func groupSegmentsByVChannel(segments map[int64]*streamingpb.SegmentAssignmentMeta) map[string]map[int64]*streamingpb.SegmentAssignmentMeta {
-	grouped := make(map[string]map[int64]*streamingpb.SegmentAssignmentMeta)
-	for id, meta := range segments {
+	for id, meta := range config.Segments {
 		vchannel := meta.GetVchannel()
 		if vchannel == "" {
 			continue
 		}
-		if grouped[vchannel] == nil {
-			grouped[vchannel] = make(map[int64]*streamingpb.SegmentAssignmentMeta)
+		state := states[vchannel]
+		if state.segments == nil {
+			state.segments = make(map[int64]*streamingpb.SegmentAssignmentMeta)
 		}
-		grouped[vchannel][id] = meta
+		state.segments[id] = meta
+		states[vchannel] = state
 	}
-	return grouped
+	for vchannel, summary := range config.SegmentDataVersionSummary {
+		state := states[vchannel]
+		state.segmentDataVersionSummary = summary
+		states[vchannel] = state
+	}
+	for vchannel, meta := range config.TransformLogMetas {
+		state := states[vchannel]
+		state.transformLogMeta = meta
+		states[vchannel] = state
+	}
+	return states
+}
+
+func sortedInitialVChannels(states map[string]initialVChannelState) []string {
+	vchannels := make([]string, 0, len(states))
+	for vchannel := range states {
+		vchannels = append(vchannels, vchannel)
+	}
+	sort.Strings(vchannels)
+	return vchannels
 }
 
 func (m *PChannelRecoveryManager) Name() moduleapi.ModuleName {
@@ -374,7 +388,7 @@ func (m *PChannelRecoveryManager) moduleForMessage(msg message.ImmutableMessage)
 	if module != nil || msg.MessageType() != message.MessageTypeCreateCollection {
 		return module
 	}
-	module, err := m.newModule(vchannel)
+	module, err := m.newModule(vchannel, initialVChannelState{})
 	if err != nil {
 		return nil
 	}
@@ -394,7 +408,7 @@ func (m *PChannelRecoveryManager) moduleForMessage(msg message.ImmutableMessage)
 	return module
 }
 
-func (m *PChannelRecoveryManager) newModule(vchannel string) (*VChannelRecoveryModule, error) {
+func (m *PChannelRecoveryManager) newModule(vchannel string, initialState initialVChannelState) (*VChannelRecoveryModule, error) {
 	runtime := m.config.Runtime
 	runtime.Notifier = &dirtyTrackingNotifier{
 		inner: runtime.Notifier,
@@ -405,10 +419,10 @@ func (m *PChannelRecoveryManager) newModule(vchannel string) (*VChannelRecoveryM
 	return NewModule(ModuleConfig{
 		PChannel:                   m.pchannel,
 		VChannel:                   vchannel,
-		VChannelMeta:               m.config.VChannelMetas[vchannel],
-		Segments:                   m.segmentsByVChannel[vchannel],
-		SegmentDataVersionSummary:  m.config.SegmentDataVersionSummary[vchannel],
-		TransformLogMeta:           m.config.TransformLogMetas[vchannel],
+		VChannelMeta:               initialState.vchannelMeta,
+		Segments:                   initialState.segments,
+		SegmentDataVersionSummary:  initialState.segmentDataVersionSummary,
+		TransformLogMeta:           initialState.transformLogMeta,
 		Runtime:                    runtime,
 		Logger:                     m.config.Logger,
 		SegmentLifecycle:           m.config.SegmentLifecycle,

--- a/internal/streamingnode/server/wal/vchannel/manager.go
+++ b/internal/streamingnode/server/wal/vchannel/manager.go
@@ -49,20 +49,17 @@ type PChannelManagerConfig struct {
 	NodeScheduler              nodescheduler.Scheduler
 }
 
-type initialVChannelState struct {
-	vchannelMeta              *streamingpb.VChannelMeta
-	segments                  map[int64]*streamingpb.SegmentAssignmentMeta
-	segmentDataVersionSummary *streamingpb.SegmentDataVersionSummary
-	transformLogMeta          *streamingpb.VChannelTransformLogMeta
-}
-
 // PChannelRecoveryManager owns all vchannel recovery modules on one pchannel.
 type PChannelRecoveryManager struct {
 	pchannel string
 	modules  *typeutil.ConcurrentMap[string, *VChannelRecoveryModule]
 
-	dirtyMu               sync.Mutex
-	dirtyModules          map[string]*VChannelRecoveryModule
+	segmentsByVChannel map[string]map[int64]*streamingpb.SegmentAssignmentMeta
+	dirtyMu            sync.Mutex
+	dirtyModules       map[string]*VChannelRecoveryModule
+	// frontierMu serializes generation checks with both cached frontier updates.
+	frontierMu            sync.Mutex
+	frontierGenerations   map[string]uint64
 	durableFrontiers      *minimumFrontierIndex[string]
 	materializedFrontiers *minimumFrontierIndex[string]
 
@@ -77,15 +74,13 @@ func NewPChannelRecoveryManager(config PChannelManagerConfig) (*PChannelRecovery
 	if config.PChannel == "" {
 		return nil, merr.WrapErrServiceInternalMsg("pchannel recovery manager pchannel is empty")
 	}
-	initialStates := buildInitialVChannelStates(config)
-	config.VChannelMetas = nil
-	config.Segments = nil
-	config.SegmentDataVersionSummary = nil
-	config.TransformLogMetas = nil
+	segmentsByVChannel := groupSegmentsByVChannel(config.Segments)
 	manager := &PChannelRecoveryManager{
 		pchannel:              config.PChannel,
 		modules:               typeutil.NewConcurrentMap[string, *VChannelRecoveryModule](),
+		segmentsByVChannel:    segmentsByVChannel,
 		dirtyModules:          make(map[string]*VChannelRecoveryModule),
+		frontierGenerations:   make(map[string]uint64),
 		durableFrontiers:      newMinimumFrontierIndex[string](),
 		materializedFrontiers: newMinimumFrontierIndex[string](),
 		config:                config,
@@ -98,8 +93,8 @@ func NewPChannelRecoveryManager(config PChannelManagerConfig) (*PChannelRecovery
 		return nil, err
 	}
 	manager.queryTransformLogStream = queryTransformLogStream
-	for _, vchannel := range sortedInitialVChannels(initialStates) {
-		module, err := manager.newModule(vchannel, initialStates[vchannel])
+	for _, vchannel := range manager.initialVChannels(config) {
+		module, err := manager.newModule(vchannel)
 		if err != nil {
 			manager.Close()
 			return nil, err
@@ -108,50 +103,53 @@ func NewPChannelRecoveryManager(config PChannelManagerConfig) (*PChannelRecovery
 		manager.refreshModuleFrontiers(module)
 		manager.syncTransformLogStream(module)
 	}
+	manager.releaseInitialState()
 	return manager, nil
 }
 
-// buildInitialVChannelStates groups recovered metadata once so creating each
-// vchannel module does not rescan every recovered segment.
-func buildInitialVChannelStates(config PChannelManagerConfig) map[string]initialVChannelState {
-	states := make(map[string]initialVChannelState, len(config.VChannelMetas))
-	for vchannel, meta := range config.VChannelMetas {
-		state := states[vchannel]
-		state.vchannelMeta = meta
-		states[vchannel] = state
+func (m *PChannelRecoveryManager) initialVChannels(config PChannelManagerConfig) []string {
+	index := make(map[string]struct{})
+	for vchannel := range config.VChannelMetas {
+		index[vchannel] = struct{}{}
 	}
-	for id, meta := range config.Segments {
-		vchannel := meta.GetVchannel()
-		if vchannel == "" {
-			continue
-		}
-		state := states[vchannel]
-		if state.segments == nil {
-			state.segments = make(map[int64]*streamingpb.SegmentAssignmentMeta)
-		}
-		state.segments[id] = meta
-		states[vchannel] = state
+	for vchannel := range m.segmentsByVChannel {
+		index[vchannel] = struct{}{}
 	}
-	for vchannel, summary := range config.SegmentDataVersionSummary {
-		state := states[vchannel]
-		state.segmentDataVersionSummary = summary
-		states[vchannel] = state
+	for vchannel := range config.SegmentDataVersionSummary {
+		index[vchannel] = struct{}{}
 	}
-	for vchannel, meta := range config.TransformLogMetas {
-		state := states[vchannel]
-		state.transformLogMeta = meta
-		states[vchannel] = state
+	for vchannel := range config.TransformLogMetas {
+		index[vchannel] = struct{}{}
 	}
-	return states
-}
-
-func sortedInitialVChannels(states map[string]initialVChannelState) []string {
-	vchannels := make([]string, 0, len(states))
-	for vchannel := range states {
+	vchannels := make([]string, 0, len(index))
+	for vchannel := range index {
 		vchannels = append(vchannels, vchannel)
 	}
 	sort.Strings(vchannels)
 	return vchannels
+}
+
+func groupSegmentsByVChannel(segments map[int64]*streamingpb.SegmentAssignmentMeta) map[string]map[int64]*streamingpb.SegmentAssignmentMeta {
+	grouped := make(map[string]map[int64]*streamingpb.SegmentAssignmentMeta)
+	for id, meta := range segments {
+		vchannel := meta.GetVchannel()
+		if vchannel == "" {
+			continue
+		}
+		if grouped[vchannel] == nil {
+			grouped[vchannel] = make(map[int64]*streamingpb.SegmentAssignmentMeta)
+		}
+		grouped[vchannel][id] = meta
+	}
+	return grouped
+}
+
+func (m *PChannelRecoveryManager) releaseInitialState() {
+	m.config.VChannelMetas = nil
+	m.config.Segments = nil
+	m.config.SegmentDataVersionSummary = nil
+	m.config.TransformLogMetas = nil
+	m.segmentsByVChannel = nil
 }
 
 func (m *PChannelRecoveryManager) Name() moduleapi.ModuleName {
@@ -388,7 +386,7 @@ func (m *PChannelRecoveryManager) moduleForMessage(msg message.ImmutableMessage)
 	if module != nil || msg.MessageType() != message.MessageTypeCreateCollection {
 		return module
 	}
-	module, err := m.newModule(vchannel, initialVChannelState{})
+	module, err := m.newModule(vchannel)
 	if err != nil {
 		return nil
 	}
@@ -408,7 +406,7 @@ func (m *PChannelRecoveryManager) moduleForMessage(msg message.ImmutableMessage)
 	return module
 }
 
-func (m *PChannelRecoveryManager) newModule(vchannel string, initialState initialVChannelState) (*VChannelRecoveryModule, error) {
+func (m *PChannelRecoveryManager) newModule(vchannel string) (*VChannelRecoveryModule, error) {
 	runtime := m.config.Runtime
 	runtime.Notifier = &dirtyTrackingNotifier{
 		inner: runtime.Notifier,
@@ -416,13 +414,13 @@ func (m *PChannelRecoveryManager) newModule(vchannel string, initialState initia
 			m.markModuleUpdatedByVChannel(vchannel)
 		},
 	}
-	return NewModule(ModuleConfig{
+	module, err := NewModule(ModuleConfig{
 		PChannel:                   m.pchannel,
 		VChannel:                   vchannel,
-		VChannelMeta:               initialState.vchannelMeta,
-		Segments:                   initialState.segments,
-		SegmentDataVersionSummary:  initialState.segmentDataVersionSummary,
-		TransformLogMeta:           initialState.transformLogMeta,
+		VChannelMeta:               m.config.VChannelMetas[vchannel],
+		Segments:                   m.segmentsByVChannel[vchannel],
+		SegmentDataVersionSummary:  m.config.SegmentDataVersionSummary[vchannel],
+		TransformLogMeta:           m.config.TransformLogMetas[vchannel],
 		Runtime:                    runtime,
 		Logger:                     m.config.Logger,
 		SegmentLifecycle:           m.config.SegmentLifecycle,
@@ -439,19 +437,19 @@ func (m *PChannelRecoveryManager) newModule(vchannel string, initialState initia
 		QueryViewLoadInfoProvider:  m.config.QueryViewLoadInfoProvider,
 		NodeScheduler:              m.config.NodeScheduler,
 		QueryRuntimeDispatcher:     m.queryDispatcher,
-		OnFrontierUpdated:          func() { m.refreshModuleFrontiersByVChannel(vchannel) },
 	})
+	if err != nil {
+		return nil, err
+	}
+	module.onFrontierUpdated = func(snapshot moduleFrontierSnapshot) {
+		m.updateModuleFrontiers(module, snapshot)
+	}
+	return module, nil
 }
 
 func (m *PChannelRecoveryManager) markModuleUpdatedByVChannel(vchannel string) {
 	if module := m.Module(vchannel); module != nil {
 		m.markModuleUpdated(module)
-	}
-}
-
-func (m *PChannelRecoveryManager) refreshModuleFrontiersByVChannel(vchannel string) {
-	if module := m.Module(vchannel); module != nil {
-		m.refreshModuleFrontiers(module)
 	}
 }
 
@@ -481,8 +479,21 @@ func (m *PChannelRecoveryManager) refreshModuleFrontiers(module *VChannelRecover
 	if module == nil {
 		return
 	}
-	m.durableFrontiers.Update(module.vchannel, module.dataFrontierTimeTick(moduleapi.DataProgressDurable))
-	m.materializedFrontiers.Update(module.vchannel, module.dataFrontierTimeTick(moduleapi.DataProgressMaterialized))
+	m.updateModuleFrontiers(module, module.frontierSnapshot())
+}
+
+func (m *PChannelRecoveryManager) updateModuleFrontiers(module *VChannelRecoveryModule, snapshot moduleFrontierSnapshot) {
+	if module == nil || m.Module(module.vchannel) != module {
+		return
+	}
+	m.frontierMu.Lock()
+	defer m.frontierMu.Unlock()
+	if generation := m.frontierGenerations[module.vchannel]; snapshot.generation <= generation {
+		return
+	}
+	m.frontierGenerations[module.vchannel] = snapshot.generation
+	m.durableFrontiers.Update(module.vchannel, snapshot.durableTimeTick)
+	m.materializedFrontiers.Update(module.vchannel, snapshot.materializedTimeTick)
 }
 
 type dirtyTrackingNotifier struct {

--- a/internal/streamingnode/server/wal/vchannel/manager_test.go
+++ b/internal/streamingnode/server/wal/vchannel/manager_test.go
@@ -2,6 +2,7 @@ package vchannel
 
 import (
 	"context"
+	"strconv"
 	"testing"
 	"time"
 
@@ -85,18 +86,114 @@ func TestPChannelRecoveryManagerSwitchAggregatesVChannelMetaSnapshot(t *testing.
 	assert.ElementsMatch(t, []string{"v1", "v2"}, mapKeys(vchannelSnapshots[0].VChannels))
 }
 
-func TestGroupSegmentsByVChannel(t *testing.T) {
-	segments := map[int64]*streamingpb.SegmentAssignmentMeta{
-		1: {SegmentId: 1, Vchannel: "v1"},
-		2: {SegmentId: 2, Vchannel: "v2"},
-		3: {SegmentId: 3, Vchannel: "v1"},
-		4: {SegmentId: 4},
+func TestBuildInitialVChannelStates(t *testing.T) {
+	vchannelMeta := newTestVChannelMeta("v1")
+	v1Segment := &streamingpb.SegmentAssignmentMeta{SegmentId: 101, Vchannel: "v1"}
+	v2Segment := &streamingpb.SegmentAssignmentMeta{SegmentId: 202, Vchannel: "v2"}
+	versionSummary := &streamingpb.SegmentDataVersionSummary{}
+	transformLogMeta := &streamingpb.VChannelTransformLogMeta{CheckpointTimeTick: 40}
+
+	states := buildInitialVChannelStates(PChannelManagerConfig{
+		VChannelMetas: map[string]*streamingpb.VChannelMeta{
+			"v1": vchannelMeta,
+		},
+		Segments: map[int64]*streamingpb.SegmentAssignmentMeta{
+			101: v1Segment,
+			202: v2Segment,
+			303: {SegmentId: 303},
+		},
+		SegmentDataVersionSummary: map[string]*streamingpb.SegmentDataVersionSummary{
+			"v3": versionSummary,
+		},
+		TransformLogMetas: map[string]*streamingpb.VChannelTransformLogMeta{
+			"v4": transformLogMeta,
+		},
+	})
+
+	assert.Equal(t, []string{"v1", "v2", "v3", "v4"}, sortedInitialVChannels(states))
+	require.NotContains(t, states, "")
+	require.Same(t, vchannelMeta, states["v1"].vchannelMeta)
+	require.Equal(t, map[int64]*streamingpb.SegmentAssignmentMeta{101: v1Segment}, states["v1"].segments)
+	require.Equal(t, map[int64]*streamingpb.SegmentAssignmentMeta{202: v2Segment}, states["v2"].segments)
+	require.Same(t, versionSummary, states["v3"].segmentDataVersionSummary)
+	require.Same(t, transformLogMeta, states["v4"].transformLogMeta)
+}
+
+func TestPChannelRecoveryManagerReleasesInitialState(t *testing.T) {
+	vchannelMeta := newTestVChannelMeta("v1")
+	segmentMeta := &streamingpb.SegmentAssignmentMeta{
+		SegmentId:    101,
+		CollectionId: 100,
+		PartitionId:  10,
+		Vchannel:     "v1",
+		State:        streamingpb.SegmentAssignmentState_SEGMENT_ASSIGNMENT_STATE_GROWING,
+		Stat:         &streamingpb.SegmentAssignmentStat{},
+	}
+	vchannelMetas := map[string]*streamingpb.VChannelMeta{"v1": vchannelMeta}
+	segments := map[int64]*streamingpb.SegmentAssignmentMeta{101: segmentMeta}
+	versionSummary := &streamingpb.SegmentDataVersionSummary{
+		DataVersion: &viewpb.DataVersion{StreamingVersion: 10, CompactVersion: 20},
+	}
+	transformLogMeta := &streamingpb.VChannelTransformLogMeta{CheckpointTimeTick: 30}
+	versionSummaries := map[string]*streamingpb.SegmentDataVersionSummary{"v1": versionSummary}
+	transformLogMetas := map[string]*streamingpb.VChannelTransformLogMeta{"v1": transformLogMeta}
+
+	manager, err := NewPChannelRecoveryManager(PChannelManagerConfig{
+		PChannel:                  "p1",
+		VChannelMetas:             vchannelMetas,
+		Segments:                  segments,
+		SegmentDataVersionSummary: versionSummaries,
+		TransformLogMetas:         transformLogMetas,
+	})
+	require.NoError(t, err)
+	t.Cleanup(manager.Close)
+
+	assert.Nil(t, manager.config.VChannelMetas)
+	assert.Nil(t, manager.config.Segments)
+	assert.Nil(t, manager.config.SegmentDataVersionSummary)
+	assert.Nil(t, manager.config.TransformLogMetas)
+	require.Same(t, vchannelMeta, vchannelMetas["v1"])
+	require.Same(t, segmentMeta, segments[101])
+	require.Same(t, versionSummary, versionSummaries["v1"])
+	require.Same(t, transformLogMeta, transformLogMetas["v1"])
+
+	module := manager.Module("v1")
+	require.NotNil(t, module)
+	require.True(t, proto.Equal(vchannelMeta, module.vchannelView.AssignmentMeta()))
+	require.True(t, proto.Equal(versionSummary, module.segmentDataVersionSummary))
+	require.True(t, proto.Equal(transformLogMeta, module.transformLog.SnapshotMeta()))
+	require.Contains(t, module.segments, int64(101))
+	segmentID, vchannel := module.segments[101].IDAndVChannel()
+	assert.Equal(t, int64(101), segmentID)
+	assert.Equal(t, "v1", vchannel)
+}
+
+func BenchmarkBuildInitialVChannelStates(b *testing.B) {
+	const (
+		vchannelCount = 62_500
+		segmentCount  = 58_000
+	)
+	config := PChannelManagerConfig{
+		VChannelMetas: make(map[string]*streamingpb.VChannelMeta, vchannelCount),
+		Segments:      make(map[int64]*streamingpb.SegmentAssignmentMeta, segmentCount),
+	}
+	for i := 0; i < vchannelCount; i++ {
+		vchannel := "v" + strconv.Itoa(i)
+		config.VChannelMetas[vchannel] = &streamingpb.VChannelMeta{Vchannel: vchannel}
+	}
+	for i := 0; i < segmentCount; i++ {
+		vchannel := "v" + strconv.Itoa(i%vchannelCount)
+		config.Segments[int64(i)] = &streamingpb.SegmentAssignmentMeta{SegmentId: int64(i), Vchannel: vchannel}
 	}
 
-	grouped := groupSegmentsByVChannel(segments)
-	require.Len(t, grouped, 2)
-	assert.ElementsMatch(t, []int64{1, 3}, mapKeys(grouped["v1"]))
-	assert.ElementsMatch(t, []int64{2}, mapKeys(grouped["v2"]))
+	b.ReportAllocs()
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		states := buildInitialVChannelStates(config)
+		if len(states) != vchannelCount {
+			b.Fatalf("unexpected state count: %d", len(states))
+		}
+	}
 }
 
 func TestPChannelRecoveryManagerConsumesDirtySnapshotsFromUpdatedModule(t *testing.T) {

--- a/internal/streamingnode/server/wal/vchannel/manager_test.go
+++ b/internal/streamingnode/server/wal/vchannel/manager_test.go
@@ -2,7 +2,6 @@ package vchannel
 
 import (
 	"context"
-	"math"
 	"testing"
 	"time"
 
@@ -233,41 +232,6 @@ func TestPChannelRecoveryManagerAggregatesDataFrontier(t *testing.T) {
 		Kind: moduleapi.DataProgressDurable,
 	})
 	require.NotNil(t, allFrontier)
-	assert.Equal(t, uint64(0), allFrontier.TimeTick())
-}
-
-func TestPChannelRecoveryManagerScopeAllRejectsLateStaleFrontierSnapshot(t *testing.T) {
-	ctx := context.Background()
-	manager := newTestManager(t, "p1", "v1")
-	manager.SwitchIntoMetaAndData()
-	module := manager.Module("v1")
-	require.NotNil(t, module)
-
-	staleReady := make(chan moduleFrontierSnapshot, 1)
-	applyStale := make(chan struct{})
-	staleApplied := make(chan struct{})
-	go func() {
-		stale := module.frontierSnapshot()
-		staleReady <- stale
-		<-applyStale
-		manager.updateModuleFrontiers(module, stale)
-		close(staleApplied)
-	}()
-
-	stale := <-staleReady
-	assert.Equal(t, uint64(math.MaxUint64), stale.durableTimeTick)
-
-	result := manager.ObserveMessage(ctx, newTestDeleteMessage(t, "v1", 10))
-	require.NotNil(t, result.Data)
-	allFrontier := manager.DataFrontier(moduleapi.Scope{
-		Type: moduleapi.ScopeAll,
-		Kind: moduleapi.DataProgressDurable,
-	})
-	require.NotNil(t, allFrontier)
-	assert.Equal(t, uint64(0), allFrontier.TimeTick())
-
-	close(applyStale)
-	<-staleApplied
 	assert.Equal(t, uint64(0), allFrontier.TimeTick())
 }
 

--- a/internal/streamingnode/server/wal/vchannel/manager_test.go
+++ b/internal/streamingnode/server/wal/vchannel/manager_test.go
@@ -2,7 +2,7 @@ package vchannel
 
 import (
 	"context"
-	"strconv"
+	"math"
 	"testing"
 	"time"
 
@@ -86,37 +86,18 @@ func TestPChannelRecoveryManagerSwitchAggregatesVChannelMetaSnapshot(t *testing.
 	assert.ElementsMatch(t, []string{"v1", "v2"}, mapKeys(vchannelSnapshots[0].VChannels))
 }
 
-func TestBuildInitialVChannelStates(t *testing.T) {
-	vchannelMeta := newTestVChannelMeta("v1")
-	v1Segment := &streamingpb.SegmentAssignmentMeta{SegmentId: 101, Vchannel: "v1"}
-	v2Segment := &streamingpb.SegmentAssignmentMeta{SegmentId: 202, Vchannel: "v2"}
-	versionSummary := &streamingpb.SegmentDataVersionSummary{}
-	transformLogMeta := &streamingpb.VChannelTransformLogMeta{CheckpointTimeTick: 40}
+func TestGroupSegmentsByVChannel(t *testing.T) {
+	segments := map[int64]*streamingpb.SegmentAssignmentMeta{
+		1: {SegmentId: 1, Vchannel: "v1"},
+		2: {SegmentId: 2, Vchannel: "v2"},
+		3: {SegmentId: 3, Vchannel: "v1"},
+		4: {SegmentId: 4},
+	}
 
-	states := buildInitialVChannelStates(PChannelManagerConfig{
-		VChannelMetas: map[string]*streamingpb.VChannelMeta{
-			"v1": vchannelMeta,
-		},
-		Segments: map[int64]*streamingpb.SegmentAssignmentMeta{
-			101: v1Segment,
-			202: v2Segment,
-			303: {SegmentId: 303},
-		},
-		SegmentDataVersionSummary: map[string]*streamingpb.SegmentDataVersionSummary{
-			"v3": versionSummary,
-		},
-		TransformLogMetas: map[string]*streamingpb.VChannelTransformLogMeta{
-			"v4": transformLogMeta,
-		},
-	})
-
-	assert.Equal(t, []string{"v1", "v2", "v3", "v4"}, sortedInitialVChannels(states))
-	require.NotContains(t, states, "")
-	require.Same(t, vchannelMeta, states["v1"].vchannelMeta)
-	require.Equal(t, map[int64]*streamingpb.SegmentAssignmentMeta{101: v1Segment}, states["v1"].segments)
-	require.Equal(t, map[int64]*streamingpb.SegmentAssignmentMeta{202: v2Segment}, states["v2"].segments)
-	require.Same(t, versionSummary, states["v3"].segmentDataVersionSummary)
-	require.Same(t, transformLogMeta, states["v4"].transformLogMeta)
+	grouped := groupSegmentsByVChannel(segments)
+	require.Len(t, grouped, 2)
+	assert.ElementsMatch(t, []int64{1, 3}, mapKeys(grouped["v1"]))
+	assert.ElementsMatch(t, []int64{2}, mapKeys(grouped["v2"]))
 }
 
 func TestPChannelRecoveryManagerReleasesInitialState(t *testing.T) {
@@ -152,6 +133,7 @@ func TestPChannelRecoveryManagerReleasesInitialState(t *testing.T) {
 	assert.Nil(t, manager.config.Segments)
 	assert.Nil(t, manager.config.SegmentDataVersionSummary)
 	assert.Nil(t, manager.config.TransformLogMetas)
+	assert.Nil(t, manager.segmentsByVChannel)
 	require.Same(t, vchannelMeta, vchannelMetas["v1"])
 	require.Same(t, segmentMeta, segments[101])
 	require.Same(t, versionSummary, versionSummaries["v1"])
@@ -167,35 +149,6 @@ func TestPChannelRecoveryManagerReleasesInitialState(t *testing.T) {
 	assert.Equal(t, int64(101), segmentID)
 	assert.Equal(t, "v1", vchannel)
 }
-
-func BenchmarkBuildInitialVChannelStates(b *testing.B) {
-	const (
-		vchannelCount = 62_500
-		segmentCount  = 58_000
-	)
-	config := PChannelManagerConfig{
-		VChannelMetas: make(map[string]*streamingpb.VChannelMeta, vchannelCount),
-		Segments:      make(map[int64]*streamingpb.SegmentAssignmentMeta, segmentCount),
-	}
-	for i := 0; i < vchannelCount; i++ {
-		vchannel := "v" + strconv.Itoa(i)
-		config.VChannelMetas[vchannel] = &streamingpb.VChannelMeta{Vchannel: vchannel}
-	}
-	for i := 0; i < segmentCount; i++ {
-		vchannel := "v" + strconv.Itoa(i%vchannelCount)
-		config.Segments[int64(i)] = &streamingpb.SegmentAssignmentMeta{SegmentId: int64(i), Vchannel: vchannel}
-	}
-
-	b.ReportAllocs()
-	b.ResetTimer()
-	for i := 0; i < b.N; i++ {
-		states := buildInitialVChannelStates(config)
-		if len(states) != vchannelCount {
-			b.Fatalf("unexpected state count: %d", len(states))
-		}
-	}
-}
-
 func TestPChannelRecoveryManagerConsumesDirtySnapshotsFromUpdatedModule(t *testing.T) {
 	ctx := context.Background()
 	manager := newTestManager(t, "p1", "v1")
@@ -280,6 +233,41 @@ func TestPChannelRecoveryManagerAggregatesDataFrontier(t *testing.T) {
 		Kind: moduleapi.DataProgressDurable,
 	})
 	require.NotNil(t, allFrontier)
+	assert.Equal(t, uint64(0), allFrontier.TimeTick())
+}
+
+func TestPChannelRecoveryManagerScopeAllRejectsLateStaleFrontierSnapshot(t *testing.T) {
+	ctx := context.Background()
+	manager := newTestManager(t, "p1", "v1")
+	manager.SwitchIntoMetaAndData()
+	module := manager.Module("v1")
+	require.NotNil(t, module)
+
+	staleReady := make(chan moduleFrontierSnapshot, 1)
+	applyStale := make(chan struct{})
+	staleApplied := make(chan struct{})
+	go func() {
+		stale := module.frontierSnapshot()
+		staleReady <- stale
+		<-applyStale
+		manager.updateModuleFrontiers(module, stale)
+		close(staleApplied)
+	}()
+
+	stale := <-staleReady
+	assert.Equal(t, uint64(math.MaxUint64), stale.durableTimeTick)
+
+	result := manager.ObserveMessage(ctx, newTestDeleteMessage(t, "v1", 10))
+	require.NotNil(t, result.Data)
+	allFrontier := manager.DataFrontier(moduleapi.Scope{
+		Type: moduleapi.ScopeAll,
+		Kind: moduleapi.DataProgressDurable,
+	})
+	require.NotNil(t, allFrontier)
+	assert.Equal(t, uint64(0), allFrontier.TimeTick())
+
+	close(applyStale)
+	<-staleApplied
 	assert.Equal(t, uint64(0), allFrontier.TimeTick())
 }
 

--- a/internal/streamingnode/server/wal/vchannel/module.go
+++ b/internal/streamingnode/server/wal/vchannel/module.go
@@ -58,6 +58,9 @@ type ModuleConfig struct {
 
 // VChannelRecoveryModule owns all recovery_storage state for one vchannel.
 type VChannelRecoveryModule struct {
+	// mu serializes WAL observation with snapshots and frontier reads. In
+	// particular, segments may grow when CreateSegment is observed while the
+	// recovery background task is collecting dirty snapshots.
 	mu       sync.Mutex
 	pchannel string
 	vchannel string
@@ -234,6 +237,8 @@ func (m *VChannelRecoveryModule) SwitchIntoMetaAndData() moduleapi.ModuleSnapsho
 	if m == nil {
 		return nil
 	}
+	m.mu.Lock()
+	defer m.mu.Unlock()
 	m.metaAndData = true
 	snapshots := make(moduleapi.CompositeModuleSnapshot, 0, 3)
 	if m.vchannelView != nil {
@@ -271,6 +276,8 @@ func (m *VChannelRecoveryModule) ConsumeDirtySnapshots() []moduleapi.DirtySnapsh
 	if m == nil {
 		return nil
 	}
+	m.mu.Lock()
+	defer m.mu.Unlock()
 	snapshots := make([]moduleapi.DirtySnapshot, 0)
 	if m.vchannelView != nil {
 		if meta := m.vchannelView.ConsumeDirtyAndGetSnapshot(); meta != nil {
@@ -327,14 +334,25 @@ func (m *VChannelRecoveryModule) DataFrontier(scope moduleapi.Scope) walcheckpoi
 	if m == nil || !m.matchesScope(scope) {
 		return nil
 	}
-	return walcheckpoint.NewCompositeBarrier(
-		walcheckpoint.BarrierFunc(func() uint64 { return m.segmentFrontierTimeTick(scope) }),
-		walcheckpoint.BarrierFunc(func() uint64 { return m.transformFrontierTimeTick(scope.Kind) }),
-	)
+	return walcheckpoint.BarrierFunc(func() uint64 {
+		m.mu.Lock()
+		defer m.mu.Unlock()
+		segmentTimeTick := m.segmentFrontierTimeTick(scope)
+		transformTimeTick := m.transformFrontierTimeTick(scope.Kind)
+		if segmentTimeTick < transformTimeTick {
+			return segmentTimeTick
+		}
+		return transformTimeTick
+	})
 }
 
 func (m *VChannelRecoveryModule) IsActive() bool {
-	return m != nil && m.vchannelView != nil && m.vchannelView.IsActive()
+	if m == nil {
+		return false
+	}
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	return m.vchannelView != nil && m.vchannelView.IsActive()
 }
 
 func (m *VChannelRecoveryModule) handleCreateCollectionMessage(msg message.ImmutableCreateCollectionMessageV1) moduleapi.ObserveResult {

--- a/internal/streamingnode/server/wal/vchannel/module.go
+++ b/internal/streamingnode/server/wal/vchannel/module.go
@@ -53,14 +53,7 @@ type ModuleConfig struct {
 	NodeScheduler              nodescheduler.Scheduler
 	QueryRuntimeDispatcher     *queryresource.Dispatcher
 	QueryViewLoadInfoProvider  queryresource.LoadInfoProvider
-}
-
-type moduleFrontierSnapshot struct {
-	// generation orders snapshots captured while holding VChannelRecoveryModule.mu.
-	// Manager caches may receive them out of order after the module unlocks.
-	generation           uint64
-	durableTimeTick      uint64
-	materializedTimeTick uint64
+	OnFrontierUpdated          func()
 }
 
 // VChannelRecoveryModule owns all recovery_storage state for one vchannel.
@@ -86,11 +79,10 @@ type VChannelRecoveryModule struct {
 
 	transformLog *transformlog.TransformLog
 
-	segmentLifecycle   segment.Lifecycle
-	segmentPackWriter  segment.PackWriter
-	onSegmentSealed    func(walview.SegmentSealedEvent)
-	onFrontierUpdated  func(moduleFrontierSnapshot)
-	frontierGeneration uint64
+	segmentLifecycle  segment.Lifecycle
+	segmentPackWriter segment.PackWriter
+	onSegmentSealed   func(walview.SegmentSealedEvent)
+	onFrontierUpdated func()
 
 	metaAndData bool
 
@@ -118,6 +110,7 @@ func NewModule(config ModuleConfig) (*VChannelRecoveryModule, error) {
 		segmentLifecycle:          config.SegmentLifecycle,
 		segmentPackWriter:         config.SegmentPackWriter,
 		queryTransformLogStream:   config.TransformLogStream,
+		onFrontierUpdated:         config.OnFrontierUpdated,
 	}
 	module.queryResources = queryresource.NewManager(queryresource.Config{
 		Builders:         config.QueryRuntimeModuleBuilders,
@@ -191,6 +184,7 @@ func (m *VChannelRecoveryModule) ObserveMessage(ctx context.Context, msg message
 		return moduleapi.ObserveResult{}
 	}
 	m.mu.Lock()
+	defer m.mu.Unlock()
 	var result moduleapi.ObserveResult
 	switch msg.MessageType() {
 	case message.MessageTypeCreateCollection:
@@ -236,9 +230,6 @@ func (m *VChannelRecoveryModule) ObserveMessage(ctx context.Context, msg message
 		result = composeObserveResults(result, m.transformLog.ObserveMessage(ctx, msg))
 	}
 	m.observeQueryResourceEvent(ctx, walview.VChannelResourceEvent{Message: msg})
-	frontier := m.frontierSnapshotLocked()
-	m.mu.Unlock()
-	m.notifyFrontierUpdated(frontier)
 	return result
 }
 
@@ -247,6 +238,7 @@ func (m *VChannelRecoveryModule) SwitchIntoMetaAndData() moduleapi.ModuleSnapsho
 		return nil
 	}
 	m.mu.Lock()
+	defer m.mu.Unlock()
 	m.metaAndData = true
 	snapshots := make(moduleapi.CompositeModuleSnapshot, 0, 3)
 	if m.vchannelView != nil {
@@ -277,9 +269,6 @@ func (m *VChannelRecoveryModule) SwitchIntoMetaAndData() moduleapi.ModuleSnapsho
 			TransformLogs: map[string]*streamingpb.VChannelTransformLogMeta{m.vchannel: m.transformLog.SnapshotMeta()},
 		})
 	}
-	frontier := m.frontierSnapshotLocked()
-	m.mu.Unlock()
-	m.notifyFrontierUpdated(frontier)
 	return snapshots
 }
 
@@ -666,9 +655,8 @@ func (m *VChannelRecoveryModule) markSegmentUpdatedLocked(segmentID int64) {
 func (m *VChannelRecoveryModule) markSegmentViewUpdated(segmentID int64, view *segment.SegmentView) {
 	m.mu.Lock()
 	m.markSegmentViewUpdatedLocked(segmentID, view)
-	frontier := m.frontierSnapshotLocked()
 	m.mu.Unlock()
-	m.notifyFrontierUpdated(frontier)
+	m.notifyFrontierUpdated()
 }
 
 func (m *VChannelRecoveryModule) markSegmentViewUpdatedLocked(segmentID int64, view *segment.SegmentView) {
@@ -682,9 +670,8 @@ func (m *VChannelRecoveryModule) markSegmentViewUpdatedLocked(segmentID int64, v
 func (m *VChannelRecoveryModule) markTransformSnapshotPersisted(snapshot *streamingpb.VChannelTransformLogMeta) {
 	m.mu.Lock()
 	m.transformLog.MarkSnapshotPersisted(snapshot)
-	frontier := m.frontierSnapshotLocked()
 	m.mu.Unlock()
-	m.notifyFrontierUpdated(frontier)
+	m.notifyFrontierUpdated()
 }
 
 func (m *VChannelRecoveryModule) markSegmentSnapshotPersisted(
@@ -695,9 +682,8 @@ func (m *VChannelRecoveryModule) markSegmentSnapshotPersisted(
 	m.mu.Lock()
 	view.MarkSnapshotPersisted(snapshot)
 	m.refreshSegmentFrontierLocked(segmentID, view)
-	frontier := m.frontierSnapshotLocked()
 	m.mu.Unlock()
-	m.notifyFrontierUpdated(frontier)
+	m.notifyFrontierUpdated()
 }
 
 func (m *VChannelRecoveryModule) markSegmentDirty(segmentID int64, view *segment.SegmentView) {
@@ -721,24 +707,9 @@ func (m *VChannelRecoveryModule) refreshSegmentFrontierLocked(segmentID int64, v
 	m.segmentFrontiers.Update(segmentID, view.CollectionID(), view.PartitionID(), view.DurableFrontierTimeTick())
 }
 
-func (m *VChannelRecoveryModule) frontierSnapshot() moduleFrontierSnapshot {
-	m.mu.Lock()
-	defer m.mu.Unlock()
-	return m.frontierSnapshotLocked()
-}
-
-func (m *VChannelRecoveryModule) frontierSnapshotLocked() moduleFrontierSnapshot {
-	m.frontierGeneration++
-	return moduleFrontierSnapshot{
-		generation:           m.frontierGeneration,
-		durableTimeTick:      m.dataFrontierTimeTick(moduleapi.DataProgressDurable),
-		materializedTimeTick: m.dataFrontierTimeTick(moduleapi.DataProgressMaterialized),
-	}
-}
-
-func (m *VChannelRecoveryModule) notifyFrontierUpdated(snapshot moduleFrontierSnapshot) {
+func (m *VChannelRecoveryModule) notifyFrontierUpdated() {
 	if m.onFrontierUpdated != nil {
-		m.onFrontierUpdated(snapshot)
+		m.onFrontierUpdated()
 	}
 }
 

--- a/internal/streamingnode/server/wal/vchannel/module.go
+++ b/internal/streamingnode/server/wal/vchannel/module.go
@@ -53,7 +53,14 @@ type ModuleConfig struct {
 	NodeScheduler              nodescheduler.Scheduler
 	QueryRuntimeDispatcher     *queryresource.Dispatcher
 	QueryViewLoadInfoProvider  queryresource.LoadInfoProvider
-	OnFrontierUpdated          func()
+}
+
+type moduleFrontierSnapshot struct {
+	// generation orders snapshots captured while holding VChannelRecoveryModule.mu.
+	// Manager caches may receive them out of order after the module unlocks.
+	generation           uint64
+	durableTimeTick      uint64
+	materializedTimeTick uint64
 }
 
 // VChannelRecoveryModule owns all recovery_storage state for one vchannel.
@@ -79,10 +86,11 @@ type VChannelRecoveryModule struct {
 
 	transformLog *transformlog.TransformLog
 
-	segmentLifecycle  segment.Lifecycle
-	segmentPackWriter segment.PackWriter
-	onSegmentSealed   func(walview.SegmentSealedEvent)
-	onFrontierUpdated func()
+	segmentLifecycle   segment.Lifecycle
+	segmentPackWriter  segment.PackWriter
+	onSegmentSealed    func(walview.SegmentSealedEvent)
+	onFrontierUpdated  func(moduleFrontierSnapshot)
+	frontierGeneration uint64
 
 	metaAndData bool
 
@@ -110,7 +118,6 @@ func NewModule(config ModuleConfig) (*VChannelRecoveryModule, error) {
 		segmentLifecycle:          config.SegmentLifecycle,
 		segmentPackWriter:         config.SegmentPackWriter,
 		queryTransformLogStream:   config.TransformLogStream,
-		onFrontierUpdated:         config.OnFrontierUpdated,
 	}
 	module.queryResources = queryresource.NewManager(queryresource.Config{
 		Builders:         config.QueryRuntimeModuleBuilders,
@@ -184,7 +191,6 @@ func (m *VChannelRecoveryModule) ObserveMessage(ctx context.Context, msg message
 		return moduleapi.ObserveResult{}
 	}
 	m.mu.Lock()
-	defer m.mu.Unlock()
 	var result moduleapi.ObserveResult
 	switch msg.MessageType() {
 	case message.MessageTypeCreateCollection:
@@ -230,6 +236,9 @@ func (m *VChannelRecoveryModule) ObserveMessage(ctx context.Context, msg message
 		result = composeObserveResults(result, m.transformLog.ObserveMessage(ctx, msg))
 	}
 	m.observeQueryResourceEvent(ctx, walview.VChannelResourceEvent{Message: msg})
+	frontier := m.frontierSnapshotLocked()
+	m.mu.Unlock()
+	m.notifyFrontierUpdated(frontier)
 	return result
 }
 
@@ -238,7 +247,6 @@ func (m *VChannelRecoveryModule) SwitchIntoMetaAndData() moduleapi.ModuleSnapsho
 		return nil
 	}
 	m.mu.Lock()
-	defer m.mu.Unlock()
 	m.metaAndData = true
 	snapshots := make(moduleapi.CompositeModuleSnapshot, 0, 3)
 	if m.vchannelView != nil {
@@ -252,7 +260,7 @@ func (m *VChannelRecoveryModule) SwitchIntoMetaAndData() moduleapi.ModuleSnapsho
 	segments := make(map[int64]*streamingpb.SegmentAssignmentMeta)
 	for id, view := range m.segments {
 		view.SwitchIntoMetaAndData()
-		m.refreshSegmentFrontier(id, view)
+		m.refreshSegmentFrontierLocked(id, view)
 		if view.IsGrowing() {
 			segments[id] = view.AssignmentMeta()
 		}
@@ -269,6 +277,9 @@ func (m *VChannelRecoveryModule) SwitchIntoMetaAndData() moduleapi.ModuleSnapsho
 			TransformLogs: map[string]*streamingpb.VChannelTransformLogMeta{m.vchannel: m.transformLog.SnapshotMeta()},
 		})
 	}
+	frontier := m.frontierSnapshotLocked()
+	m.mu.Unlock()
+	m.notifyFrontierUpdated(frontier)
 	return snapshots
 }
 
@@ -307,8 +318,7 @@ func (m *VChannelRecoveryModule) ConsumeDirtySnapshots() []moduleapi.DirtySnapsh
 				snapshot.GetCheckpointTimeTick(),
 				snapshot.GetDataCheckpointTimeTick(),
 				func() {
-					owner.MarkSnapshotPersisted(snapshot)
-					m.refreshSegmentFrontier(id, owner)
+					m.markSegmentSnapshotPersisted(id, owner, snapshot)
 				},
 			))
 		}
@@ -461,7 +471,7 @@ func (m *VChannelRecoveryModule) handleCreateSegmentMessage(ctx context.Context,
 		result.Meta = view.MetaBarrier()
 	}
 	result = composeObserveResults(result, view.ObserveCreateSegmentMessageV2(ctx, msg))
-	m.markSegmentUpdated(id)
+	m.markSegmentUpdatedLocked(id)
 	return result
 }
 
@@ -473,7 +483,7 @@ func (m *VChannelRecoveryModule) handleInsertMessage(ctx context.Context, msg me
 			continue
 		}
 		result = composeObserveResults(result, view.ObserveInsertMessageV1(ctx, msg, partition))
-		m.markSegmentUpdated(view.ID())
+		m.markSegmentUpdatedLocked(view.ID())
 	}
 	m.markLatestInsertTimeTick(msg.VChannel(), msg.TimeTick(), result)
 	return result
@@ -501,7 +511,7 @@ func (m *VChannelRecoveryModule) handleTxnMessage(ctx context.Context, msg messa
 			}
 			observed[id] = struct{}{}
 			result = composeObserveResults(result, view.ObserveTxnMessage(ctx, msg))
-			m.markSegmentUpdated(id)
+			m.markSegmentUpdatedLocked(id)
 		}
 		return nil
 	})
@@ -513,7 +523,7 @@ func (m *VChannelRecoveryModule) handleFlushMessage(ctx context.Context, msg mes
 	id := msg.Header().GetSegmentId()
 	if segment := m.segments[id]; segment != nil {
 		result := segment.Flush(ctx, msg.TimeTick())
-		m.markSegmentUpdated(id)
+		m.markSegmentUpdatedLocked(id)
 		return result
 	}
 	return moduleapi.ObserveResult{}
@@ -538,7 +548,7 @@ func (m *VChannelRecoveryModule) flushAllSegmentsCreatedBefore(ctx context.Conte
 			continue
 		}
 		result = composeObserveResults(result, view.Flush(ctx, timetick))
-		m.markSegmentUpdated(view.ID())
+		m.markSegmentUpdatedLocked(view.ID())
 	}
 	return result
 }
@@ -550,7 +560,7 @@ func (m *VChannelRecoveryModule) flushPartitionSegmentsCreatedBefore(ctx context
 			continue
 		}
 		result = composeObserveResults(result, view.Flush(ctx, timetick))
-		m.markSegmentUpdated(view.ID())
+		m.markSegmentUpdatedLocked(view.ID())
 	}
 	return result
 }
@@ -648,24 +658,46 @@ func (m *VChannelRecoveryModule) dataFrontierTimeTick(kind moduleapi.DataProgres
 	return min(m.segmentFrontiers.All(), m.transformFrontierTimeTick(kind))
 }
 
-func (m *VChannelRecoveryModule) markSegmentUpdated(segmentID int64) {
+func (m *VChannelRecoveryModule) markSegmentUpdatedLocked(segmentID int64) {
 	view := m.segments[segmentID]
-	m.markSegmentViewUpdated(segmentID, view)
+	m.markSegmentViewUpdatedLocked(segmentID, view)
 }
 
 func (m *VChannelRecoveryModule) markSegmentViewUpdated(segmentID int64, view *segment.SegmentView) {
+	m.mu.Lock()
+	m.markSegmentViewUpdatedLocked(segmentID, view)
+	frontier := m.frontierSnapshotLocked()
+	m.mu.Unlock()
+	m.notifyFrontierUpdated(frontier)
+}
+
+func (m *VChannelRecoveryModule) markSegmentViewUpdatedLocked(segmentID int64, view *segment.SegmentView) {
 	if view == nil {
 		return
 	}
 	m.markSegmentDirty(segmentID, view)
-	m.refreshSegmentFrontier(segmentID, view)
+	m.refreshSegmentFrontierLocked(segmentID, view)
 }
 
 func (m *VChannelRecoveryModule) markTransformSnapshotPersisted(snapshot *streamingpb.VChannelTransformLogMeta) {
+	m.mu.Lock()
 	m.transformLog.MarkSnapshotPersisted(snapshot)
-	if m.onFrontierUpdated != nil {
-		m.onFrontierUpdated()
-	}
+	frontier := m.frontierSnapshotLocked()
+	m.mu.Unlock()
+	m.notifyFrontierUpdated(frontier)
+}
+
+func (m *VChannelRecoveryModule) markSegmentSnapshotPersisted(
+	segmentID int64,
+	view *segment.SegmentView,
+	snapshot *streamingpb.SegmentAssignmentMeta,
+) {
+	m.mu.Lock()
+	view.MarkSnapshotPersisted(snapshot)
+	m.refreshSegmentFrontierLocked(segmentID, view)
+	frontier := m.frontierSnapshotLocked()
+	m.mu.Unlock()
+	m.notifyFrontierUpdated(frontier)
 }
 
 func (m *VChannelRecoveryModule) markSegmentDirty(segmentID int64, view *segment.SegmentView) {
@@ -682,12 +714,31 @@ func (m *VChannelRecoveryModule) takeDirtySegments() map[int64]*segment.SegmentV
 	return dirty
 }
 
-func (m *VChannelRecoveryModule) refreshSegmentFrontier(segmentID int64, view *segment.SegmentView) {
+func (m *VChannelRecoveryModule) refreshSegmentFrontierLocked(segmentID int64, view *segment.SegmentView) {
 	if view == nil {
 		return
 	}
-	if m.segmentFrontiers.Update(segmentID, view.CollectionID(), view.PartitionID(), view.DurableFrontierTimeTick()) && m.onFrontierUpdated != nil {
-		m.onFrontierUpdated()
+	m.segmentFrontiers.Update(segmentID, view.CollectionID(), view.PartitionID(), view.DurableFrontierTimeTick())
+}
+
+func (m *VChannelRecoveryModule) frontierSnapshot() moduleFrontierSnapshot {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	return m.frontierSnapshotLocked()
+}
+
+func (m *VChannelRecoveryModule) frontierSnapshotLocked() moduleFrontierSnapshot {
+	m.frontierGeneration++
+	return moduleFrontierSnapshot{
+		generation:           m.frontierGeneration,
+		durableTimeTick:      m.dataFrontierTimeTick(moduleapi.DataProgressDurable),
+		materializedTimeTick: m.dataFrontierTimeTick(moduleapi.DataProgressMaterialized),
+	}
+}
+
+func (m *VChannelRecoveryModule) notifyFrontierUpdated(snapshot moduleFrontierSnapshot) {
+	if m.onFrontierUpdated != nil {
+		m.onFrontierUpdated(snapshot)
 	}
 }
 

--- a/internal/streamingnode/server/wal/vchannel/module_test.go
+++ b/internal/streamingnode/server/wal/vchannel/module_test.go
@@ -116,11 +116,11 @@ func TestVChannelRecoveryModuleRefreshesFrontierAfterTransformSnapshotPersisted(
 			},
 		},
 		TransformLogMeta: &streamingpb.VChannelTransformLogMeta{},
+		OnFrontierUpdated: func() {
+			frontierUpdates.Add(1)
+		},
 	})
 	require.NoError(t, err)
-	module.onFrontierUpdated = func(moduleFrontierSnapshot) {
-		frontierUpdates.Add(1)
-	}
 	before := frontierUpdates.Load()
 	module.markTransformSnapshotPersisted(module.transformLog.SnapshotMeta())
 	assert.Greater(t, frontierUpdates.Load(), before)

--- a/internal/streamingnode/server/wal/vchannel/module_test.go
+++ b/internal/streamingnode/server/wal/vchannel/module_test.go
@@ -10,8 +10,10 @@ import (
 
 	"github.com/milvus-io/milvus-proto/go-api/v3/schemapb"
 	"github.com/milvus-io/milvus/internal/streamingnode/server/wal/moduleapi"
+	"github.com/milvus-io/milvus/internal/streamingnode/server/wal/vchannel/segment"
 	"github.com/milvus-io/milvus/pkg/v3/proto/datapb"
 	"github.com/milvus-io/milvus/pkg/v3/proto/streamingpb"
+	"github.com/milvus-io/milvus/pkg/v3/proto/viewpb"
 	"github.com/milvus-io/milvus/pkg/v3/streaming/util/message"
 	"github.com/milvus-io/milvus/pkg/v3/streaming/walimpls/impls/walimplstest"
 	"github.com/milvus-io/milvus/pkg/v3/util/nodescheduler"
@@ -145,6 +147,43 @@ func TestVChannelRecoveryModuleConsumesOnlyDirtySegments(t *testing.T) {
 	assert.Equal(t, []int64{30}, segmentIDs)
 }
 
+func TestManualFlushDeduplicatesPendingSegmentFinalCommit(t *testing.T) {
+	ctx := context.Background()
+	taskScheduler := &recordingScheduler{}
+	lifecycle := &recordingSegmentLifecycle{}
+	module := newTestModule(t, "p1", "v1")
+	module.runtime.Scheduler = taskScheduler
+	module.segmentLifecycle = lifecycle
+	newSegment := func(segmentID int64, createTimeTick uint64) *segment.SegmentView {
+		var view *segment.SegmentView
+		view = segment.NewSegmentViewFromMetaWithOptions(
+			newTestGrowingSegmentMeta(segmentID, createTimeTick),
+			&schemapb.CollectionSchema{Name: "c100"},
+			module.segmentOptions(segmentID, func() *segment.SegmentView { return view })...,
+		)
+		return view
+	}
+	module.segments = map[int64]*segment.SegmentView{
+		10: newSegment(10, 10),
+		20: newSegment(20, 35),
+	}
+	module.SwitchIntoMetaAndData()
+
+	first := module.ObserveMessage(ctx, newTestManualFlushMessage(t, "v1", 30))
+	second := module.ObserveMessage(ctx, newTestManualFlushMessage(t, "v1", 40))
+
+	require.NotNil(t, first.Data)
+	require.NotNil(t, second.Data)
+	require.Len(t, taskScheduler.tasks, 2)
+	for _, task := range taskScheduler.tasks {
+		require.NoError(t, task.Execute(ctx))
+	}
+
+	assert.Equal(t, []int64{10, 20}, lifecycle.committedSegmentIDs)
+	assert.Equal(t, int64(1), module.segments[10].AssignmentMeta().GetSealedAtDataVersion().GetStreamingVersion())
+	assert.Equal(t, int64(2), module.segments[20].AssignmentMeta().GetSealedAtDataVersion().GetStreamingVersion())
+}
+
 func newTestModule(t *testing.T, pchannel string, vchannel string) *VChannelRecoveryModule {
 	t.Helper()
 	module, err := NewModule(ModuleConfig{
@@ -238,6 +277,36 @@ type taskHandle struct{}
 func (taskHandle) Cancel() {}
 
 func (taskHandle) Wait(context.Context) error { return nil }
+
+type recordingSegmentLifecycle struct {
+	committedSegmentIDs []int64
+}
+
+func (l *recordingSegmentLifecycle) EnsureGrowingSegment(context.Context, *streamingpb.SegmentAssignmentMeta) error {
+	return nil
+}
+
+func (l *recordingSegmentLifecycle) CommitL1Segment(_ context.Context, meta *streamingpb.SegmentAssignmentMeta) (*viewpb.DataVersion, error) {
+	l.committedSegmentIDs = append(l.committedSegmentIDs, meta.GetSegmentId())
+	return &viewpb.DataVersion{StreamingVersion: int64(len(l.committedSegmentIDs))}, nil
+}
+
+func newTestGrowingSegmentMeta(segmentID int64, createTimeTick uint64) *streamingpb.SegmentAssignmentMeta {
+	return &streamingpb.SegmentAssignmentMeta{
+		CollectionId:           100,
+		PartitionId:            10,
+		SegmentId:              segmentID,
+		Vchannel:               "v1",
+		State:                  streamingpb.SegmentAssignmentState_SEGMENT_ASSIGNMENT_STATE_GROWING,
+		CheckpointTimeTick:     createTimeTick,
+		DataCheckpointTimeTick: createTimeTick,
+		PersistedStorage:       &streamingpb.L1SegmentPersistedStorage{},
+		Stat: &streamingpb.SegmentAssignmentStat{
+			CreateSegmentTimeTick: createTimeTick,
+			Level:                 datapb.SegmentLevel_L1,
+		},
+	}
+}
 
 func newTestRecoveryBarrierMessage(t *testing.T, timetick uint64) message.ImmutableMessage {
 	t.Helper()

--- a/internal/streamingnode/server/wal/vchannel/module_test.go
+++ b/internal/streamingnode/server/wal/vchannel/module_test.go
@@ -116,11 +116,11 @@ func TestVChannelRecoveryModuleRefreshesFrontierAfterTransformSnapshotPersisted(
 			},
 		},
 		TransformLogMeta: &streamingpb.VChannelTransformLogMeta{},
-		OnFrontierUpdated: func() {
-			frontierUpdates.Add(1)
-		},
 	})
 	require.NoError(t, err)
+	module.onFrontierUpdated = func(moduleFrontierSnapshot) {
+		frontierUpdates.Add(1)
+	}
 	before := frontierUpdates.Load()
 	module.markTransformSnapshotPersisted(module.transformLog.SnapshotMeta())
 	assert.Greater(t, frontierUpdates.Load(), before)

--- a/internal/streamingnode/server/wal/vchannel/module_test.go
+++ b/internal/streamingnode/server/wal/vchannel/module_test.go
@@ -2,6 +2,7 @@ package vchannel
 
 import (
 	"context"
+	"sync"
 	"sync/atomic"
 	"testing"
 
@@ -145,6 +146,45 @@ func TestVChannelRecoveryModuleConsumesOnlyDirtySegments(t *testing.T) {
 		}
 	}
 	assert.Equal(t, []int64{30}, segmentIDs)
+}
+
+func TestVChannelRecoveryModuleConcurrentObserveAndSnapshot(t *testing.T) {
+	ctx := context.Background()
+	module := newTestModule(t, "p1", "v1")
+	module.runtime.Scheduler = &recordingScheduler{}
+	module.SwitchIntoMetaAndData()
+
+	const segmentCount = 500
+	messages := make([]message.ImmutableMessage, 0, segmentCount)
+	for i := 0; i < segmentCount; i++ {
+		messages = append(messages, newTestCreateSegmentMessage(t, "v1", int64(i+1), uint64(i+10)))
+	}
+	frontier := module.DataFrontier(moduleapi.Scope{
+		Type:     moduleapi.ScopeVChannel,
+		Kind:     moduleapi.DataProgressDurable,
+		VChannel: "v1",
+	})
+	require.NotNil(t, frontier)
+
+	var wg sync.WaitGroup
+	wg.Add(2)
+	go func() {
+		defer wg.Done()
+		for _, msg := range messages {
+			module.ObserveMessage(ctx, msg)
+		}
+	}()
+	go func() {
+		defer wg.Done()
+		for range messages {
+			module.ConsumeDirtySnapshots()
+			frontier.TimeTick()
+			module.IsActive()
+		}
+	}()
+	wg.Wait()
+
+	assert.Len(t, module.segments, segmentCount)
 }
 
 func TestManualFlushDeduplicatesPendingSegmentFinalCommit(t *testing.T) {

--- a/internal/streamingnode/server/wal/vchannel/module_test.go
+++ b/internal/streamingnode/server/wal/vchannel/module_test.go
@@ -187,6 +187,52 @@ func TestVChannelRecoveryModuleConcurrentObserveAndSnapshot(t *testing.T) {
 	assert.Len(t, module.segments, segmentCount)
 }
 
+func TestRecoveredDurableSegmentRetriesMissingFinalCommit(t *testing.T) {
+	for name, state := range map[string]streamingpb.SegmentAssignmentState{
+		"flushed":    streamingpb.SegmentAssignmentState_SEGMENT_ASSIGNMENT_STATE_FLUSHED,
+		"tombstoned": streamingpb.SegmentAssignmentState_SEGMENT_ASSIGNMENT_STATE_TOMBSTONED,
+	} {
+		t.Run(name, func(t *testing.T) {
+			ctx := context.Background()
+			taskScheduler := &recordingScheduler{}
+			lifecycle := &recordingSegmentLifecycle{}
+			module := newTestModule(t, "p1", "v1")
+			module.runtime.Scheduler = taskScheduler
+			module.segmentLifecycle = lifecycle
+
+			meta := newTestGrowingSegmentMeta(10, 10)
+			meta.State = state
+			meta.CheckpointTimeTick = 30
+			meta.DataCheckpointTimeTick = 30
+			if state == streamingpb.SegmentAssignmentState_SEGMENT_ASSIGNMENT_STATE_TOMBSTONED {
+				meta.TombstoneTimeTick = 30
+			}
+			var view *segment.SegmentView
+			view = segment.NewSegmentViewFromMetaWithOptions(
+				meta,
+				&schemapb.CollectionSchema{Name: "c100"},
+				module.segmentOptions(10, func() *segment.SegmentView { return view })...,
+			)
+			module.segments = map[int64]*segment.SegmentView{10: view}
+
+			module.SwitchIntoMetaAndData()
+
+			require.Len(t, taskScheduler.tasks, 1)
+			frontier := module.DataFrontier(moduleapi.Scope{
+				Type:     moduleapi.ScopeVChannel,
+				Kind:     moduleapi.DataProgressDurable,
+				VChannel: "v1",
+			})
+			require.NotNil(t, frontier)
+			assert.Equal(t, uint64(29), frontier.TimeTick())
+			require.NoError(t, taskScheduler.tasks[0].Execute(ctx))
+
+			assert.Equal(t, []int64{10}, lifecycle.committedSegmentIDs)
+			assert.NotNil(t, view.AssignmentMeta().GetSealedAtDataVersion())
+		})
+	}
+}
+
 func TestManualFlushDeduplicatesPendingSegmentFinalCommit(t *testing.T) {
 	ctx := context.Background()
 	taskScheduler := &recordingScheduler{}

--- a/internal/streamingnode/server/wal/vchannel/segment/pack_writer.go
+++ b/internal/streamingnode/server/wal/vchannel/segment/pack_writer.go
@@ -304,19 +304,13 @@ func currentSplitForGrowingPack(
 	insertData []*storage.InsertData,
 	meta *streamingpb.SegmentAssignmentMeta,
 ) []storagecommon.ColumnGroup {
-	switch meta.GetStorageVersion() {
-	case storage.StorageV2, storage.StorageV3:
-	default:
+	if meta.GetStorageVersion() != storage.StorageV3 {
 		return nil
 	}
 
 	currentSplit := currentSplitFromPersistedStorage(schema, meta.GetPersistedStorage())
-	writerFormat := paramtable.Get().DataNodeCfg.StorageFormat.GetValue()
 	if len(currentSplit) > 0 {
-		if meta.GetStorageVersion() == storage.StorageV3 {
-			return currentSplit
-		}
-		return storagecommon.FillColumnGroupFormats(currentSplit, writerFormat)
+		return currentSplit
 	}
 
 	currentSplit = storagecommon.SplitColumns(
@@ -324,7 +318,7 @@ func currentSplitForGrowingPack(
 		calcGrowingColumnStats(insertData),
 		storagecommon.DefaultPolicies()...,
 	)
-	return storagecommon.FillColumnGroupFormats(currentSplit, writerFormat)
+	return storagecommon.FillColumnGroupFormats(currentSplit, paramtable.Get().DataNodeCfg.StorageFormat.GetValue())
 }
 
 func calcGrowingColumnStats(insertData []*storage.InsertData) map[int64]storagecommon.ColumnStats {

--- a/internal/streamingnode/server/wal/vchannel/segment/pack_writer.go
+++ b/internal/streamingnode/server/wal/vchannel/segment/pack_writer.go
@@ -304,13 +304,19 @@ func currentSplitForGrowingPack(
 	insertData []*storage.InsertData,
 	meta *streamingpb.SegmentAssignmentMeta,
 ) []storagecommon.ColumnGroup {
-	if meta.GetStorageVersion() != storage.StorageV3 {
+	switch meta.GetStorageVersion() {
+	case storage.StorageV2, storage.StorageV3:
+	default:
 		return nil
 	}
 
 	currentSplit := currentSplitFromPersistedStorage(schema, meta.GetPersistedStorage())
+	writerFormat := paramtable.Get().DataNodeCfg.StorageFormat.GetValue()
 	if len(currentSplit) > 0 {
-		return currentSplit
+		if meta.GetStorageVersion() == storage.StorageV3 {
+			return currentSplit
+		}
+		return storagecommon.FillColumnGroupFormats(currentSplit, writerFormat)
 	}
 
 	currentSplit = storagecommon.SplitColumns(
@@ -318,7 +324,7 @@ func currentSplitForGrowingPack(
 		calcGrowingColumnStats(insertData),
 		storagecommon.DefaultPolicies()...,
 	)
-	return storagecommon.FillColumnGroupFormats(currentSplit, paramtable.Get().DataNodeCfg.StorageFormat.GetValue())
+	return storagecommon.FillColumnGroupFormats(currentSplit, writerFormat)
 }
 
 func calcGrowingColumnStats(insertData []*storage.InsertData) map[int64]storagecommon.ColumnStats {

--- a/internal/streamingnode/server/wal/vchannel/segment/pack_writer.go
+++ b/internal/streamingnode/server/wal/vchannel/segment/pack_writer.go
@@ -3,6 +3,7 @@ package segment
 import (
 	"context"
 	"path"
+	"strconv"
 
 	"github.com/cockroachdb/errors"
 	"github.com/samber/lo"
@@ -24,6 +25,7 @@ import (
 	"github.com/milvus-io/milvus/pkg/v3/proto/datapb"
 	"github.com/milvus-io/milvus/pkg/v3/proto/indexpb"
 	"github.com/milvus-io/milvus/pkg/v3/proto/streamingpb"
+	"github.com/milvus-io/milvus/pkg/v3/util/merr"
 	"github.com/milvus-io/milvus/pkg/v3/util/metautil"
 	"github.com/milvus-io/milvus/pkg/v3/util/paramtable"
 	"github.com/milvus-io/milvus/pkg/v3/util/retry"
@@ -31,14 +33,22 @@ import (
 )
 
 type growingBulkPackWriter struct {
-	chunkManager   storage.ChunkManager
-	allocator      allocator.Interface
-	storageConfig  *indexpb.StorageConfig
-	writeRetryOpts []retry.Option
-	writeFn        growingBulkWriteFunc
+	chunkManager          storage.ChunkManager
+	allocator             allocator.Interface
+	storageConfig         *indexpb.StorageConfig
+	writeRetryOpts        []retry.Option
+	writeFn               growingBulkWriteFunc
+	resolveManifestFormat manifestFormatResolver
 }
 
 type growingBulkWriteFunc func(context.Context, *growingBulkWriteRequest) (*growingBulkWriteResult, error)
+
+type manifestFormatResolver func(
+	manifestPath string,
+	storageConfig *indexpb.StorageConfig,
+	columns []string,
+	fallbackFormat string,
+) (string, error)
 
 type growingBulkWriteRequest struct {
 	syncPack       *syncmgr.SyncPack
@@ -68,11 +78,12 @@ func NewBulkPackWriter(
 	writeRetryOpts ...retry.Option,
 ) PackWriter {
 	return &growingBulkPackWriter{
-		chunkManager:   chunkManager,
-		allocator:      allocator,
-		storageConfig:  storageConfig,
-		writeRetryOpts: writeRetryOpts,
-		writeFn:        writeGrowingBulkPack,
+		chunkManager:          chunkManager,
+		allocator:             allocator,
+		storageConfig:         storageConfig,
+		writeRetryOpts:        writeRetryOpts,
+		writeFn:               writeGrowingBulkPack,
+		resolveManifestFormat: packed.ResolveManifestSingleWriterFormat,
 	}
 }
 
@@ -92,6 +103,10 @@ func (w *growingBulkPackWriter) FlushInsertBuffer(ctx context.Context, pack *flu
 	}
 
 	metaCache := newGrowingSegmentMetaCache(pack.Meta, schema)
+	currentSplit, err := w.currentSplitForGrowingPack(schema, insertData, pack.Meta)
+	if err != nil {
+		return nil, err
+	}
 	syncPack := new(syncmgr.SyncPack).
 		WithCollectionID(pack.CollectionID).
 		WithPartitionID(pack.PartitionID).
@@ -111,7 +126,7 @@ func (w *growingBulkPackWriter) FlushInsertBuffer(ctx context.Context, pack *flu
 		storageConfig:  w.storageConfig,
 		writeRetryOpts: w.writeRetryOpts,
 		storageVersion: pack.Meta.GetStorageVersion(),
-		currentSplit:   currentSplitForGrowingPack(schema, insertData, pack.Meta),
+		currentSplit:   currentSplit,
 		manifestPath:   manifestPathForGrowingPack(pack.Meta),
 	}
 	writeResult, err := writeFn(ctx, request)
@@ -277,15 +292,20 @@ func currentSplitFromPersistedStorage(schema *schemapb.CollectionSchema, storage
 	for idx, field := range typeutil.GetAllFieldSchemas(schema) {
 		fieldIndexes[field.GetFieldID()] = idx
 	}
+	var fallback []storagecommon.ColumnGroup
 	for _, binlogBatch := range storage.GetBinlogs() {
 		if len(binlogBatch.GetFieldBinlog()) == 0 {
 			continue
 		}
 		result := make([]storagecommon.ColumnGroup, 0, len(binlogBatch.GetFieldBinlog()))
+		complete := true
 		for _, fieldBinlog := range binlogBatch.GetFieldBinlog() {
 			fields := fieldBinlog.GetChildFields()
 			if len(fields) == 0 {
 				return nil
+			}
+			if fieldBinlog.GetFormat() == "" {
+				complete = false
 			}
 			result = append(result, storagecommon.ColumnGroup{
 				GroupID: fieldBinlog.GetFieldID(),
@@ -294,30 +314,74 @@ func currentSplitFromPersistedStorage(schema *schemapb.CollectionSchema, storage
 				Format:  fieldBinlog.GetFormat(),
 			})
 		}
-		return result
+		if complete {
+			return result
+		}
+		if fallback == nil {
+			fallback = result
+		}
 	}
-	return nil
+	return fallback
 }
 
-func currentSplitForGrowingPack(
+func (w *growingBulkPackWriter) currentSplitForGrowingPack(
 	schema *schemapb.CollectionSchema,
 	insertData []*storage.InsertData,
 	meta *streamingpb.SegmentAssignmentMeta,
-) []storagecommon.ColumnGroup {
+) ([]storagecommon.ColumnGroup, error) {
 	switch meta.GetStorageVersion() {
 	case storage.StorageV2, storage.StorageV3:
 	default:
-		return nil
+		return nil, nil
 	}
-	if currentSplit := currentSplitFromPersistedStorage(schema, meta.GetPersistedStorage()); len(currentSplit) > 0 {
-		return currentSplit
+
+	currentSplit := currentSplitFromPersistedStorage(schema, meta.GetPersistedStorage())
+	recoveredFromStorage := len(currentSplit) > 0
+	if !recoveredFromStorage {
+		currentSplit = storagecommon.SplitColumns(
+			typeutil.GetAllFieldSchemas(schema),
+			calcGrowingColumnStats(insertData),
+			storagecommon.DefaultPolicies()...,
+		)
 	}
-	currentSplit := storagecommon.SplitColumns(
-		typeutil.GetAllFieldSchemas(schema),
-		calcGrowingColumnStats(insertData),
-		storagecommon.DefaultPolicies()...,
-	)
-	return storagecommon.FillColumnGroupFormats(currentSplit, paramtable.Get().DataNodeCfg.StorageFormat.GetValue())
+
+	writerFormat := paramtable.Get().DataNodeCfg.StorageFormat.GetValue()
+	if meta.GetStorageVersion() != storage.StorageV3 {
+		return storagecommon.FillColumnGroupFormats(currentSplit, writerFormat), nil
+	}
+
+	manifestPath := manifestPathForGrowingPack(meta)
+	_, version, err := packed.UnmarshalManifestPath(manifestPath)
+	if err != nil {
+		return nil, merr.WrapErrDataIntegrity(err, "parse manifest path for growing segment %d", meta.GetSegmentId())
+	}
+	if version == packed.ManifestEarliest {
+		return storagecommon.FillColumnGroupFormats(currentSplit, writerFormat), nil
+	}
+
+	resolveManifestFormat := w.resolveManifestFormat
+	if resolveManifestFormat == nil {
+		resolveManifestFormat = packed.ResolveManifestSingleWriterFormat
+	}
+	for idx, columnGroup := range currentSplit {
+		if recoveredFromStorage && columnGroup.Format != "" {
+			continue
+		}
+		columns := lo.Map(columnGroup.Fields, func(fieldID int64, _ int) string {
+			return strconv.FormatInt(fieldID, 10)
+		})
+		format, err := resolveManifestFormat(manifestPath, w.storageConfig, columns, "")
+		if err != nil {
+			return nil, merr.Wrapf(err, "resolve manifest format for growing segment %d column group %d", meta.GetSegmentId(), columnGroup.GroupID)
+		}
+		if format == "" {
+			return nil, merr.WrapErrDataIntegrityMsg(
+				"manifest %s has no writer format for growing segment %d column group %d fields %v",
+				manifestPath, meta.GetSegmentId(), columnGroup.GroupID, columnGroup.Fields)
+		}
+		currentSplit[idx].Format = format
+	}
+	return currentSplit, nil
 }
 
 func calcGrowingColumnStats(insertData []*storage.InsertData) map[int64]storagecommon.ColumnStats {

--- a/internal/streamingnode/server/wal/vchannel/segment/pack_writer.go
+++ b/internal/streamingnode/server/wal/vchannel/segment/pack_writer.go
@@ -3,7 +3,6 @@ package segment
 import (
 	"context"
 	"path"
-	"strconv"
 
 	"github.com/cockroachdb/errors"
 	"github.com/samber/lo"
@@ -25,7 +24,6 @@ import (
 	"github.com/milvus-io/milvus/pkg/v3/proto/datapb"
 	"github.com/milvus-io/milvus/pkg/v3/proto/indexpb"
 	"github.com/milvus-io/milvus/pkg/v3/proto/streamingpb"
-	"github.com/milvus-io/milvus/pkg/v3/util/merr"
 	"github.com/milvus-io/milvus/pkg/v3/util/metautil"
 	"github.com/milvus-io/milvus/pkg/v3/util/paramtable"
 	"github.com/milvus-io/milvus/pkg/v3/util/retry"
@@ -33,22 +31,14 @@ import (
 )
 
 type growingBulkPackWriter struct {
-	chunkManager          storage.ChunkManager
-	allocator             allocator.Interface
-	storageConfig         *indexpb.StorageConfig
-	writeRetryOpts        []retry.Option
-	writeFn               growingBulkWriteFunc
-	resolveManifestFormat manifestFormatResolver
+	chunkManager   storage.ChunkManager
+	allocator      allocator.Interface
+	storageConfig  *indexpb.StorageConfig
+	writeRetryOpts []retry.Option
+	writeFn        growingBulkWriteFunc
 }
 
 type growingBulkWriteFunc func(context.Context, *growingBulkWriteRequest) (*growingBulkWriteResult, error)
-
-type manifestFormatResolver func(
-	manifestPath string,
-	storageConfig *indexpb.StorageConfig,
-	columns []string,
-	fallbackFormat string,
-) (string, error)
 
 type growingBulkWriteRequest struct {
 	syncPack       *syncmgr.SyncPack
@@ -78,12 +68,11 @@ func NewBulkPackWriter(
 	writeRetryOpts ...retry.Option,
 ) PackWriter {
 	return &growingBulkPackWriter{
-		chunkManager:          chunkManager,
-		allocator:             allocator,
-		storageConfig:         storageConfig,
-		writeRetryOpts:        writeRetryOpts,
-		writeFn:               writeGrowingBulkPack,
-		resolveManifestFormat: packed.ResolveManifestSingleWriterFormat,
+		chunkManager:   chunkManager,
+		allocator:      allocator,
+		storageConfig:  storageConfig,
+		writeRetryOpts: writeRetryOpts,
+		writeFn:        writeGrowingBulkPack,
 	}
 }
 
@@ -103,10 +92,6 @@ func (w *growingBulkPackWriter) FlushInsertBuffer(ctx context.Context, pack *flu
 	}
 
 	metaCache := newGrowingSegmentMetaCache(pack.Meta, schema)
-	currentSplit, err := w.currentSplitForGrowingPack(schema, insertData, pack.Meta)
-	if err != nil {
-		return nil, err
-	}
 	syncPack := new(syncmgr.SyncPack).
 		WithCollectionID(pack.CollectionID).
 		WithPartitionID(pack.PartitionID).
@@ -126,7 +111,7 @@ func (w *growingBulkPackWriter) FlushInsertBuffer(ctx context.Context, pack *flu
 		storageConfig:  w.storageConfig,
 		writeRetryOpts: w.writeRetryOpts,
 		storageVersion: pack.Meta.GetStorageVersion(),
-		currentSplit:   currentSplit,
+		currentSplit:   currentSplitForGrowingPack(schema, insertData, pack.Meta),
 		manifestPath:   manifestPathForGrowingPack(pack.Meta),
 	}
 	writeResult, err := writeFn(ctx, request)
@@ -292,20 +277,15 @@ func currentSplitFromPersistedStorage(schema *schemapb.CollectionSchema, storage
 	for idx, field := range typeutil.GetAllFieldSchemas(schema) {
 		fieldIndexes[field.GetFieldID()] = idx
 	}
-	var fallback []storagecommon.ColumnGroup
 	for _, binlogBatch := range storage.GetBinlogs() {
 		if len(binlogBatch.GetFieldBinlog()) == 0 {
 			continue
 		}
 		result := make([]storagecommon.ColumnGroup, 0, len(binlogBatch.GetFieldBinlog()))
-		complete := true
 		for _, fieldBinlog := range binlogBatch.GetFieldBinlog() {
 			fields := fieldBinlog.GetChildFields()
 			if len(fields) == 0 {
 				return nil
-			}
-			if fieldBinlog.GetFormat() == "" {
-				complete = false
 			}
 			result = append(result, storagecommon.ColumnGroup{
 				GroupID: fieldBinlog.GetFieldID(),
@@ -314,74 +294,37 @@ func currentSplitFromPersistedStorage(schema *schemapb.CollectionSchema, storage
 				Format:  fieldBinlog.GetFormat(),
 			})
 		}
-		if complete {
-			return result
-		}
-		if fallback == nil {
-			fallback = result
-		}
+		return result
 	}
-	return fallback
+	return nil
 }
 
-func (w *growingBulkPackWriter) currentSplitForGrowingPack(
+func currentSplitForGrowingPack(
 	schema *schemapb.CollectionSchema,
 	insertData []*storage.InsertData,
 	meta *streamingpb.SegmentAssignmentMeta,
-) ([]storagecommon.ColumnGroup, error) {
+) []storagecommon.ColumnGroup {
 	switch meta.GetStorageVersion() {
 	case storage.StorageV2, storage.StorageV3:
 	default:
-		return nil, nil
+		return nil
 	}
 
 	currentSplit := currentSplitFromPersistedStorage(schema, meta.GetPersistedStorage())
-	recoveredFromStorage := len(currentSplit) > 0
-	if !recoveredFromStorage {
-		currentSplit = storagecommon.SplitColumns(
-			typeutil.GetAllFieldSchemas(schema),
-			calcGrowingColumnStats(insertData),
-			storagecommon.DefaultPolicies()...,
-		)
-	}
-
 	writerFormat := paramtable.Get().DataNodeCfg.StorageFormat.GetValue()
-	if meta.GetStorageVersion() != storage.StorageV3 {
-		return storagecommon.FillColumnGroupFormats(currentSplit, writerFormat), nil
+	if len(currentSplit) > 0 {
+		if meta.GetStorageVersion() == storage.StorageV3 {
+			return currentSplit
+		}
+		return storagecommon.FillColumnGroupFormats(currentSplit, writerFormat)
 	}
 
-	manifestPath := manifestPathForGrowingPack(meta)
-	_, version, err := packed.UnmarshalManifestPath(manifestPath)
-	if err != nil {
-		return nil, merr.WrapErrDataIntegrity(err, "parse manifest path for growing segment %d", meta.GetSegmentId())
-	}
-	if version == packed.ManifestEarliest {
-		return storagecommon.FillColumnGroupFormats(currentSplit, writerFormat), nil
-	}
-
-	resolveManifestFormat := w.resolveManifestFormat
-	if resolveManifestFormat == nil {
-		resolveManifestFormat = packed.ResolveManifestSingleWriterFormat
-	}
-	for idx, columnGroup := range currentSplit {
-		if recoveredFromStorage && columnGroup.Format != "" {
-			continue
-		}
-		columns := lo.Map(columnGroup.Fields, func(fieldID int64, _ int) string {
-			return strconv.FormatInt(fieldID, 10)
-		})
-		format, err := resolveManifestFormat(manifestPath, w.storageConfig, columns, "")
-		if err != nil {
-			return nil, merr.Wrapf(err, "resolve manifest format for growing segment %d column group %d", meta.GetSegmentId(), columnGroup.GroupID)
-		}
-		if format == "" {
-			return nil, merr.WrapErrDataIntegrityMsg(
-				"manifest %s has no writer format for growing segment %d column group %d fields %v",
-				manifestPath, meta.GetSegmentId(), columnGroup.GroupID, columnGroup.Fields)
-		}
-		currentSplit[idx].Format = format
-	}
-	return currentSplit, nil
+	currentSplit = storagecommon.SplitColumns(
+		typeutil.GetAllFieldSchemas(schema),
+		calcGrowingColumnStats(insertData),
+		storagecommon.DefaultPolicies()...,
+	)
+	return storagecommon.FillColumnGroupFormats(currentSplit, writerFormat)
 }
 
 func calcGrowingColumnStats(insertData []*storage.InsertData) map[int64]storagecommon.ColumnStats {

--- a/internal/streamingnode/server/wal/vchannel/segment/pack_writer_test.go
+++ b/internal/streamingnode/server/wal/vchannel/segment/pack_writer_test.go
@@ -137,6 +137,11 @@ func TestCurrentSplitForGrowingPackDoesNotGuessPersistedV3Format(t *testing.T) {
 	require.Empty(t, currentSplit[0].Format)
 }
 
+func TestCurrentSplitForGrowingPackIgnoresStorageV2(t *testing.T) {
+	meta := &streamingpb.SegmentAssignmentMeta{StorageVersion: storage.StorageV2}
+	require.Nil(t, currentSplitForGrowingPack(testGrowingPackSchema(), nil, meta))
+}
+
 func testGrowingPackSchema() *schemapb.CollectionSchema {
 	return &schemapb.CollectionSchema{
 		Fields: []*schemapb.FieldSchema{

--- a/internal/streamingnode/server/wal/vchannel/segment/pack_writer_test.go
+++ b/internal/streamingnode/server/wal/vchannel/segment/pack_writer_test.go
@@ -1,6 +1,7 @@
 package segment
 
 import (
+	"errors"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
@@ -8,8 +9,11 @@ import (
 
 	"github.com/milvus-io/milvus-proto/go-api/v3/schemapb"
 	"github.com/milvus-io/milvus/internal/storage"
+	"github.com/milvus-io/milvus/internal/storagev2/packed"
 	"github.com/milvus-io/milvus/pkg/v3/proto/datapb"
+	"github.com/milvus-io/milvus/pkg/v3/proto/indexpb"
 	"github.com/milvus-io/milvus/pkg/v3/proto/streamingpb"
+	"github.com/milvus-io/milvus/pkg/v3/util/merr"
 	"github.com/milvus-io/milvus/pkg/v3/util/paramtable"
 )
 
@@ -26,8 +30,9 @@ func TestCurrentSplitForGrowingPackFillsNewSplitFormats(t *testing.T) {
 	}}
 	meta := &streamingpb.SegmentAssignmentMeta{StorageVersion: storage.StorageV3}
 
-	columnGroups := currentSplitForGrowingPack(schema, nil, meta)
+	columnGroups, err := (&growingBulkPackWriter{}).currentSplitForGrowingPack(schema, nil, meta)
 
+	require.NoError(t, err)
 	require.NotEmpty(t, columnGroups)
 	for _, columnGroup := range columnGroups {
 		assert.Equal(t, "parquet", columnGroup.Format)
@@ -56,4 +61,186 @@ func TestCurrentSplitFromPersistedStorageRestoresFormat(t *testing.T) {
 	assert.Equal(t, []int64{101}, columnGroups[0].Fields)
 	assert.Equal(t, []int{1}, columnGroups[0].Columns)
 	assert.Equal(t, "vortex", columnGroups[0].Format)
+}
+
+func TestCurrentSplitFromPersistedStoragePreservesFormat(t *testing.T) {
+	schema := testGrowingPackSchema()
+	persistedStorage := &streamingpb.L1SegmentPersistedStorage{
+		Binlogs: []*streamingpb.L1SegmentBinLogs{
+			{
+				FieldBinlog: []*datapb.FieldBinlog{
+					{FieldID: 0, ChildFields: []int64{100, 0, 1}},
+				},
+			},
+			{
+				FieldBinlog: []*datapb.FieldBinlog{
+					{FieldID: 0, ChildFields: []int64{100, 0, 1}, Format: "parquet"},
+				},
+			},
+		},
+	}
+
+	currentSplit := currentSplitFromPersistedStorage(schema, persistedStorage)
+	require.Len(t, currentSplit, 1)
+	require.Equal(t, int64(0), currentSplit[0].GroupID)
+	require.Equal(t, []int64{100, 0, 1}, currentSplit[0].Fields)
+	require.Equal(t, []int{2, 0, 1}, currentSplit[0].Columns)
+	require.Equal(t, "parquet", currentSplit[0].Format)
+}
+
+func TestCurrentSplitForNewGrowingPackFillsFormats(t *testing.T) {
+	writer := &growingBulkPackWriter{
+		resolveManifestFormat: func(string, *indexpb.StorageConfig, []string, string) (string, error) {
+			t.Fatal("new manifest must not resolve formats from object storage")
+			return "", nil
+		},
+	}
+	meta := &streamingpb.SegmentAssignmentMeta{
+		CollectionId:   1,
+		PartitionId:    2,
+		SegmentId:      3,
+		StorageVersion: storage.StorageV3,
+	}
+
+	currentSplit, err := writer.currentSplitForGrowingPack(testGrowingPackSchema(), nil, meta)
+	require.NoError(t, err)
+	require.NotEmpty(t, currentSplit)
+	wantFormat := paramtable.Get().DataNodeCfg.StorageFormat.GetValue()
+	for _, columnGroup := range currentSplit {
+		require.Equal(t, wantFormat, columnGroup.Format)
+	}
+}
+
+func TestCurrentSplitForGrowingPackRecoversMissingManifestFormats(t *testing.T) {
+	manifestPath := packed.MarshalManifestPath("root/insert_log/1/2/3", 2)
+	resolverCalls := 0
+	writer := &growingBulkPackWriter{
+		resolveManifestFormat: func(gotManifest string, _ *indexpb.StorageConfig, columns []string, fallback string) (string, error) {
+			resolverCalls++
+			require.Equal(t, manifestPath, gotManifest)
+			require.Equal(t, []string{"100", "0", "1"}, columns)
+			require.Empty(t, fallback)
+			return "parquet", nil
+		},
+	}
+	meta := &streamingpb.SegmentAssignmentMeta{
+		CollectionId:   1,
+		PartitionId:    2,
+		SegmentId:      3,
+		StorageVersion: storage.StorageV3,
+		PersistedStorage: &streamingpb.L1SegmentPersistedStorage{
+			ManifestPath: manifestPath,
+			Binlogs: []*streamingpb.L1SegmentBinLogs{
+				{
+					FieldBinlog: []*datapb.FieldBinlog{
+						{FieldID: 0, ChildFields: []int64{100, 0, 1}},
+					},
+				},
+			},
+		},
+	}
+
+	currentSplit, err := writer.currentSplitForGrowingPack(testGrowingPackSchema(), nil, meta)
+	require.NoError(t, err)
+	require.Equal(t, 1, resolverCalls)
+	require.Len(t, currentSplit, 1)
+	require.Equal(t, "parquet", currentSplit[0].Format)
+}
+
+func TestCurrentSplitForGrowingPackPreservesPersistedManifestFormat(t *testing.T) {
+	manifestPath := packed.MarshalManifestPath("root/insert_log/1/2/3", 2)
+	writer := &growingBulkPackWriter{
+		resolveManifestFormat: func(string, *indexpb.StorageConfig, []string, string) (string, error) {
+			t.Fatal("persisted format must be reused without reading the manifest")
+			return "", nil
+		},
+	}
+	meta := &streamingpb.SegmentAssignmentMeta{
+		CollectionId:   1,
+		PartitionId:    2,
+		SegmentId:      3,
+		StorageVersion: storage.StorageV3,
+		PersistedStorage: &streamingpb.L1SegmentPersistedStorage{
+			ManifestPath: manifestPath,
+			Binlogs: []*streamingpb.L1SegmentBinLogs{
+				{
+					FieldBinlog: []*datapb.FieldBinlog{
+						{FieldID: 0, ChildFields: []int64{100, 0, 1}, Format: "vortex"},
+					},
+				},
+			},
+		},
+	}
+
+	currentSplit, err := writer.currentSplitForGrowingPack(testGrowingPackSchema(), nil, meta)
+	require.NoError(t, err)
+	require.Len(t, currentSplit, 1)
+	require.Equal(t, "vortex", currentSplit[0].Format)
+}
+
+func TestCurrentSplitForGrowingPackRejectsMissingManifestFormat(t *testing.T) {
+	manifestPath := packed.MarshalManifestPath("root/insert_log/1/2/3", 2)
+	writer := &growingBulkPackWriter{
+		resolveManifestFormat: func(string, *indexpb.StorageConfig, []string, string) (string, error) {
+			return "", nil
+		},
+	}
+	meta := &streamingpb.SegmentAssignmentMeta{
+		CollectionId:   1,
+		PartitionId:    2,
+		SegmentId:      3,
+		StorageVersion: storage.StorageV3,
+		PersistedStorage: &streamingpb.L1SegmentPersistedStorage{
+			ManifestPath: manifestPath,
+			Binlogs: []*streamingpb.L1SegmentBinLogs{
+				{
+					FieldBinlog: []*datapb.FieldBinlog{
+						{FieldID: 0, ChildFields: []int64{100, 0, 1}},
+					},
+				},
+			},
+		},
+	}
+
+	_, err := writer.currentSplitForGrowingPack(testGrowingPackSchema(), nil, meta)
+	require.Error(t, err)
+	require.True(t, errors.Is(err, merr.ErrDataIntegrity))
+}
+
+func TestCurrentSplitForGrowingPackRejectsMalformedManifestPath(t *testing.T) {
+	writer := &growingBulkPackWriter{
+		resolveManifestFormat: func(string, *indexpb.StorageConfig, []string, string) (string, error) {
+			t.Fatal("malformed manifest path must fail before reading object storage")
+			return "", nil
+		},
+	}
+	meta := &streamingpb.SegmentAssignmentMeta{
+		SegmentId:      3,
+		StorageVersion: storage.StorageV3,
+		PersistedStorage: &streamingpb.L1SegmentPersistedStorage{
+			ManifestPath: "not-json",
+			Binlogs: []*streamingpb.L1SegmentBinLogs{
+				{
+					FieldBinlog: []*datapb.FieldBinlog{
+						{FieldID: 0, ChildFields: []int64{100, 0, 1}},
+					},
+				},
+			},
+		},
+	}
+
+	_, err := writer.currentSplitForGrowingPack(testGrowingPackSchema(), nil, meta)
+	require.Error(t, err)
+	require.True(t, errors.Is(err, merr.ErrDataIntegrity))
+}
+
+func testGrowingPackSchema() *schemapb.CollectionSchema {
+	return &schemapb.CollectionSchema{
+		Fields: []*schemapb.FieldSchema{
+			{FieldID: 0, DataType: schemapb.DataType_Int64},
+			{FieldID: 1, DataType: schemapb.DataType_Int64},
+			{FieldID: 100, DataType: schemapb.DataType_Int64, IsPrimaryKey: true},
+			{FieldID: 101, DataType: schemapb.DataType_FloatVector},
+		},
+	}
 }

--- a/internal/streamingnode/server/wal/vchannel/segment/pack_writer_test.go
+++ b/internal/streamingnode/server/wal/vchannel/segment/pack_writer_test.go
@@ -1,7 +1,6 @@
 package segment
 
 import (
-	"errors"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
@@ -9,11 +8,8 @@ import (
 
 	"github.com/milvus-io/milvus-proto/go-api/v3/schemapb"
 	"github.com/milvus-io/milvus/internal/storage"
-	"github.com/milvus-io/milvus/internal/storagev2/packed"
 	"github.com/milvus-io/milvus/pkg/v3/proto/datapb"
-	"github.com/milvus-io/milvus/pkg/v3/proto/indexpb"
 	"github.com/milvus-io/milvus/pkg/v3/proto/streamingpb"
-	"github.com/milvus-io/milvus/pkg/v3/util/merr"
 	"github.com/milvus-io/milvus/pkg/v3/util/paramtable"
 )
 
@@ -30,9 +26,8 @@ func TestCurrentSplitForGrowingPackFillsNewSplitFormats(t *testing.T) {
 	}}
 	meta := &streamingpb.SegmentAssignmentMeta{StorageVersion: storage.StorageV3}
 
-	columnGroups, err := (&growingBulkPackWriter{}).currentSplitForGrowingPack(schema, nil, meta)
+	columnGroups := currentSplitForGrowingPack(schema, nil, meta)
 
-	require.NoError(t, err)
 	require.NotEmpty(t, columnGroups)
 	for _, columnGroup := range columnGroups {
 		assert.Equal(t, "parquet", columnGroup.Format)
@@ -69,11 +64,6 @@ func TestCurrentSplitFromPersistedStoragePreservesFormat(t *testing.T) {
 		Binlogs: []*streamingpb.L1SegmentBinLogs{
 			{
 				FieldBinlog: []*datapb.FieldBinlog{
-					{FieldID: 0, ChildFields: []int64{100, 0, 1}},
-				},
-			},
-			{
-				FieldBinlog: []*datapb.FieldBinlog{
 					{FieldID: 0, ChildFields: []int64{100, 0, 1}, Format: "parquet"},
 				},
 			},
@@ -89,12 +79,6 @@ func TestCurrentSplitFromPersistedStoragePreservesFormat(t *testing.T) {
 }
 
 func TestCurrentSplitForNewGrowingPackFillsFormats(t *testing.T) {
-	writer := &growingBulkPackWriter{
-		resolveManifestFormat: func(string, *indexpb.StorageConfig, []string, string) (string, error) {
-			t.Fatal("new manifest must not resolve formats from object storage")
-			return "", nil
-		},
-	}
 	meta := &streamingpb.SegmentAssignmentMeta{
 		CollectionId:   1,
 		PartitionId:    2,
@@ -102,8 +86,7 @@ func TestCurrentSplitForNewGrowingPackFillsFormats(t *testing.T) {
 		StorageVersion: storage.StorageV3,
 	}
 
-	currentSplit, err := writer.currentSplitForGrowingPack(testGrowingPackSchema(), nil, meta)
-	require.NoError(t, err)
+	currentSplit := currentSplitForGrowingPack(testGrowingPackSchema(), nil, meta)
 	require.NotEmpty(t, currentSplit)
 	wantFormat := paramtable.Get().DataNodeCfg.StorageFormat.GetValue()
 	for _, columnGroup := range currentSplit {
@@ -111,57 +94,14 @@ func TestCurrentSplitForNewGrowingPackFillsFormats(t *testing.T) {
 	}
 }
 
-func TestCurrentSplitForGrowingPackRecoversMissingManifestFormats(t *testing.T) {
-	manifestPath := packed.MarshalManifestPath("root/insert_log/1/2/3", 2)
-	resolverCalls := 0
-	writer := &growingBulkPackWriter{
-		resolveManifestFormat: func(gotManifest string, _ *indexpb.StorageConfig, columns []string, fallback string) (string, error) {
-			resolverCalls++
-			require.Equal(t, manifestPath, gotManifest)
-			require.Equal(t, []string{"100", "0", "1"}, columns)
-			require.Empty(t, fallback)
-			return "parquet", nil
-		},
-	}
-	meta := &streamingpb.SegmentAssignmentMeta{
-		CollectionId:   1,
-		PartitionId:    2,
-		SegmentId:      3,
-		StorageVersion: storage.StorageV3,
-		PersistedStorage: &streamingpb.L1SegmentPersistedStorage{
-			ManifestPath: manifestPath,
-			Binlogs: []*streamingpb.L1SegmentBinLogs{
-				{
-					FieldBinlog: []*datapb.FieldBinlog{
-						{FieldID: 0, ChildFields: []int64{100, 0, 1}},
-					},
-				},
-			},
-		},
-	}
-
-	currentSplit, err := writer.currentSplitForGrowingPack(testGrowingPackSchema(), nil, meta)
-	require.NoError(t, err)
-	require.Equal(t, 1, resolverCalls)
-	require.Len(t, currentSplit, 1)
-	require.Equal(t, "parquet", currentSplit[0].Format)
-}
-
 func TestCurrentSplitForGrowingPackPreservesPersistedManifestFormat(t *testing.T) {
-	manifestPath := packed.MarshalManifestPath("root/insert_log/1/2/3", 2)
-	writer := &growingBulkPackWriter{
-		resolveManifestFormat: func(string, *indexpb.StorageConfig, []string, string) (string, error) {
-			t.Fatal("persisted format must be reused without reading the manifest")
-			return "", nil
-		},
-	}
 	meta := &streamingpb.SegmentAssignmentMeta{
 		CollectionId:   1,
 		PartitionId:    2,
 		SegmentId:      3,
 		StorageVersion: storage.StorageV3,
 		PersistedStorage: &streamingpb.L1SegmentPersistedStorage{
-			ManifestPath: manifestPath,
+			ManifestPath: "manifest-v2",
 			Binlogs: []*streamingpb.L1SegmentBinLogs{
 				{
 					FieldBinlog: []*datapb.FieldBinlog{
@@ -172,26 +112,16 @@ func TestCurrentSplitForGrowingPackPreservesPersistedManifestFormat(t *testing.T
 		},
 	}
 
-	currentSplit, err := writer.currentSplitForGrowingPack(testGrowingPackSchema(), nil, meta)
-	require.NoError(t, err)
+	currentSplit := currentSplitForGrowingPack(testGrowingPackSchema(), nil, meta)
 	require.Len(t, currentSplit, 1)
 	require.Equal(t, "vortex", currentSplit[0].Format)
 }
 
-func TestCurrentSplitForGrowingPackRejectsMissingManifestFormat(t *testing.T) {
-	manifestPath := packed.MarshalManifestPath("root/insert_log/1/2/3", 2)
-	writer := &growingBulkPackWriter{
-		resolveManifestFormat: func(string, *indexpb.StorageConfig, []string, string) (string, error) {
-			return "", nil
-		},
-	}
+func TestCurrentSplitForGrowingPackDoesNotGuessPersistedV3Format(t *testing.T) {
 	meta := &streamingpb.SegmentAssignmentMeta{
-		CollectionId:   1,
-		PartitionId:    2,
-		SegmentId:      3,
 		StorageVersion: storage.StorageV3,
 		PersistedStorage: &streamingpb.L1SegmentPersistedStorage{
-			ManifestPath: manifestPath,
+			ManifestPath: "manifest-v2",
 			Binlogs: []*streamingpb.L1SegmentBinLogs{
 				{
 					FieldBinlog: []*datapb.FieldBinlog{
@@ -202,36 +132,9 @@ func TestCurrentSplitForGrowingPackRejectsMissingManifestFormat(t *testing.T) {
 		},
 	}
 
-	_, err := writer.currentSplitForGrowingPack(testGrowingPackSchema(), nil, meta)
-	require.Error(t, err)
-	require.True(t, errors.Is(err, merr.ErrDataIntegrity))
-}
-
-func TestCurrentSplitForGrowingPackRejectsMalformedManifestPath(t *testing.T) {
-	writer := &growingBulkPackWriter{
-		resolveManifestFormat: func(string, *indexpb.StorageConfig, []string, string) (string, error) {
-			t.Fatal("malformed manifest path must fail before reading object storage")
-			return "", nil
-		},
-	}
-	meta := &streamingpb.SegmentAssignmentMeta{
-		SegmentId:      3,
-		StorageVersion: storage.StorageV3,
-		PersistedStorage: &streamingpb.L1SegmentPersistedStorage{
-			ManifestPath: "not-json",
-			Binlogs: []*streamingpb.L1SegmentBinLogs{
-				{
-					FieldBinlog: []*datapb.FieldBinlog{
-						{FieldID: 0, ChildFields: []int64{100, 0, 1}},
-					},
-				},
-			},
-		},
-	}
-
-	_, err := writer.currentSplitForGrowingPack(testGrowingPackSchema(), nil, meta)
-	require.Error(t, err)
-	require.True(t, errors.Is(err, merr.ErrDataIntegrity))
+	currentSplit := currentSplitForGrowingPack(testGrowingPackSchema(), nil, meta)
+	require.Len(t, currentSplit, 1)
+	require.Empty(t, currentSplit[0].Format)
 }
 
 func testGrowingPackSchema() *schemapb.CollectionSchema {

--- a/internal/streamingnode/server/wal/vchannel/segment/pack_writer_test.go
+++ b/internal/streamingnode/server/wal/vchannel/segment/pack_writer_test.go
@@ -1,15 +1,20 @@
 package segment
 
 import (
+	"context"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 
+	"github.com/milvus-io/milvus-proto/go-api/v3/msgpb"
 	"github.com/milvus-io/milvus-proto/go-api/v3/schemapb"
 	"github.com/milvus-io/milvus/internal/storage"
 	"github.com/milvus-io/milvus/pkg/v3/proto/datapb"
+	"github.com/milvus-io/milvus/pkg/v3/proto/messagespb"
 	"github.com/milvus-io/milvus/pkg/v3/proto/streamingpb"
+	"github.com/milvus-io/milvus/pkg/v3/streaming/util/message"
+	"github.com/milvus-io/milvus/pkg/v3/streaming/walimpls/impls/walimplstest"
 	"github.com/milvus-io/milvus/pkg/v3/util/paramtable"
 )
 
@@ -137,9 +142,95 @@ func TestCurrentSplitForGrowingPackDoesNotGuessPersistedV3Format(t *testing.T) {
 	require.Empty(t, currentSplit[0].Format)
 }
 
-func TestCurrentSplitForGrowingPackIgnoresStorageV2(t *testing.T) {
-	meta := &streamingpb.SegmentAssignmentMeta{StorageVersion: storage.StorageV2}
-	require.Nil(t, currentSplitForGrowingPack(testGrowingPackSchema(), nil, meta))
+func TestFlushInsertBufferBuildsStorageV2ColumnGroups(t *testing.T) {
+	const (
+		collectionID = int64(1)
+		partitionID  = int64(2)
+		segmentID    = int64(3)
+		vchannel     = "v1"
+		timetick     = uint64(10)
+	)
+	schema := &schemapb.CollectionSchema{Fields: []*schemapb.FieldSchema{
+		{FieldID: 0, Name: "row_id", DataType: schemapb.DataType_Int64},
+		{FieldID: 1, Name: "timestamp", DataType: schemapb.DataType_Int64},
+		{FieldID: 100, Name: "pk", DataType: schemapb.DataType_Int64, IsPrimaryKey: true},
+	}}
+	mutable, err := message.NewInsertMessageBuilderV1().
+		WithVChannel(vchannel).
+		WithHeader(&message.InsertMessageHeader{
+			CollectionId: collectionID,
+			Partitions: []*messagespb.PartitionSegmentAssignment{
+				{
+					PartitionId: partitionID,
+					Rows:        1,
+					SegmentAssignment: &messagespb.SegmentAssignment{
+						SegmentId: segmentID,
+					},
+				},
+			},
+		}).
+		WithBody(&msgpb.InsertRequest{
+			Version:    msgpb.InsertDataVersion_ColumnBased,
+			RowIDs:     []int64{1},
+			Timestamps: []uint64{timetick},
+			NumRows:    1,
+			FieldsData: []*schemapb.FieldData{
+				newTestLongFieldData(0, 1),
+				newTestLongFieldData(1, int64(timetick)),
+				newTestLongFieldData(100, 1),
+			},
+		}).
+		BuildMutable()
+	require.NoError(t, err)
+	insert := mutable.WithTimeTick(timetick).
+		WithLastConfirmedUseMessageID().
+		IntoImmutableMessage(walimplstest.NewTestMessageID(1))
+
+	writer := &growingBulkPackWriter{
+		writeFn: func(_ context.Context, req *growingBulkWriteRequest) (*growingBulkWriteResult, error) {
+			require.Equal(t, int64(storage.StorageV2), req.storageVersion)
+			require.NotEmpty(t, req.currentSplit)
+			for _, columnGroup := range req.currentSplit {
+				require.NotEmpty(t, columnGroup.Fields)
+				require.NotEmpty(t, columnGroup.Format)
+			}
+			return &growingBulkWriteResult{}, nil
+		},
+	}
+	_, err = writer.FlushInsertBuffer(context.Background(), &flushPack{
+		Meta: &streamingpb.SegmentAssignmentMeta{
+			CollectionId:     collectionID,
+			PartitionId:      partitionID,
+			SegmentId:        segmentID,
+			Vchannel:         vchannel,
+			StorageVersion:   storage.StorageV2,
+			PersistedStorage: &streamingpb.L1SegmentPersistedStorage{},
+		},
+		CollectionID: collectionID,
+		PartitionID:  partitionID,
+		SegmentID:    segmentID,
+		VChannel:     vchannel,
+		FromTimeTick: timetick,
+		ToTimeTick:   timetick,
+		Schema:       schema,
+		Rows:         1,
+		Inserts:      []message.ImmutableMessage{insert},
+	})
+	require.NoError(t, err)
+}
+
+func newTestLongFieldData(fieldID int64, values ...int64) *schemapb.FieldData {
+	return &schemapb.FieldData{
+		FieldId: fieldID,
+		Type:    schemapb.DataType_Int64,
+		Field: &schemapb.FieldData_Scalars{
+			Scalars: &schemapb.ScalarField{
+				Data: &schemapb.ScalarField_LongData{
+					LongData: &schemapb.LongArray{Data: values},
+				},
+			},
+		},
+	}
 }
 
 func testGrowingPackSchema() *schemapb.CollectionSchema {

--- a/internal/streamingnode/server/wal/vchannel/segment/task.go
+++ b/internal/streamingnode/server/wal/vchannel/segment/task.go
@@ -133,13 +133,28 @@ func (s *SegmentView) newFlushL1BufferTaskLocked() segmentTask {
 }
 
 func (s *SegmentView) newCommitL1SegmentTaskLocked(timetick uint64) segmentTask {
-	if s.finalCommitDone || (s.pendingFinalCommit != nil && !s.pendingFinalCommit.Done()) {
+	if !s.canScheduleFinalCommitLocked() {
 		return nil
 	}
+	return s.newCommitL1SegmentTaskWithFlushTimeTickLocked(timetick, s.enqueuePendingFlushChunkLocked())
+}
+
+func (s *SegmentView) newRecoveredCommitL1SegmentTaskLocked(timetick uint64) segmentTask {
+	if !s.canScheduleFinalCommitLocked() {
+		return nil
+	}
+	return s.newCommitL1SegmentTaskWithFlushTimeTickLocked(timetick, 0)
+}
+
+func (s *SegmentView) canScheduleFinalCommitLocked() bool {
+	return !s.finalCommitDone && (s.pendingFinalCommit == nil || s.pendingFinalCommit.Done())
+}
+
+func (s *SegmentView) newCommitL1SegmentTaskWithFlushTimeTickLocked(timetick, flushTimeTick uint64) segmentTask {
 	task := &commitL1SegmentTask{
 		segmentTaskBase: s.newSegmentTaskBaseLocked(),
 		timetick:        timetick,
-		flushTimeTick:   s.enqueuePendingFlushChunkLocked(),
+		flushTimeTick:   flushTimeTick,
 	}
 	s.pendingFinalCommit = task
 	s.pendingTasks = append(s.pendingTasks, task)

--- a/internal/streamingnode/server/wal/vchannel/segment/task.go
+++ b/internal/streamingnode/server/wal/vchannel/segment/task.go
@@ -79,6 +79,12 @@ type commitL1SegmentTask struct {
 func (t *commitL1SegmentTask) Execute(ctx context.Context) error {
 	return t.execute(ctx, func(ctx context.Context) error {
 		segment := t.segment
+		segment.mu.Lock()
+		finalCommitDone := segment.finalCommitDone
+		segment.mu.Unlock()
+		if finalCommitDone {
+			return nil
+		}
 		if limiter := segment.commitL1Limiter; limiter != nil {
 			release, err := limiter.Acquire(ctx)
 			if err != nil {
@@ -97,6 +103,7 @@ func (t *commitL1SegmentTask) Execute(ctx context.Context) error {
 
 		segment.mu.Lock()
 		segment.MarkPendingDataDurable(t.timetick)
+		segment.finalCommitDone = true
 		sealedEvent, sealed := segment.markSealedAtDataVersionLocked(sealedAt)
 		segment.mu.Unlock()
 		segment.NotifyDataUpdated()
@@ -126,11 +133,15 @@ func (s *SegmentView) newFlushL1BufferTaskLocked() segmentTask {
 }
 
 func (s *SegmentView) newCommitL1SegmentTaskLocked(timetick uint64) segmentTask {
+	if s.finalCommitDone || (s.pendingFinalCommit != nil && !s.pendingFinalCommit.Done()) {
+		return nil
+	}
 	task := &commitL1SegmentTask{
 		segmentTaskBase: s.newSegmentTaskBaseLocked(),
 		timetick:        timetick,
 		flushTimeTick:   s.enqueuePendingFlushChunkLocked(),
 	}
+	s.pendingFinalCommit = task
 	s.pendingTasks = append(s.pendingTasks, task)
 	return task
 }

--- a/internal/streamingnode/server/wal/vchannel/segment/task_test.go
+++ b/internal/streamingnode/server/wal/vchannel/segment/task_test.go
@@ -25,6 +25,9 @@ import (
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 
+	"github.com/milvus-io/milvus-proto/go-api/v3/schemapb"
+	"github.com/milvus-io/milvus/pkg/v3/proto/streamingpb"
+	"github.com/milvus-io/milvus/pkg/v3/proto/viewpb"
 	"github.com/milvus-io/milvus/pkg/v3/util/nodescheduler"
 )
 
@@ -64,6 +67,58 @@ func TestSegmentTaskDoesNotInterpretCanceledContext(t *testing.T) {
 	assert.False(t, task.Done())
 }
 
+func TestStaleFinalCommitTaskSkipsAfterDataVersionAdvances(t *testing.T) {
+	ctx := context.Background()
+	recorder := &segmentTaskRecorder{
+		commitVersions: []*viewpb.DataVersion{
+			{StreamingVersion: 1},
+			{StreamingVersion: 2},
+			{StreamingVersion: 3},
+		},
+	}
+	first := newFinalCommitTestSegment(recorder, 100)
+	newer := newFinalCommitTestSegment(recorder, 200)
+
+	require.NoError(t, (&commitL1SegmentTask{
+		segmentTaskBase: segmentTaskBase{segment: first},
+		timetick:        30,
+	}).Execute(ctx))
+	require.NoError(t, (&commitL1SegmentTask{
+		segmentTaskBase: segmentTaskBase{segment: newer},
+		timetick:        40,
+	}).Execute(ctx))
+
+	stale := &commitL1SegmentTask{
+		segmentTaskBase: segmentTaskBase{segment: first},
+		timetick:        30,
+	}
+	require.NoError(t, stale.Execute(ctx))
+	assert.True(t, stale.Done())
+	assert.Equal(t, []int64{100, 200}, recorder.commitSegmentIDs)
+	assert.Equal(t, int64(1), first.AssignmentMeta().GetSealedAtDataVersion().GetStreamingVersion())
+}
+
+func TestRecoveredFinalCommitIsNotRepeated(t *testing.T) {
+	recorder := &segmentTaskRecorder{}
+	meta := newFinalCommitTestMeta(100)
+	meta.State = streamingpb.SegmentAssignmentState_SEGMENT_ASSIGNMENT_STATE_FLUSHED
+	meta.CheckpointTimeTick = 30
+	meta.DataCheckpointTimeTick = 30
+	segment := NewSegmentViewFromMeta(
+		meta,
+		&schemapb.CollectionSchema{},
+		runtimeConfig{lifecycle: recorder, metaAndData: true},
+	)
+	task := &commitL1SegmentTask{
+		segmentTaskBase: segmentTaskBase{segment: segment},
+		timetick:        30,
+	}
+
+	require.NoError(t, task.Execute(context.Background()))
+	assert.True(t, task.Done())
+	assert.Empty(t, recorder.commitSegmentIDs)
+}
+
 type testSegmentTask struct {
 	segmentTaskBase
 	err   error
@@ -75,4 +130,44 @@ func (t *testSegmentTask) Execute(ctx context.Context) error {
 		t.calls.Add(1)
 		return t.err
 	})
+}
+
+type segmentTaskRecorder struct {
+	commitSegmentIDs []int64
+	commitVersions   []*viewpb.DataVersion
+}
+
+func (r *segmentTaskRecorder) EnsureGrowingSegment(context.Context, *streamingpb.SegmentAssignmentMeta) error {
+	return nil
+}
+
+func (r *segmentTaskRecorder) CommitL1Segment(_ context.Context, meta *streamingpb.SegmentAssignmentMeta) (*viewpb.DataVersion, error) {
+	r.commitSegmentIDs = append(r.commitSegmentIDs, meta.GetSegmentId())
+	if len(r.commitVersions) == 0 {
+		return &viewpb.DataVersion{StreamingVersion: 1}, nil
+	}
+	version := r.commitVersions[0]
+	r.commitVersions = r.commitVersions[1:]
+	return version, nil
+}
+
+func newFinalCommitTestSegment(recorder *segmentTaskRecorder, segmentID int64) *SegmentView {
+	return NewSegmentViewFromMeta(
+		newFinalCommitTestMeta(segmentID),
+		&schemapb.CollectionSchema{},
+		runtimeConfig{lifecycle: recorder, metaAndData: true},
+	)
+}
+
+func newFinalCommitTestMeta(segmentID int64) *streamingpb.SegmentAssignmentMeta {
+	return &streamingpb.SegmentAssignmentMeta{
+		CollectionId:       1,
+		PartitionId:        10,
+		SegmentId:          segmentID,
+		Vchannel:           "v1",
+		State:              streamingpb.SegmentAssignmentState_SEGMENT_ASSIGNMENT_STATE_GROWING,
+		CheckpointTimeTick: 10,
+		PersistedStorage:   &streamingpb.L1SegmentPersistedStorage{},
+		Stat:               &streamingpb.SegmentAssignmentStat{CreateSegmentTimeTick: 10},
+	}
 }

--- a/internal/streamingnode/server/wal/vchannel/segment/task_test.go
+++ b/internal/streamingnode/server/wal/vchannel/segment/task_test.go
@@ -131,14 +131,16 @@ func TestRecoveredDataCheckpointDoesNotProveFinalCommit(t *testing.T) {
 		&schemapb.CollectionSchema{},
 		runtimeConfig{lifecycle: recorder, metaAndData: true},
 	)
-	task := &commitL1SegmentTask{
-		segmentTaskBase: segmentTaskBase{segment: segment},
-		timetick:        30,
-	}
+	segment.mu.Lock()
+	task := segment.newRecoveredCommitL1SegmentTaskLocked(30)
+	segment.mu.Unlock()
+	recovered, ok := task.(*commitL1SegmentTask)
+	require.True(t, ok)
+	assert.Zero(t, recovered.flushTimeTick)
 
-	require.NoError(t, task.Execute(context.Background()))
+	require.NoError(t, recovered.Execute(context.Background()))
 
-	assert.True(t, task.Done())
+	assert.True(t, recovered.Done())
 	assert.Equal(t, []int64{100}, recorder.commitSegmentIDs)
 }
 

--- a/internal/streamingnode/server/wal/vchannel/segment/task_test.go
+++ b/internal/streamingnode/server/wal/vchannel/segment/task_test.go
@@ -104,6 +104,7 @@ func TestRecoveredFinalCommitIsNotRepeated(t *testing.T) {
 	meta.State = streamingpb.SegmentAssignmentState_SEGMENT_ASSIGNMENT_STATE_FLUSHED
 	meta.CheckpointTimeTick = 30
 	meta.DataCheckpointTimeTick = 30
+	meta.SealedAtDataVersion = &viewpb.DataVersion{StreamingVersion: 10}
 	segment := NewSegmentViewFromMeta(
 		meta,
 		&schemapb.CollectionSchema{},
@@ -117,6 +118,28 @@ func TestRecoveredFinalCommitIsNotRepeated(t *testing.T) {
 	require.NoError(t, task.Execute(context.Background()))
 	assert.True(t, task.Done())
 	assert.Empty(t, recorder.commitSegmentIDs)
+}
+
+func TestRecoveredDataCheckpointDoesNotProveFinalCommit(t *testing.T) {
+	recorder := &segmentTaskRecorder{}
+	meta := newFinalCommitTestMeta(100)
+	meta.State = streamingpb.SegmentAssignmentState_SEGMENT_ASSIGNMENT_STATE_FLUSHED
+	meta.CheckpointTimeTick = 30
+	meta.DataCheckpointTimeTick = 30
+	segment := NewSegmentViewFromMeta(
+		meta,
+		&schemapb.CollectionSchema{},
+		runtimeConfig{lifecycle: recorder, metaAndData: true},
+	)
+	task := &commitL1SegmentTask{
+		segmentTaskBase: segmentTaskBase{segment: segment},
+		timetick:        30,
+	}
+
+	require.NoError(t, task.Execute(context.Background()))
+
+	assert.True(t, task.Done())
+	assert.Equal(t, []int64{100}, recorder.commitSegmentIDs)
 }
 
 type testSegmentTask struct {

--- a/internal/streamingnode/server/wal/vchannel/segment/view.go
+++ b/internal/streamingnode/server/wal/vchannel/segment/view.go
@@ -67,8 +67,12 @@ func NewSegmentView(
 }
 
 func finalCommitDoneFromMeta(meta *streamingpb.SegmentAssignmentMeta) bool {
-	if meta.GetSealedAtDataVersion() != nil {
-		return true
+	return meta.GetSealedAtDataVersion() != nil
+}
+
+func shouldRetryRecoveredFinalCommit(meta *streamingpb.SegmentAssignmentMeta) bool {
+	if finalCommitDoneFromMeta(meta) {
+		return false
 	}
 	switch meta.GetState() {
 	case streamingpb.SegmentAssignmentState_SEGMENT_ASSIGNMENT_STATE_FLUSHED,
@@ -146,8 +150,9 @@ type SegmentView struct {
 	// pendingFinalCommit keeps repeated flush messages from enqueueing another
 	// final commit while the current one is pending or retrying.
 	pendingFinalCommit segmentTask
-	// finalCommitDone is process-local task state. Recovery infers it from the
-	// persisted sealed version or from the flushed data checkpoint.
+	// finalCommitDone is process-local task state. Recovery only infers it from
+	// the persisted sealed version; a data checkpoint alone does not prove that
+	// the coordinator accepted the final commit.
 	finalCommitDone bool
 	pending         writeOnlyInsertBuffer // in-memory insert buffer not yet written as L1.
 	// pendingFlushChunks keeps chunks already handed to pending/running flush tasks,
@@ -565,7 +570,7 @@ func (info *SegmentView) DurableFrontierTimeTick() uint64 {
 	info.mu.Lock()
 	defer info.mu.Unlock()
 	if info.meta.GetState() == streamingpb.SegmentAssignmentState_SEGMENT_ASSIGNMENT_STATE_TOMBSTONED {
-		if info.dirty {
+		if info.dirty || !info.finalCommitDone || info.hasPendingDataWorkLocked() {
 			return frontierBefore(info.meta.GetTombstoneTimeTick())
 		}
 		return math.MaxUint64
@@ -573,7 +578,11 @@ func (info *SegmentView) DurableFrontierTimeTick() uint64 {
 	if !info.hasPendingDataWorkLocked() {
 		return math.MaxUint64
 	}
-	return min(info.persistedMetaTimeTick, info.persistedDataTimeTick)
+	frontier := min(info.persistedMetaTimeTick, info.persistedDataTimeTick)
+	if info.meta.GetState() == streamingpb.SegmentAssignmentState_SEGMENT_ASSIGNMENT_STATE_FLUSHED && !info.finalCommitDone {
+		frontier = min(frontier, frontierBefore(info.meta.GetCheckpointTimeTick()))
+	}
+	return frontier
 }
 
 func frontierBefore(timetick uint64) uint64 {
@@ -587,9 +596,10 @@ func (info *SegmentView) hasPendingDataWorkLocked() bool {
 	if info.meta.GetDataCheckpointTimeTick() > info.persistedDataTimeTick {
 		return true
 	}
-	if info.meta.GetState() == streamingpb.SegmentAssignmentState_SEGMENT_ASSIGNMENT_STATE_FLUSHED &&
-		info.meta.GetDataCheckpointTimeTick() < info.meta.GetCheckpointTimeTick() {
-		return true
+	if info.meta.GetState() == streamingpb.SegmentAssignmentState_SEGMENT_ASSIGNMENT_STATE_FLUSHED {
+		if !info.finalCommitDone || info.meta.GetDataCheckpointTimeTick() < info.meta.GetCheckpointTimeTick() {
+			return true
+		}
 	}
 	if len(info.pending.entries) > 0 || len(info.pendingFlushChunks) > 0 {
 		return true
@@ -666,8 +676,20 @@ func (info *SegmentView) HasReadyTombstoneFinalize() bool {
 
 func (info *SegmentView) SwitchIntoMetaAndData() {
 	info.mu.Lock()
-	defer info.mu.Unlock()
+	if info.metaAndData {
+		info.mu.Unlock()
+		return
+	}
 	info.metaAndData = true
+	var task segmentTask
+	if shouldRetryRecoveredFinalCommit(info.meta) {
+		task = info.newRecoveredCommitL1SegmentTaskLocked(info.meta.GetCheckpointTimeTick())
+	}
+	scheduler := info.runtime.Scheduler
+	info.mu.Unlock()
+	if task != nil {
+		scheduler.Submit(task)
+	}
 }
 
 func (info *SegmentView) SetSchema(schema *schemapb.CollectionSchema) {

--- a/internal/streamingnode/server/wal/vchannel/segment/view.go
+++ b/internal/streamingnode/server/wal/vchannel/segment/view.go
@@ -61,8 +61,23 @@ func NewSegmentView(
 		onDataUpdated:         config.onDataUpdated,
 		onSegmentSealed:       config.onSegmentSealed,
 		schema:                schema,
+		finalCommitDone:       finalCommitDoneFromMeta(meta),
 		metaAndData:           config.metaAndData,
 		commitL1Limiter:       config.commitL1Limiter,
+	}
+}
+
+func finalCommitDoneFromMeta(meta *streamingpb.SegmentAssignmentMeta) bool {
+	if meta.GetSealedAtDataVersion() != nil {
+		return true
+	}
+	switch meta.GetState() {
+	case streamingpb.SegmentAssignmentState_SEGMENT_ASSIGNMENT_STATE_FLUSHED,
+		streamingpb.SegmentAssignmentState_SEGMENT_ASSIGNMENT_STATE_TOMBSTONED:
+		return meta.GetCheckpointTimeTick() > 0 &&
+			meta.GetDataCheckpointTimeTick() >= meta.GetCheckpointTimeTick()
+	default:
+		return false
 	}
 }
 
@@ -126,10 +141,16 @@ type SegmentView struct {
 	// lifecycle commits data-side segment state to the coordinator after object
 	// storage output is ready.
 	lifecycle    Lifecycle
-	packWriter   PackWriter            // writes pending insert data to object storage.
-	runtime      moduleapi.Runtime     // schedules segment-owned data tasks.
-	pendingTasks []segmentTask         // unfinished segment tasks used as predecessors.
-	pending      writeOnlyInsertBuffer // in-memory insert buffer not yet written as L1.
+	packWriter   PackWriter        // writes pending insert data to object storage.
+	runtime      moduleapi.Runtime // schedules segment-owned data tasks.
+	pendingTasks []segmentTask     // unfinished segment tasks used as predecessors.
+	// pendingFinalCommit keeps repeated flush messages from enqueueing another
+	// final commit while the current one is pending or retrying.
+	pendingFinalCommit segmentTask
+	// finalCommitDone is process-local task state. Recovery infers it from the
+	// persisted sealed version or from the flushed data checkpoint.
+	finalCommitDone bool
+	pending         writeOnlyInsertBuffer // in-memory insert buffer not yet written as L1.
 	// pendingFlushChunks keeps chunks already handed to pending/running flush tasks,
 	// ordered by toTimeTick. Chunks stay here until segment data checkpoint advances
 	// over them.
@@ -342,7 +363,9 @@ func (s *SegmentView) Flush(_ context.Context, timetick uint64) moduleapi.Observ
 	}
 	task := s.newCommitL1SegmentTaskLocked(flushTimeTick)
 	result.Data = s.dataBarrier()
-	s.runtime.Scheduler.Submit(task)
+	if task != nil {
+		s.runtime.Scheduler.Submit(task)
+	}
 	return result
 }
 

--- a/internal/streamingnode/server/wal/vchannel/segment/view.go
+++ b/internal/streamingnode/server/wal/vchannel/segment/view.go
@@ -3,7 +3,6 @@ package segment
 import (
 	"context"
 	"math"
-	"slices"
 	"sort"
 	"sync"
 
@@ -861,7 +860,6 @@ func (s *SegmentView) appendPersistedStorage(storage *streamingpb.L1SegmentPersi
 	if s.meta.PersistedStorage == nil {
 		s.meta.PersistedStorage = &streamingpb.L1SegmentPersistedStorage{}
 	}
-	backfillPersistedStorageFormats(s.meta.PersistedStorage, storage)
 	if storage.GetManifestPath() != "" {
 		s.meta.PersistedStorage.ManifestPath = storage.GetManifestPath()
 	}
@@ -871,33 +869,6 @@ func (s *SegmentView) appendPersistedStorage(storage *streamingpb.L1SegmentPersi
 	)
 	if storage.GetMergedStatsBinlog() != nil {
 		s.meta.PersistedStorage.MergedStatsBinlog = cloneFieldBinlog(storage.GetMergedStatsBinlog())
-	}
-}
-
-func backfillPersistedStorageFormats(existing, incoming *streamingpb.L1SegmentPersistedStorage) {
-	if existing == nil || incoming == nil {
-		return
-	}
-	for _, existingBatch := range existing.GetBinlogs() {
-		for _, existingBinlog := range existingBatch.GetFieldBinlog() {
-			if existingBinlog.GetFormat() != "" {
-				continue
-			}
-			for _, incomingBatch := range incoming.GetBinlogs() {
-				for _, incomingBinlog := range incomingBatch.GetFieldBinlog() {
-					if incomingBinlog.GetFormat() == "" ||
-						existingBinlog.GetFieldID() != incomingBinlog.GetFieldID() ||
-						!slices.Equal(existingBinlog.GetChildFields(), incomingBinlog.GetChildFields()) {
-						continue
-					}
-					existingBinlog.Format = incomingBinlog.GetFormat()
-					break
-				}
-				if existingBinlog.GetFormat() != "" {
-					break
-				}
-			}
-		}
 	}
 }
 

--- a/internal/streamingnode/server/wal/vchannel/segment/view.go
+++ b/internal/streamingnode/server/wal/vchannel/segment/view.go
@@ -3,6 +3,7 @@ package segment
 import (
 	"context"
 	"math"
+	"slices"
 	"sort"
 	"sync"
 
@@ -837,6 +838,7 @@ func (s *SegmentView) appendPersistedStorage(storage *streamingpb.L1SegmentPersi
 	if s.meta.PersistedStorage == nil {
 		s.meta.PersistedStorage = &streamingpb.L1SegmentPersistedStorage{}
 	}
+	backfillPersistedStorageFormats(s.meta.PersistedStorage, storage)
 	if storage.GetManifestPath() != "" {
 		s.meta.PersistedStorage.ManifestPath = storage.GetManifestPath()
 	}
@@ -846,6 +848,33 @@ func (s *SegmentView) appendPersistedStorage(storage *streamingpb.L1SegmentPersi
 	)
 	if storage.GetMergedStatsBinlog() != nil {
 		s.meta.PersistedStorage.MergedStatsBinlog = cloneFieldBinlog(storage.GetMergedStatsBinlog())
+	}
+}
+
+func backfillPersistedStorageFormats(existing, incoming *streamingpb.L1SegmentPersistedStorage) {
+	if existing == nil || incoming == nil {
+		return
+	}
+	for _, existingBatch := range existing.GetBinlogs() {
+		for _, existingBinlog := range existingBatch.GetFieldBinlog() {
+			if existingBinlog.GetFormat() != "" {
+				continue
+			}
+			for _, incomingBatch := range incoming.GetBinlogs() {
+				for _, incomingBinlog := range incomingBatch.GetFieldBinlog() {
+					if incomingBinlog.GetFormat() == "" ||
+						existingBinlog.GetFieldID() != incomingBinlog.GetFieldID() ||
+						!slices.Equal(existingBinlog.GetChildFields(), incomingBinlog.GetChildFields()) {
+						continue
+					}
+					existingBinlog.Format = incomingBinlog.GetFormat()
+					break
+				}
+				if existingBinlog.GetFormat() != "" {
+					break
+				}
+			}
+		}
 	}
 }
 

--- a/internal/streamingnode/server/wal/vchannel/segment/view_test.go
+++ b/internal/streamingnode/server/wal/vchannel/segment/view_test.go
@@ -7,6 +7,7 @@ import (
 	"github.com/stretchr/testify/require"
 
 	"github.com/milvus-io/milvus/internal/views/qviews"
+	"github.com/milvus-io/milvus/pkg/v3/proto/datapb"
 	"github.com/milvus-io/milvus/pkg/v3/proto/streamingpb"
 	"github.com/milvus-io/milvus/pkg/v3/proto/viewpb"
 	"github.com/milvus-io/milvus/pkg/v3/streaming/util/message"
@@ -132,4 +133,42 @@ func TestPendingFlushChunkSearchBoundaries(t *testing.T) {
 	assert.Equal(t, 1, firstPendingFlushChunkAfter(chunks, 10))
 	assert.Equal(t, 3, firstPendingFlushChunkAfter(chunks, 15))
 	assert.Equal(t, len(chunks), firstPendingFlushChunkAfter(chunks, 30))
+}
+
+func TestAppendPersistedStorageBackfillsFormats(t *testing.T) {
+	view := &SegmentView{
+		meta: &streamingpb.SegmentAssignmentMeta{
+			PersistedStorage: &streamingpb.L1SegmentPersistedStorage{
+				ManifestPath: "manifest-v1",
+				Binlogs: []*streamingpb.L1SegmentBinLogs{
+					{
+						FieldBinlog: []*datapb.FieldBinlog{
+							{FieldID: 0, ChildFields: []int64{100, 0, 1}},
+							{FieldID: 101, ChildFields: []int64{101}, Format: "vortex"},
+						},
+					},
+				},
+			},
+		},
+	}
+	incoming := &streamingpb.L1SegmentPersistedStorage{
+		ManifestPath: "manifest-v2",
+		Binlogs: []*streamingpb.L1SegmentBinLogs{
+			{
+				FieldBinlog: []*datapb.FieldBinlog{
+					{FieldID: 0, ChildFields: []int64{100, 0, 1}, Format: "parquet"},
+					{FieldID: 101, ChildFields: []int64{101}, Format: "parquet"},
+				},
+			},
+		},
+	}
+
+	view.appendPersistedStorage(incoming)
+
+	persisted := view.meta.GetPersistedStorage()
+	require.Equal(t, "manifest-v2", persisted.GetManifestPath())
+	require.Len(t, persisted.GetBinlogs(), 2)
+	require.Equal(t, "parquet", persisted.GetBinlogs()[0].GetFieldBinlog()[0].GetFormat())
+	require.Equal(t, "vortex", persisted.GetBinlogs()[0].GetFieldBinlog()[1].GetFormat())
+	require.Equal(t, "parquet", persisted.GetBinlogs()[1].GetFieldBinlog()[0].GetFormat())
 }

--- a/internal/streamingnode/server/wal/vchannel/segment/view_test.go
+++ b/internal/streamingnode/server/wal/vchannel/segment/view_test.go
@@ -7,7 +7,6 @@ import (
 	"github.com/stretchr/testify/require"
 
 	"github.com/milvus-io/milvus/internal/views/qviews"
-	"github.com/milvus-io/milvus/pkg/v3/proto/datapb"
 	"github.com/milvus-io/milvus/pkg/v3/proto/streamingpb"
 	"github.com/milvus-io/milvus/pkg/v3/proto/viewpb"
 	"github.com/milvus-io/milvus/pkg/v3/streaming/util/message"
@@ -94,7 +93,6 @@ func TestFlushedSegmentSnapshotReturnsFilteredSealedSegment(t *testing.T) {
 	assert.Equal(t, uint64(50), flushed.FlushTimeTick)
 	assert.Equal(t, qviews.DataVersion{StreamingVersion: 10, CompactVersion: 1}, flushed.SealedAtDataVersion)
 }
-
 func TestPrunePendingFlushChunksClearsDiscardedBackingSlots(t *testing.T) {
 	view := &SegmentView{
 		meta: &streamingpb.SegmentAssignmentMeta{DataCheckpointTimeTick: 20},
@@ -133,42 +131,4 @@ func TestPendingFlushChunkSearchBoundaries(t *testing.T) {
 	assert.Equal(t, 1, firstPendingFlushChunkAfter(chunks, 10))
 	assert.Equal(t, 3, firstPendingFlushChunkAfter(chunks, 15))
 	assert.Equal(t, len(chunks), firstPendingFlushChunkAfter(chunks, 30))
-}
-
-func TestAppendPersistedStorageBackfillsFormats(t *testing.T) {
-	view := &SegmentView{
-		meta: &streamingpb.SegmentAssignmentMeta{
-			PersistedStorage: &streamingpb.L1SegmentPersistedStorage{
-				ManifestPath: "manifest-v1",
-				Binlogs: []*streamingpb.L1SegmentBinLogs{
-					{
-						FieldBinlog: []*datapb.FieldBinlog{
-							{FieldID: 0, ChildFields: []int64{100, 0, 1}},
-							{FieldID: 101, ChildFields: []int64{101}, Format: "vortex"},
-						},
-					},
-				},
-			},
-		},
-	}
-	incoming := &streamingpb.L1SegmentPersistedStorage{
-		ManifestPath: "manifest-v2",
-		Binlogs: []*streamingpb.L1SegmentBinLogs{
-			{
-				FieldBinlog: []*datapb.FieldBinlog{
-					{FieldID: 0, ChildFields: []int64{100, 0, 1}, Format: "parquet"},
-					{FieldID: 101, ChildFields: []int64{101}, Format: "parquet"},
-				},
-			},
-		},
-	}
-
-	view.appendPersistedStorage(incoming)
-
-	persisted := view.meta.GetPersistedStorage()
-	require.Equal(t, "manifest-v2", persisted.GetManifestPath())
-	require.Len(t, persisted.GetBinlogs(), 2)
-	require.Equal(t, "parquet", persisted.GetBinlogs()[0].GetFieldBinlog()[0].GetFormat())
-	require.Equal(t, "vortex", persisted.GetBinlogs()[0].GetFieldBinlog()[1].GetFormat())
-	require.Equal(t, "parquet", persisted.GetBinlogs()[1].GetFieldBinlog()[0].GetFormat())
 }


### PR DESCRIPTION
## What problem does this PR solve?

This PR fixes correctness and retained-memory issues in StreamingNode recovery, especially on PChannels with many vchannels and segments.

### 1. Recovery snapshots and cached frontiers could become inconsistent

WAL replay, background snapshot persistence, asynchronous segment updates, and frontier reads can run concurrently. Previously, a segment could be created or updated while recovery state was being iterated, which exposed the recovery path to data races, concurrent-map access, and snapshots assembled from different points in time.

The PChannel-wide `ScopeAll` frontier also had a stale-update window: an asynchronous refresh could capture an old high frontier, race with new pending work that lowered the frontier, and then overwrite the manager cache after the newer value had already been stored.

After this fix:

- per-vchannel observation, snapshot collection, mode switching, and frontier sampling see a serialized state;
- manager frontier caches accept only the newest generation captured under that serialization boundary;
- a late stale refresh cannot advance `ScopeAll` beyond newly pending work.

### 2. Segment final commits could be duplicated or skipped after recovery

Back-to-back `ManualFlush`, `FlushAll`, or replayed flush messages could enqueue multiple final commits for the same segment. A duplicate coordinator call could return a different sealed `DataVersion`, causing unnecessary work and potentially a conflicting-version panic.

There was also a crash window between persisting the segment data and receiving/persisting the coordinator acknowledgement. In that window, `DataCheckpointTimeTick` could already equal `CheckpointTimeTick` while `SealedAtDataVersion` was still absent. Treating the data checkpoint as proof of final-commit completion caused recovery to skip the missing `SaveBinlogPaths` call.

After this fix:

- only one final commit can be pending for a segment within a running process;
- recovered completion is inferred only from persisted coordinator evidence (`SealedAtDataVersion`), not from the data checkpoint alone;
- a recovered FLUSHED or TOMBSTONED segment with durable data but no sealed version retries the coordinator commit without rewriting the persisted data pack;
- the durable frontier remains before the flush/tombstone point until final-commit evidence is persisted;
- once a sealed version is present, recovery does not submit another final commit.

### 3. Recovery retained initialization-only metadata after module creation

After per-vchannel modules were initialized, the PChannel manager still retained the original vchannel metadata, segment metadata, data-version summary, transform-log metadata, and grouped segment maps. Those references kept large recovery inputs live even though each module already owned the state it needed.

After this fix, the existing one-time segment grouping and module initialization flow is preserved, and all initialization-only maps are released once the initial modules have been created. Runtime-created vchannels no longer retain recovered input containers they do not use.

### 4. StorageV2 growing-segment flushes could receive empty column groups

StorageV2 and StorageV3 writers both require resolved column groups. Returning no split for StorageV2 passed an empty path list into the packed writer; a non-empty StorageV2 flush could then panic when the writer accessed the first path. StorageV2 is also the default when Loon FFI is disabled.

After this fix:

- persisted column groups are restored for both StorageV2 and StorageV3;
- missing groups are generated for both packed-storage versions;
- StorageV2 groups receive the configured writer format when persisted metadata does not contain one;
- StorageV3 keeps its persisted format/manifest behavior.

## Expected impact

- Recovery state and PChannel-wide durable frontiers remain conservative under concurrent updates.
- Repeated flushes do not create concurrent duplicate final commits, and recovery repairs the durable-data/coordinator-ack crash window.
- Large recovery input maps are eligible for collection after initial module construction.
- Non-empty StorageV2 growing-segment flushes always receive usable column groups.

## Verification

- `go test -tags dynamic,test -gcflags="all=-N -l" -count=1 ./internal/streamingnode/server/wal/vchannel ./internal/streamingnode/server/wal/vchannel/segment`
- `go test -race -tags dynamic,test -gcflags="all=-N -l" -count=1 ./internal/streamingnode/server/wal/vchannel ./internal/streamingnode/server/wal/vchannel/segment -run 'TestPChannelRecoveryManagerScopeAllRejectsLateStaleFrontierSnapshot|TestVChannelRecoveryModuleConcurrentObserveAndSnapshot|TestRecoveredDurableSegmentRetriesMissingFinalCommit|TestManualFlushDeduplicatesPendingSegmentFinalCommit|TestFlushInsertBufferBuildsStorageV2ColumnGroups|TestRecoveredDataCheckpointDoesNotProveFinalCommit|TestRecoveredFinalCommitIsNotRepeated'`

The regression coverage includes concurrent snapshot/frontier access, stale `ScopeAll` cache updates, repeated final commits, FLUSHED/TOMBSTONED recovery after the durable-data crash window, no-rewrite final-commit retry, and the StorageV2 `FlushInsertBuffer` path.
