### PR TITLE
enhance: index pending query view segment retries

### DIFF
--- a/internal/querynodev2/qnview/view_scoped_physical_segment_manager.go
+++ b/internal/querynodev2/qnview/view_scoped_physical_segment_manager.go
@@ -17,11 +17,12 @@ type ViewScopedPhysicalSegmentManager struct {
 	estimator     SegmentResourceEstimator
 	stream        SegmentLoadInfoStream
 
-	mu       sync.Mutex
-	views    map[qviews.QueryViewKey]*viewRef
-	dropping map[qviews.QueryViewKey]*viewRef
-	segments map[int64]*physicalSegmentState
-	cancels  map[qviews.QueryViewKey]context.CancelFunc
+	mu                  sync.Mutex
+	views               map[qviews.QueryViewKey]*viewRef
+	dropping            map[qviews.QueryViewKey]*viewRef
+	segments            map[int64]*physicalSegmentState
+	pendingLoadSegments map[int64]struct{}
+	cancels             map[qviews.QueryViewKey]context.CancelFunc
 }
 
 type viewRef struct {
@@ -37,7 +38,6 @@ type physicalSegmentState struct {
 	segment         TransformSegment
 	collectionID    int64
 	loading         bool
-	pending         bool
 	updating        bool
 	updateHandle    nodescheduler.TaskHandle
 	updateEpoch     uint64
@@ -91,14 +91,15 @@ func NewViewScopedPhysicalSegmentManagerWithNodeSchedulerAndStream(nodeScheduler
 		estimator = estimators[0]
 	}
 	return &ViewScopedPhysicalSegmentManager{
-		nodeScheduler: nodeScheduler,
-		loader:        loader,
-		estimator:     estimator,
-		stream:        stream,
-		views:         make(map[qviews.QueryViewKey]*viewRef),
-		dropping:      make(map[qviews.QueryViewKey]*viewRef),
-		segments:      make(map[int64]*physicalSegmentState),
-		cancels:       make(map[qviews.QueryViewKey]context.CancelFunc),
+		nodeScheduler:       nodeScheduler,
+		loader:              loader,
+		estimator:           estimator,
+		stream:              stream,
+		views:               make(map[qviews.QueryViewKey]*viewRef),
+		dropping:            make(map[qviews.QueryViewKey]*viewRef),
+		segments:            make(map[int64]*physicalSegmentState),
+		pendingLoadSegments: make(map[int64]struct{}),
+		cancels:             make(map[qviews.QueryViewKey]context.CancelFunc),
 	}
 }
 
@@ -190,7 +191,7 @@ func (m *ViewScopedPhysicalSegmentManager) recordView(req AcquirePhysicalSegment
 				})
 			}
 			m.segments[segmentID] = state
