### PR TITLE
enhance: reuse pinned collections during query view segment loading

### DIFF
--- a/internal/querynodev2/qnview/segment_manager_test_fixtures_test.go
+++ b/internal/querynodev2/qnview/segment_manager_test_fixtures_test.go
@@ -228,6 +228,10 @@ func (g *fakeCollectionRuntimeGuard) CCollection() *segcore.CCollection {
 	return nil
 }
 
+func (g *fakeCollectionRuntimeGuard) PinnedCollection() *segments.Collection {
+	return nil
+}
+
 func (g *fakeCollectionRuntimeGuard) UpdateIndexMeta(_ context.Context, indexes []*indexpb.IndexInfo) error {
 	g.updatedIndexes = append([]*indexpb.IndexInfo(nil), indexes...)
 	return g.updateErr

--- a/internal/querynodev2/qnview/segment_resource_types.go
+++ b/internal/querynodev2/qnview/segment_resource_types.go
@@ -5,6 +5,7 @@ import (
 
 	"github.com/milvus-io/milvus-proto/go-api/v3/milvuspb"
 	"github.com/milvus-io/milvus-proto/go-api/v3/schemapb"
+	"github.com/milvus-io/milvus/internal/querynodev2/segments"
 	"github.com/milvus-io/milvus/internal/util/segcore"
 	"github.com/milvus-io/milvus/internal/views/qviews"
 	"github.com/milvus-io/milvus/pkg/v3/proto/indexpb"
@@ -54,6 +55,7 @@ type CollectionRuntime interface {
 	Schema() *schemapb.CollectionSchema
 	SchemaVersion() int64
 	CCollection() *segcore.CCollection
+	PinnedCollection() *segments.Collection
 }
 
 type CollectionIndexMetaUpdater interface {

--- a/internal/querynodev2/qvresource/qv_collection_runtime.go
+++ b/internal/querynodev2/qvresource/qv_collection_runtime.go
@@ -60,12 +60,14 @@ func (m *queryViewCollectionRuntimeManager) Acquire(ctx context.Context, view *q
 	); err != nil {
 		return nil, false, err
 	}
+	localCollection := m.collections.Get(meta.GetCollectionId())
 	var ccollection *segcore.CCollection
-	if local := m.collections.Get(meta.GetCollectionId()); local != nil {
-		ccollection = local.GetCCollection()
+	if localCollection != nil {
+		ccollection = localCollection.GetCCollection()
 	}
 	return &queryViewCollectionRuntimeGuard{
 		collections:   m.collections,
+		collection:    localCollection,
 		collectionID:  meta.GetCollectionId(),
 		databaseName:  collection.GetDbName(),
 		schema:        collection.GetSchema(),
@@ -91,6 +93,7 @@ func (m *queryViewCollectionRuntimeManager) loadInfo(ctx context.Context, meta *
 
 type queryViewCollectionRuntimeGuard struct {
 	collections   qvCollectionManager
+	collection    *segments.Collection
 	collectionID  int64
 	databaseName  string
 	schema        *schemapb.CollectionSchema
@@ -118,22 +121,13 @@ func (g *queryViewCollectionRuntimeGuard) CCollection() *segcore.CCollection {
 	return g.ccollection
 }
 
+func (g *queryViewCollectionRuntimeGuard) PinnedCollection() *segments.Collection {
+	return g.collection
+}
+
 func (g *queryViewCollectionRuntimeGuard) UpdateIndexMeta(ctx context.Context, indexes []*indexpb.IndexInfo) error {
-	if err := g.collections.PutOrRef(
-		g.collectionID,
-		g.schema,
-		segments.ComposeIndexMeta(ctx, indexes, g.schema),
-		&querypb.LoadMetaInfo{
-			LoadType:        querypb.LoadType_LoadCollection,
-			CollectionID:    g.collectionID,
-			DbName:          g.databaseName,
-			SchemaBarrierTs: uint64(g.schemaVersion),
-		},
-	); err != nil {
-		return err
-	}
-	g.collections.Unref(g.collectionID, 1)
-	return nil
+	indexMeta := segments.ComposeIndexMeta(ctx, indexes, g.schema)
+	return g.collection.UpdateIndexMeta(indexMeta)
 }
 
 func (g *queryViewCollectionRuntimeGuard) Release() {

--- a/internal/querynodev2/qvresource/qv_collection_runtime_test.go
+++ b/internal/querynodev2/qvresource/qv_collection_runtime_test.go
@@ -6,21 +6,25 @@ import (
 	"context"
 	"testing"
 
+	"github.com/bytedance/mockey"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 
 	"github.com/milvus-io/milvus-proto/go-api/v3/commonpb"
 	"github.com/milvus-io/milvus-proto/go-api/v3/milvuspb"
 	"github.com/milvus-io/milvus-proto/go-api/v3/schemapb"
+	"github.com/milvus-io/milvus/internal/querynodev2/segments"
 	"github.com/milvus-io/milvus/internal/views/qviews"
 	"github.com/milvus-io/milvus/pkg/v3/proto/indexpb"
 	"github.com/milvus-io/milvus/pkg/v3/proto/querypb"
+	"github.com/milvus-io/milvus/pkg/v3/proto/segcorepb"
 	"github.com/milvus-io/milvus/pkg/v3/proto/viewpb"
 	"github.com/milvus-io/milvus/pkg/v3/util/merr"
 )
 
 func TestQueryViewCollectionRuntimeManager_AcquireRefsCollectionAndReleaseUnrefs(t *testing.T) {
-	collection := &fakeQVCollectionManager{}
+	localCollection := segments.NewCollectionWithoutSegcoreForTest(1, &schemapb.CollectionSchema{Name: "coll"})
+	collection := &fakeQVCollectionManager{collection: localCollection}
 	provider := &fakeQVLoadMetadataProvider{
 		collection: &milvuspb.DescribeCollectionResponse{
 			CollectionID:    1,
@@ -49,6 +53,7 @@ func TestQueryViewCollectionRuntimeManager_AcquireRefsCollectionAndReleaseUnrefs
 	require.NoError(t, err)
 	assert.False(t, retryable)
 	require.NotNil(t, guard)
+	assert.Same(t, localCollection, guard.(*queryViewCollectionRuntimeGuard).collection)
 
 	assert.Equal(t, int64(1), guard.CollectionID())
 	assert.Equal(t, "db", guard.DatabaseName())
@@ -135,31 +140,38 @@ func TestQueryViewCollectionRuntimeManager_AcquireClassifiesRetryability(t *test
 	})
 }
 
-func TestQueryViewCollectionRuntimeGuard_UpdateIndexMetaRefsAndUnrefsCollection(t *testing.T) {
-	collection := &fakeQVCollectionManager{}
+func TestQueryViewCollectionRuntimeGuard_UpdateIndexMetaUsesPinnedCollection(t *testing.T) {
+	schema := &schemapb.CollectionSchema{Name: "coll"}
+	localCollection := segments.NewCollectionWithoutSegcoreForTest(1, schema)
+	collection := &fakeQVCollectionManager{collection: localCollection}
 	guard := &queryViewCollectionRuntimeGuard{
-		collections:   collection,
-		collectionID:  1,
-		databaseName:  "db",
-		schema:        &schemapb.CollectionSchema{Name: "coll"},
-		schemaVersion: 9,
+		collections:  collection,
+		collection:   localCollection,
+		collectionID: 1,
+		schema:       schema,
 	}
 	indexes := []*indexpb.IndexInfo{{CollectionID: 1, FieldID: 100, IndexName: "vec_idx"}}
+
+	var updatedCollection *segments.Collection
+	var updatedMeta *segcorepb.CollectionIndexMeta
+	patch := mockey.Mock((*segments.Collection).UpdateIndexMeta).
+		To(func(collection *segments.Collection, meta *segcorepb.CollectionIndexMeta) error {
+			updatedCollection = collection
+			updatedMeta = meta
+			return nil
+		}).
+		Build()
+	t.Cleanup(func() {
+		patch.UnPatch()
+	})
 
 	err := guard.UpdateIndexMeta(context.Background(), indexes)
 	require.NoError(t, err)
 
-	assert.Equal(t, int64(1), collection.putCollectionID)
-	assert.Equal(t, "coll", collection.putSchema.GetName())
-	require.NotNil(t, collection.putIndexMeta)
-	require.Len(t, collection.putIndexMeta.GetIndexMetas(), 1)
-	assert.Equal(t, int64(100), collection.putIndexMeta.GetIndexMetas()[0].GetFieldID())
-	assert.Equal(t, "vec_idx", collection.putIndexMeta.GetIndexMetas()[0].GetIndexName())
-	require.NotNil(t, collection.putLoadMeta)
-	assert.Equal(t, querypb.LoadType_LoadCollection, collection.putLoadMeta.GetLoadType())
-	assert.Equal(t, int64(1), collection.putLoadMeta.GetCollectionID())
-	assert.Equal(t, "db", collection.putLoadMeta.GetDbName())
-	assert.Equal(t, uint64(9), collection.putLoadMeta.GetSchemaBarrierTs())
-	assert.Equal(t, int64(1), collection.unrefCollection)
-	assert.Equal(t, uint32(1), collection.unrefCount)
+	assert.Same(t, localCollection, updatedCollection)
+	require.Len(t, updatedMeta.GetIndexMetas(), 1)
+	assert.Equal(t, int64(100), updatedMeta.GetIndexMetas()[0].GetFieldID())
+	assert.Equal(t, "vec_idx", updatedMeta.GetIndexMetas()[0].GetIndexName())
+	assert.Zero(t, collection.putCount)
+	assert.Zero(t, collection.unrefCount)
 }

--- a/internal/querynodev2/qvresource/qv_physical_segment_loader.go
+++ b/internal/querynodev2/qvresource/qv_physical_segment_loader.go
@@ -97,7 +97,7 @@ func (l realQVSegmentLoader) NewSegment(ctx context.Context, collection qnview.C
 	if collection == nil {
 		return nil, fmt.Errorf("query view collection runtime is nil")
 	}
-	localCollection := l.collections.Get(collection.CollectionID())
+	localCollection := collection.PinnedCollection()
 	if localCollection == nil {
 		return nil, merr.WrapErrCollectionNotFound(collection.CollectionID())
 	}

--- a/internal/querynodev2/qvresource/qv_physical_segment_loader_test.go
+++ b/internal/querynodev2/qvresource/qv_physical_segment_loader_test.go
@@ -6,11 +6,13 @@ import (
 	"context"
 	"testing"
 
+	"github.com/bytedance/mockey"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 
 	"github.com/milvus-io/milvus-proto/go-api/v3/msgpb"
 	"github.com/milvus-io/milvus-proto/go-api/v3/schemapb"
+	"github.com/milvus-io/milvus/internal/querynodev2/segments"
 	"github.com/milvus-io/milvus/pkg/v3/proto/querypb"
 )
 
@@ -39,4 +41,33 @@ func TestQueryViewPhysicalSegmentLoader_LoadBorrowsCollectionAndWrapsSegment(t *
 	assert.Equal(t, int64(100), loaded.PartitionID())
 	assert.Equal(t, "v1", loaded.VChannel())
 	assert.Equal(t, uint64(50), loaded.TransformStartAfterTimeTick())
+}
+
+func TestRealQVSegmentLoader_NewSegmentUsesPinnedCollection(t *testing.T) {
+	schema := &schemapb.CollectionSchema{Name: "coll"}
+	localCollection := segments.NewCollectionWithoutSegcoreForTest(1, schema)
+	collections := &fakeQVCollectionManager{collection: localCollection}
+	runtime := &queryViewCollectionRuntimeGuard{
+		collections:  collections,
+		collection:   localCollection,
+		collectionID: 1,
+		schema:       schema,
+	}
+
+	var usedCollection *segments.Collection
+	patch := mockey.Mock(segments.NewSegment).
+		To(func(_ context.Context, collection *segments.Collection, _ segments.SegmentManager, _ segments.SegmentType, _ int64, _ *querypb.SegmentLoadInfo) (segments.Segment, error) {
+			usedCollection = collection
+			return nil, assert.AnError
+		}).
+		Build()
+	t.Cleanup(func() {
+		patch.UnPatch()
+	})
+
+	loader := realQVSegmentLoader{collections: collections}
+	_, err := loader.NewSegment(context.Background(), runtime, &querypb.SegmentLoadInfo{CollectionID: 1})
+	require.ErrorIs(t, err, assert.AnError)
+	assert.Same(t, localCollection, usedCollection)
+	assert.Zero(t, collections.getCount)
 }

--- a/internal/querynodev2/qvresource/qv_segment_test_fixtures_test.go
+++ b/internal/querynodev2/qvresource/qv_segment_test_fixtures_test.go
@@ -19,6 +19,8 @@ import (
 )
 
 type fakeQVCollectionManager struct {
+	collection      *segments.Collection
+	getCount        int
 	putCollectionID int64
 	putSchema       *schemapb.CollectionSchema
 	putIndexMeta    *segcorepb.CollectionIndexMeta
@@ -31,8 +33,9 @@ type fakeQVCollectionManager struct {
 	err             error
 }
 
-func (m *fakeQVCollectionManager) Get(collectionID int64) *segments.Collection {
-	return nil
+func (m *fakeQVCollectionManager) Get(int64) *segments.Collection {
+	m.getCount++
+	return m.collection
 }
 
 func (m *fakeQVCollectionManager) PutOrRef(collectionID int64, schema *schemapb.CollectionSchema, indexMeta *segcorepb.CollectionIndexMeta, loadMeta *querypb.LoadMetaInfo) error {
@@ -182,6 +185,7 @@ type fakeQVSegment struct {
 }
 
 type fakeQVCollectionRuntime struct {
+	collection    *segments.Collection
 	collectionID  int64
 	databaseName  string
 	schema        *schemapb.CollectionSchema
@@ -206,6 +210,10 @@ func (r fakeQVCollectionRuntime) SchemaVersion() int64 {
 
 func (r fakeQVCollectionRuntime) CCollection() *segcore.CCollection {
 	return nil
+}
+
+func (r fakeQVCollectionRuntime) PinnedCollection() *segments.Collection {
+	return r.collection
 }
 
 func (s *fakeQVSegment) ID() int64 {

--- a/internal/querynodev2/segments/collection.go
+++ b/internal/querynodev2/segments/collection.go
@@ -418,6 +418,15 @@ func (c *Collection) updateIndexMeta(meta *segcorepb.CollectionIndexMeta) error 
 	return c.ccollection.UpdateIndexMeta(meta)
 }
 
+// UpdateIndexMeta updates the native collection index metadata while keeping
+// it in the same transition epoch as schema changes.
+func (c *Collection) UpdateIndexMeta(meta *segcorepb.CollectionIndexMeta) error {
+	c.lockSchemaTransitionForUpdate()
+	defer c.unlockSchemaTransitionForUpdate()
+
+	return c.updateIndexMeta(meta)
+}
+
 func (c *Collection) updateSchema(schema *schemapb.CollectionSchema, version uint64) error {
 	c.mu.Lock()
 	defer c.mu.Unlock()

--- a/internal/querynodev2/segments/collection_test.go
+++ b/internal/querynodev2/segments/collection_test.go
@@ -379,6 +379,17 @@ func (s *CollectionManagerSuite) TestPutOrRefUpdateIndexMeta() {
 		newVecFieldID)
 }
 
+func (s *CollectionManagerSuite) TestCollectionUpdateIndexMeta() {
+	coll := s.cm.Get(1)
+	s.Require().NotNil(coll)
+
+	indexMeta := proto.Clone(coll.GetCCollection().IndexMeta()).(*segcorepb.CollectionIndexMeta)
+	indexMeta.MaxIndexRowCount++
+
+	s.Require().NoError(coll.UpdateIndexMeta(indexMeta))
+	s.True(proto.Equal(indexMeta, coll.GetCCollection().IndexMeta()))
+}
+
 func (s *CollectionManagerSuite) TestPutOrRefUpdateIndexMetaWaitsForCollectionNativeLock() {
 	coll := s.cm.Get(1)
 	s.Require().NotNil(coll)


### PR DESCRIPTION
## What this PR changes

A QueryView collection runtime already pins the local `segments.Collection` from `Acquire` until `Release`. However, each segment load still looked the collection up through the manager, and each segment load/update task refreshed index metadata through a full `PutOrRef` then `Unref` cycle.

This PR reuses the collection reference already owned by the runtime:

- store and expose the pinned collection on `CollectionRuntime`;
- create sealed segments directly with that pinned collection;
- update index metadata directly on the pinned collection;
- keep index metadata updates serialized with schema transitions through the existing transition lock;
- add tests proving the segment and index-update paths do not perform extra manager `Get`, `PutOrRef`, or `Unref` operations.

## Why

When QueryView loads or updates many sealed segments from the same collection, the old path repeats collection-manager lookup, reference-count updates, load metadata construction, and the general collection update path for every task. Reusing the runtime-owned collection reduces that repeated control-plane and lock overhead, including the overhead surrounding `UpdateIndexMeta`.

The optimization does not remove `ComposeIndexMeta` or the native `CCollection.UpdateIndexMeta` call; those operations still run to keep the native collection metadata current.

## Safety

The runtime keeps the collection pinned for the whole task lifetime and releases it only from `CollectionRuntime.Release`. Direct index updates use the schema-transition lock, preserving serialization with collection schema changes.

## Test plan

```bash
source scripts/setenv.sh
go test -count=1 -tags dynamic,test -gcflags="all=-N -l" \
  ./internal/querynodev2/qnview \
  ./internal/querynodev2/qvresource \
  ./internal/querynodev2/segments \
  -timeout 300s
```

`git diff --check` also passes.