### PR TITLE
fix: preserve segment snapshots for pending load retries

### DIFF
--- a/internal/querynodev2/qnview/view_scoped_physical_segment_manager.go
+++ b/internal/querynodev2/qnview/view_scoped_physical_segment_manager.go
@@ -249,7 +249,7 @@ func (m *ViewScopedPhysicalSegmentManager) submitSegmentLoad(submission segmentL
 		OnLoaded: func(segment TransformSegment) {
 			defer done()
 			if segment == nil {
-				notifications, retries, subscriptions := m.failPhysicalSegmentLoad(submission.segmentID, nil)
+				notifications, retries, subscriptions := m.failPhysicalSegmentLoad(submission.segmentID, submission.snapshot, nil)
 				m.submitSegmentLoadSubmissions(retries)
 				m.closeSubscriptions(subscriptions)
 				for _, notify := range notifications {
@@ -270,7 +270,7 @@ func (m *ViewScopedPhysicalSegmentManager) submitSegmentLoad(submission segmentL
 		},
 		OnUnrecoverable: func(err error) {
 			defer done()
-			notifications, retries, subscriptions := m.failPhysicalSegmentLoad(submission.segmentID, err)
+			notifications, retries, subscriptions := m.failPhysicalSegmentLoad(submission.segmentID, submission.snapshot, err)
 			m.submitSegmentLoadSubmissions(retries)
 			m.closeSubscriptions(subscriptions)
 			for _, notify := range notifications {
@@ -338,6 +338,8 @@ func (m *ViewScopedPhysicalSegmentManager) recordSegmentSnapshot(ctx context.Con
 		}
 		loadCtx, loadCancel := context.WithCancel(context.Background())
 		loadDone := onceLoadDone(m.trackPendingLoadAttemptLocked(state))
+		state.pending = false
+		state.pendingSnapshot = nil
 		state.loading = true
 		state.loadCancel = loadCancel
 		state.loadDone = loadDone
@@ -472,7 +474,7 @@ func (m *ViewScopedPhysicalSegmentManager) cancelSegmentUpdateLocked(state *phys
 	}
 }
 
-func (m *ViewScopedPhysicalSegmentManager) failPhysicalSegmentLoad(segmentID int64, err error) ([]func(), []segmentLoadSubmission, []SegmentLoadInfoSubscription) {
+func (m *ViewScopedPhysicalSegmentManager) failPhysicalSegmentLoad(segmentID int64, snapshot SegmentLoadInfoSnapshot, err error) ([]func(), []segmentLoadSubmission, []SegmentLoadInfoSubscription) {
 	m.mu.Lock()
 	defer m.mu.Unlock()
 
@@ -490,6 +492,10 @@ func (m *ViewScopedPhysicalSegmentManager) failPhysicalSegmentLoad(segmentID int
 	}
 	if isSegmentResourceInsufficient(err) && m.hasOtherLoadingSegmentLocked(segmentID) {
 		state.pending = true
+		if state.pendingSnapshot == nil {
+			snapshotCopy := snapshot
+			state.pendingSnapshot = &snapshotCopy
+		}
 		return nil, nil, nil
 	}
 
@@ -517,6 +523,7 @@ func (m *ViewScopedPhysicalSegmentManager) failPhysicalSegmentLoad(segmentID int
 	state.requests = make(map[qviews.QueryViewKey]segmentLoadRequest)
 	state.loading = false
 	state.pending = false
+	state.pendingSnapshot = nil
 	state.loadCancel = nil
 	state.loadDone = nil
 	subscription := m.detachSubscriptionLocked(state)
@@ -644,12 +651,15 @@ func (m *ViewScopedPhysicalSegmentManager) collectPendingLoadSubmissionsLocked()
 		loadDone := onceLoadDone(m.trackPendingLoadAttemptLocked(state))
 		state.pending = false
 		state.loading = true
+		snapshot := *state.pendingSnapshot
+		state.pendingSnapshot = nil
 		state.loadCancel = loadCancel
 		state.loadDone = loadDone
 		submissions = append(submissions, segmentLoadSubmission{
 			segmentID: segmentID,
 			ctx:       loadCtx,
 			request:   request,
+			snapshot:  snapshot,
 			done:      chainLoadDone(loadDone, loadCancel),
 		})
 	}

--- a/internal/querynodev2/qnview/view_scoped_physical_segment_manager_test.go
+++ b/internal/querynodev2/qnview/view_scoped_physical_segment_manager_test.go
@@ -217,6 +217,84 @@ func TestViewScopedPhysicalSegmentManager_PendsResourceFailureWhileOtherSegmentL
 	}
 }
 
+func TestViewScopedPhysicalSegmentManager_PreservesLatestStreamSnapshotForPendingResourceRetry(t *testing.T) {
+	tests := []struct {
+		name                    string
+		emitLatestBeforeFailure bool
+	}{
+		{name: "snapshot arrives while load is running", emitLatestBeforeFailure: true},
+		{name: "snapshot arrives after resource failure"},
+	}
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			meta := buildHandlerTestMeta(1)
+			view := &viewpb.QueryViewOfQueryNode{
+				NodeId:     1,
+				Partitions: []*viewpb.QueryViewOfPartition{{PartitionId: 10, SegmentIds: []int64{1000, 1001}}},
+			}
+			key := qviews.NewQueryViewAtQueryNode(meta, view).QueryViewKey()
+			scheduler := &fakeNodeScheduler{}
+			stream := &fakeSegmentLoadInfoStream{}
+			mgr := newTestViewScopedPhysicalSegmentManager(t, scheduler, stream)
+
+			mgr.Acquire(AcquirePhysicalSegments{
+				Key: key, Meta: meta, View: view,
+				Collection:             &fakeCollectionRuntimeGuard{collectionID: testCollectionID},
+				OnSegmentUnrecoverable: func(segmentID int64, err error) { t.Fatalf("unexpected failed segment %d: %v", segmentID, err) },
+			})
+
+			snapshot := SegmentLoadInfoSnapshot{
+				CollectionID: testCollectionID,
+				SegmentID:    1000,
+				Revision:     SegmentLoadInfoRevision{Revision: 100},
+				LoadInfo:     &querypb.SegmentLoadInfo{SegmentID: 1000, PartitionID: 10, CollectionID: testCollectionID},
+			}
+			require.NoError(t, stream.Emit(snapshot))
+			require.NoError(t, stream.Emit(SegmentLoadInfoSnapshot{
+				CollectionID: testCollectionID,
+				SegmentID:    1001,
+				Revision:     SegmentLoadInfoRevision{Revision: 11},
+				LoadInfo:     &querypb.SegmentLoadInfo{SegmentID: 1001, PartitionID: 10, CollectionID: testCollectionID},
+			}))
+			require.Len(t, scheduler.tasks, 2)
+			taskBySegment := make(map[int64]*SegmentLoadTask, len(scheduler.tasks))
+			for _, task := range scheduler.tasks {
+				taskBySegment[task.SegmentID] = task
+			}
+			latest := snapshot
+			latest.Revision = SegmentLoadInfoRevision{Revision: 1}
+			latest.LoadInfo = &querypb.SegmentLoadInfo{
+				SegmentID:    1000,
+				PartitionID:  10,
+				CollectionID: testCollectionID,
+				NumOfRows:    1,
+			}
+
+			if test.emitLatestBeforeFailure {
+				require.NoError(t, stream.Emit(latest))
+			}
+			taskBySegment[1000].OnUnrecoverable(merr.WrapErrSegmentRequestResourceFailed("Memory"))
+			if !test.emitLatestBeforeFailure {
+				require.NoError(t, stream.Emit(latest))
+			}
+			if test.emitLatestBeforeFailure {
+				require.Len(t, scheduler.tasks, 2)
+			} else {
+				require.Len(t, scheduler.tasks, 3)
+			}
+
+			taskBySegment[1001].OnLoaded(&fakeTransformSegment{id: 1001, partitionID: 10})
+			require.Len(t, scheduler.tasks, 3)
+			retry := scheduler.tasks[2]
+			require.Equal(t, int64(1000), retry.SegmentID)
+			require.Equal(t, latest, retry.Snapshot)
+
+			retry.OnLoaded(&fakeTransformSegment{id: 1000, partitionID: 10})
+			require.Empty(t, scheduler.updates)
+		})
+	}
+}
+
 func TestViewScopedPhysicalSegmentManager_ReleaseWaitsForPendingRetryCallback(t *testing.T) {
 	meta := buildHandlerTestMeta(1)
 	view := &viewpb.QueryViewOfQueryNode{


### PR DESCRIPTION
issue: https://github.com/milvus-io/milvus/issues/40451

## What problem does this solve?

When a segment load is deferred after `ErrSegmentRequestResourceFailed` while another segment is still loading, the pending retry loses the `SegmentLoadInfoSnapshot` captured by the original task. In stream mode, the retried `SegmentLoadTask` therefore has no complete load metadata and can fail with `query view segment load requires watch snapshot`.

A newer snapshot can also arrive while the original load is running or after the segment has entered pending. The stream checkpoint advances as soon as the manager accepts that snapshot, so the manager must retain it locally until a load or update consumes it. If an immediate load starts from a new snapshot while an older pending snapshot remains recorded, the older snapshot can later be treated as an update and roll the segment metadata back.

`SegmentLoadInfoRevision` is a content hash rather than an ordered version. The manager must preserve snapshots according to stream arrival and state ownership instead of comparing revision values numerically.

## What was changed?

- Pass each load submission snapshot into the failure handler.
- Preserve an already pending newer snapshot, or fall back to the failed task snapshot when no newer snapshot exists.
- Consume pending state when a new stream snapshot starts an immediate load.
- Move the pending snapshot into the retry submission before scheduling it.
- Cover snapshots arriving before and after the resource failure, including a non-monotonic `100 -> 1` revision transition and distinct load metadata.

## Verification

```bash
gofumpt -l internal/querynodev2/qnview/view_scoped_physical_segment_manager.go internal/querynodev2/qnview/view_scoped_physical_segment_manager_test.go
git diff --check
source scripts/setenv.sh && go test -v -count=1 -tags dynamic,test -gcflags="all=-N -l" ./internal/querynodev2/qnview -run TestViewScopedPhysicalSegmentManager -timeout 300s
```

All checks passed.