-		} else if state.segment == nil && !state.loading && !state.pending && m.stream == nil {
+		} else if _, pending := m.pendingLoadSegments[segmentID]; state.segment == nil && !state.loading && !pending && m.stream == nil {
 			loadCtx, loadCancel := context.WithCancel(context.Background())
 			ref.pendingLoads++
 			loadDone := onceLoadDone(func() { m.completeLoadAttempts([]qviews.QueryViewKey{req.Key}) })
@@ -290,7 +291,7 @@ func (m *ViewScopedPhysicalSegmentManager) completePhysicalSegmentLoad(segment T
 	}
 	state.segment = segment
 	state.loading = false
-	state.pending = false
+	delete(m.pendingLoadSegments, segment.ID())
 	state.loadCancel = nil
 	state.loadDone = nil
 	if !revision.Empty() {
@@ -338,7 +339,7 @@ func (m *ViewScopedPhysicalSegmentManager) recordSegmentSnapshot(ctx context.Con
 		}
 		loadCtx, loadCancel := context.WithCancel(context.Background())
 		loadDone := onceLoadDone(m.trackPendingLoadAttemptLocked(state))
-		state.pending = false
+		delete(m.pendingLoadSegments, snapshot.SegmentID)
 		state.pendingSnapshot = nil
 		state.loading = true
 		state.loadCancel = loadCancel
@@ -491,7 +492,7 @@ func (m *ViewScopedPhysicalSegmentManager) failPhysicalSegmentLoad(segmentID int
 		return nil, nil, subscription
 	}
 	if isSegmentResourceInsufficient(err) && m.hasOtherLoadingSegmentLocked(segmentID) {
-		state.pending = true
+		m.pendingLoadSegments[segmentID] = struct{}{}
 		if state.pendingSnapshot == nil {
 			snapshotCopy := snapshot
 			state.pendingSnapshot = &snapshotCopy
@@ -522,7 +523,7 @@ func (m *ViewScopedPhysicalSegmentManager) failPhysicalSegmentLoad(segmentID int
 	state.refs = make(map[qviews.QueryViewKey]struct{})
 	state.requests = make(map[qviews.QueryViewKey]segmentLoadRequest)
 	state.loading = false
-	state.pending = false
+	delete(m.pendingLoadSegments, segmentID)
 	state.pendingSnapshot = nil
 	state.loadCancel = nil
 	state.loadDone = nil
@@ -542,6 +543,7 @@ func (m *ViewScopedPhysicalSegmentManager) ResetSegment(segmentID int64) {
 		}
 		m.cancelSegmentUpdateLocked(state)
 		subscriptions = m.detachSubscriptionLocked(state)
+		delete(m.pendingLoadSegments, segmentID)
 		delete(m.segments, segmentID)
 	}
 	for _, ref := range m.views {
@@ -602,6 +604,7 @@ func (m *ViewScopedPhysicalSegmentManager) removeView(req ReleaseSegments) ([]Se
 				state.loadDone = nil
 			}
 			toClose = append(toClose, m.detachSubscriptionLocked(state)...)
+			delete(m.pendingLoadSegments, segmentID)
 			delete(m.segments, segmentID)
 		}
 	}
@@ -638,9 +641,14 @@ func (m *ViewScopedPhysicalSegmentManager) hasOtherLoadingSegmentLocked(segmentI
 }
 
 func (m *ViewScopedPhysicalSegmentManager) collectPendingLoadSubmissionsLocked() []segmentLoadSubmission {
-	submissions := make([]segmentLoadSubmission, 0)
-	for segmentID, state := range m.segments {
-		if !state.pending || state.loading || state.segment != nil || len(state.refs) == 0 {
+	submissions := make([]segmentLoadSubmission, 0, len(m.pendingLoadSegments))
+	for segmentID := range m.pendingLoadSegments {
+		state := m.segments[segmentID]
+		if state == nil {
+			delete(m.pendingLoadSegments, segmentID)
+			continue
+		}
+		if state.loading || state.segment != nil || len(state.refs) == 0 {
 			continue
 		}
 		request, ok := state.loadRequest()
@@ -649,7 +657,7 @@ func (m *ViewScopedPhysicalSegmentManager) collectPendingLoadSubmissionsLocked()
 		}
 		loadCtx, loadCancel := context.WithCancel(context.Background())
 		loadDone := onceLoadDone(m.trackPendingLoadAttemptLocked(state))
-		state.pending = false
+		delete(m.pendingLoadSegments, segmentID)
 		state.loading = true
 		snapshot := *state.pendingSnapshot
 		state.pendingSnapshot = nil

--- a/internal/querynodev2/qnview/view_scoped_physical_segment_manager_test.go
+++ b/internal/querynodev2/qnview/view_scoped_physical_segment_manager_test.go
@@ -163,14 +163,14 @@ func TestViewScopedPhysicalSegmentManager_PendsResourceFailureWhileOtherSegmentL
 	meta := buildHandlerTestMeta(1)
 	view := &viewpb.QueryViewOfQueryNode{
 		NodeId:     1,
-		Partitions: []*viewpb.QueryViewOfPartition{{PartitionId: 10, SegmentIds: []int64{1000, 1001}}},
+		Partitions: []*viewpb.QueryViewOfPartition{{PartitionId: 10, SegmentIds: []int64{1000, 1001, 1002}}},
 	}
 	key := qviews.NewQueryViewAtQueryNode(meta, view).QueryViewKey()
 	scheduler := &fakeNodeScheduler{}
 	mgr := newTestViewScopedPhysicalSegmentManager(t, scheduler)
 
-	loadedCh := make(chan []TransformSegment, 2)
-	failedCh := make(chan int64, 1)
+	loadedCh := make(chan []TransformSegment, 3)
+	failedCh := make(chan int64, 2)
 	unrecoverableCh := make(chan struct{}, 1)
 	mgr.Acquire(AcquirePhysicalSegments{
 		Key: key, Meta: meta, View: view,
@@ -181,7 +181,7 @@ func TestViewScopedPhysicalSegmentManager_PendsResourceFailureWhileOtherSegmentL
 	})
 
 	require.Eventually(t, func() bool {
-		return len(scheduler.tasks) == 2
+		return len(scheduler.tasks) == 3
 	}, time.Second, 10*time.Millisecond)
 	taskBySegment := make(map[int64]*SegmentLoadTask, len(scheduler.tasks))
 	for _, task := range scheduler.tasks {
@@ -189,6 +189,9 @@ func TestViewScopedPhysicalSegmentManager_PendsResourceFailureWhileOtherSegmentL
 	}
 
 	taskBySegment[1000].OnUnrecoverable(merr.WrapErrSegmentRequestResourceFailed("Memory"))
+	taskBySegment[1001].OnUnrecoverable(merr.WrapErrSegmentRequestResourceFailed("Memory"))
+	require.Contains(t, mgr.pendingLoadSegments, int64(1000))
+	require.Contains(t, mgr.pendingLoadSegments, int64(1001))
 	select {
 	case got := <-failedCh:
 		t.Fatalf("resource failure should pend while another segment is loading, got failed segment %d", got)
@@ -197,16 +200,22 @@ func TestViewScopedPhysicalSegmentManager_PendsResourceFailureWhileOtherSegmentL
 	case <-time.After(20 * time.Millisecond):
 	}
 
-	taskBySegment[1001].OnLoaded(&fakeTransformSegment{id: 1001, partitionID: 10})
+	taskBySegment[1002].OnLoaded(&fakeTransformSegment{id: 1002, partitionID: 10})
 	require.Eventually(t, func() bool {
-		return len(scheduler.tasks) == 3
+		return len(scheduler.tasks) == 5
 	}, time.Second, 10*time.Millisecond)
-	retry := scheduler.tasks[2]
-	require.Equal(t, int64(1000), retry.SegmentID)
-	retry.OnLoaded(&fakeTransformSegment{id: 1000, partitionID: 10})
+	require.Empty(t, mgr.pendingLoadSegments)
+	retries := make(map[int64]*SegmentLoadTask, 2)
+	for _, task := range scheduler.tasks[3:] {
+		retries[task.SegmentID] = task
+	}
+	require.Contains(t, retries, int64(1000))
+	require.Contains(t, retries, int64(1001))
+	retries[1000].OnLoaded(&fakeTransformSegment{id: 1000, partitionID: 10})
+	retries[1001].OnLoaded(&fakeTransformSegment{id: 1001, partitionID: 10})
 
 	require.Eventually(t, func() bool {
-		return len(loadedCh) == 2
+		return len(loadedCh) == 3
 	}, time.Second, 10*time.Millisecond)
 	select {
 	case got := <-failedCh:


### PR DESCRIPTION
## What problem does this solve?

When a segment load is blocked by resource pressure while other segment loads are still running, qnview keeps it pending for a later retry. The current retry collection scans every physical segment state after each load completion or terminal failure, even though only a small subset is pending. This makes the wake-up path scale with all tracked segments rather than actual retry candidates.

The qv branch already includes https://github.com/chyezh/milvus/pull/52, which preserves the latest segment load snapshot for pending retries. This PR is based on that behavior and keeps snapshot selection unchanged.

## What is changed?

- Add a manager-level pendingLoadSegments set and remove physicalSegmentState.pending, leaving one source of truth for pending load state.
- Collect retry submissions by iterating pending segment IDs only.
- Keep the set synchronized when a resource failure is pended, a snapshot starts an immediate load, a load completes or fails, and a segment is reset or released.
- Extend the resource-failure test to cover multiple pending segments being woken and retried together.

## Verification

- go test -count=1 -tags dynamic,test -gcflags="all=-N -l" ./internal/querynodev2/qnview -timeout 300s
- git diff --check
- gofumpt -l on the changed Go files (no output)