### PR TITLE
enhance: optimize query view coordination scheduling

### DIFF
--- a/docs/design-docs/design_docs/qviews/observability/event-based-observability.md
+++ b/docs/design-docs/design_docs/qviews/observability/event-based-observability.md
@@ -383,8 +383,8 @@ Persist events observe one persisted QueryView state write.
 #### Coord
 
 ```go
-// CoordPersistViewEvent is emitted when ShardViewManager.flush persists a view
-// state.
+// CoordPersistViewEvent is emitted when ShardViewManager captures one QueryView
+// persistence effect in a shard-scoped dirty event.
 type CoordPersistViewEvent struct {
     baseEvent
     View  qviews.QueryViewKey
@@ -411,16 +411,16 @@ Sync-batch events observe one QueryView sync to one worker-node batch.
 #### Coord
 
 ```go
-// CoordSyncViewBatchEvent is emitted when ShardViewManager.flush syncs a view
-// state to one worker-node batch.
+// CoordSyncViewBatchEvent is emitted when ShardViewManager captures one
+// QueryView sync effect for a worker node in a shard-scoped dirty event.
 type CoordSyncViewBatchEvent struct {
     baseEvent
     View  qviews.QueryViewKey
     State qviews.QueryViewState
 }
 
-// CoordSyncViewBatchFailedEvent is emitted when ShardViewManager.flush fails to
-// sync a view state to one worker-node batch.
+// CoordSyncViewBatchFailedEvent is emitted when a DirtyViewFlushScheduler task
+// fails to sync a QueryView state to one worker-node batch.
 type CoordSyncViewBatchFailedEvent struct {
     baseEvent
     View  qviews.QueryViewKey

--- a/docs/design-docs/design_docs/qviews/observability/event-based-observability.md
+++ b/docs/design-docs/design_docs/qviews/observability/event-based-observability.md
@@ -125,7 +125,7 @@ func Observe(ctx context.Context, event Event) {
 
 Event type is split by cardinality. Each event payload carries the identity of
 the observed object. The supported cardinalities are `node`, `view`,
-`segment`, `view-segments`, `resource`, `persist`, and `sync-batch`.
+`segment`, `view-segments`, `resource`, `persist`, and `sync-accepted`.
 
 ## Shared Types
 
@@ -383,8 +383,8 @@ Persist events observe one persisted QueryView state write.
 #### Coord
 
 ```go
-// CoordPersistViewEvent is emitted when ShardViewManager captures one QueryView
-// persistence effect in a shard-scoped dirty event.
+// CoordPersistViewEvent is emitted after DirtyViewFlushScheduler successfully
+// persists one QueryView state.
 type CoordPersistViewEvent struct {
     baseEvent
     View  qviews.QueryViewKey
@@ -404,34 +404,34 @@ type StreamingNodePersistViewEvent struct {
 }
 ```
 
-### Sync-Batch
+### Sync-Accepted
 
-Sync-batch events observe one QueryView sync to one worker-node batch.
+Sync-accepted events observe ReliableSyncer accepting one QueryView state for
+delivery to one worker node. Acceptance does not mean the worker has applied
+the state; worker application is observed through report events.
 
 #### Coord
 
 ```go
-// CoordSyncViewBatchEvent is emitted when ShardViewManager captures one
-// QueryView sync effect for a worker node in a shard-scoped dirty event.
-type CoordSyncViewBatchEvent struct {
+// CoordSyncViewAcceptedEvent is emitted after ReliableSyncer accepts one
+// QueryView state for delivery to a worker node. It does not mean the worker
+// has applied the state.
+type CoordSyncViewAcceptedEvent struct {
     baseEvent
     View  qviews.QueryViewKey
+    Node  qviews.WorkNode
     State qviews.QueryViewState
-}
-
-// CoordSyncViewBatchFailedEvent is emitted when a DirtyViewFlushScheduler task
-// fails to sync a QueryView state to one worker-node batch.
-type CoordSyncViewBatchFailedEvent struct {
-    baseEvent
-    View  qviews.QueryViewKey
-    State qviews.QueryViewState
-    Err   error
 }
 ```
 
 ## Emission Semantics
 
 Event emission runs in the owner layer that observes the action.
+
+`ShardViewManager` observes state transitions and only creates dirty effects.
+`DirtyViewFlushScheduler` emits `CoordPersistViewEvent` after Catalog success
+and `CoordSyncViewAcceptedEvent` after ReliableSyncer accepts the per-node
+group. Shutdown cancellation errors do not produce failure events.
 
 Transition-carrying events are emitted in the same critical section that
 observes the state transition. `From` and `To` must match the owner-visible

--- a/docs/design-docs/design_docs/qviews/observability/metric-based-observability.md
+++ b/docs/design-docs/design_docs/qviews/observability/metric-based-observability.md
@@ -305,26 +305,7 @@ Initial reason set:
 `MetricsObserver` should classify only reasons available from the event type
 and stable fields. Raw error strings must not become label values.
 
-### 6.6 `milvus_qv_sync_failure_total`
-
-Type: Counter
-
-Description: Count of failed Coord-to-worker QueryView sync batch attempts.
-
-Labels:
-
-```text
-node_role, state, reason
-```
-
-Derived from:
-
-- `CoordSyncViewBatchFailedEvent`
-
-The first implementation can use `reason="unknown"` until sync errors are
-classified into stable categories.
-
-### 6.7 `milvus_qv_view_ready_percent_bucket`
+### 6.6 `milvus_qv_view_ready_percent_bucket`
 
 Type: Gauge
 
@@ -361,7 +342,7 @@ StreamingNode reports, it is currently state-derived: resource-ready states
 report 100 and other states report 0. The metric is exported from the Coord
 observer because Coord owns the merged worker report view.
 
-### 6.8 `milvus_qv_sync_pending`
+### 6.7 `milvus_qv_sync_pending`
 
 Type: Gauge
 
@@ -375,10 +356,9 @@ node_role, node_id, state
 
 Status:
 
-This metric requires additional syncer events for exact accounting. Existing
-`CoordSyncViewBatchEvent` and `CoordSyncViewBatchFailedEvent` can observe send
-attempts and send failures, but they do not fully identify when a pending entry
-is matched and removed.
+This metric requires additional syncer events for exact accounting.
+`CoordSyncViewAcceptedEvent` identifies when ReliableSyncer accepts an entry,
+but does not identify when that entry is matched and removed.
 
 Required additional events:
 
@@ -539,7 +519,6 @@ Recommended first alerts:
 | Stuck non-Up view | `max(milvus_qv_view_state_max_age_seconds) > threshold` |
 | Shard not loaded | `milvus_qv_shard_load_states{state!="loaded"} > 0` for a sustained window |
 | Unrecoverable spike | Rate of `milvus_qv_unrecoverable_total` exceeds baseline |
-| Sync failure spike | Rate of `milvus_qv_sync_failure_total` exceeds baseline |
 
 Thresholds should be derived from expected segment load time and QueryView
 preparation SLA. The metric design intentionally exposes state and bounded age
@@ -548,7 +527,7 @@ diagnostics so alerts can be tuned without changing code.
 ## 12. Implementation Order
 
 1. Add QueryCoord event-derived counters:
-   `view_transition_total`, `unrecoverable_total`, and `sync_failure_total`.
+   `view_transition_total` and `unrecoverable_total`.
 2. Add QueryCoord state cache gauges:
    `view_states`, `view_state_max_age_seconds`, and
    `view_ready_percent_bucket`.

--- a/docs/design-docs/design_docs/qviews/shard_view_management.md
+++ b/docs/design-docs/design_docs/qviews/shard_view_management.md
@@ -1,137 +1,263 @@
 # Shard View Manager Design
 
-> This document describes the design of `ShardViewManager`, which manages multiple QueryViews for a single shard (vchannel) within a single replica on the Coord side.
-> Reference: [Distributed Query View Design](README.md), [QueryView State Machine](query_view_state_machine.md), [view.proto](../../../../pkg/proto/view.proto), [ReliableSyncer](../../../../internal/views/coord/coordview/syncer/reliable_syncer.go), [CoordQueryViewStateMachine](../../../../internal/views/coord/coordview/state_machine.go)
+> This document describes the Coord-side management of QueryViews for one shard
+> (vchannel) and the shared flush scheduler used to externalize state-machine
+> effects across shards.
+> Reference: [Distributed Query View Design](README.md),
+> [QueryView State Machine](query_view_state_machine.md),
+> [view.proto](../../../../pkg/proto/view.proto),
+> [ReliableSyncer](../../../../internal/views/coord/coordview/syncer/reliable_syncer.go),
+> [CoordQueryViewStateMachine](../../../../internal/views/coord/coordview/state_machine.go),
+> [NodeScheduler](../../../../pkg/util/nodescheduler/scheduler.go).
 
 ## 1. Overview
 
-`ShardViewManager` is the Coord-side component responsible for:
+`ShardViewManager` is the in-memory owner of the QueryViews for one shard on one
+replica. It is responsible for:
 
-1. Maintaining the set of active QueryViews for one shard (typically 2–3, double/triple buffer pattern).
-2. Orchestrating multiple `CoordQueryViewStateMachine` instances and their cross-view interactions.
-3. Persisting view state to ETCD via `QueryViewCatalog`.
-4. Pushing view state to nodes via `ReliableSyncer`, with response handling through callbacks.
-5. Supporting crash recovery from ETCD-persisted views + node responses.
+1. Maintaining the active QueryView set, normally following a double/triple
+   buffer pattern.
+2. Orchestrating `CoordQueryViewStateMachine` instances and cross-view
+   interactions such as preemption and Up-then-Down handoff.
+3. Creating response and QueryNode-loss callbacks for node synchronization.
+4. Publishing per-shard placement statistics.
+5. Emitting one immutable shard-scoped dirty event after each state operation.
+
+The manager does not perform ETCD or node-sync I/O itself. All managers owned by
+one `ShardViewRegistry` share one `DirtyViewFlushScheduler`. The scheduler merges
+events by `ShardID`, claims disjoint shard lanes into concurrent batch tasks,
+persists QueryView states, and only then dispatches the corresponding node syncs.
 
 ### Architecture Position
 
-```
+```text
 Sealed Segment Balancer
-        │  (generates QueryViewAtCoordBuilder)
+        │  AddPreparing / RequestRelease
         ▼
- ShardViewManager
-        │
-        ├── calls Catalog ────────→ ETCD (persistence)
-        └── calls ReliableSyncer ─→ SyncQueryView RPC ─→ StreamingNode / QueryNode
-                                           │
-                                   Node Responses
-                                           │
-                                           ▼
-                               ReliableSyncer routes to
-                              ShardViewManager callbacks
+ ShardViewRegistry
+        │ owns
+        ├──────────────► ShardViewManager per shard
+        │                        │
+        │                        │ Submit(DirtyViewEvent)
+        │                        ▼
+        └──────────────► DirtyViewFlushScheduler
+                                  │ keyed batching by ShardID
+                                  │ Submit multiple batch tasks
+                                  ▼
+                            NodeScheduler
+                                  │
+                    ┌─────────────┴─────────────┐
+                    ▼                           ▼
+             QueryViewCatalog            ReliableSyncer
+               ETCD persist              SyncQueryView RPC
+                                                │
+                                                ▼
+                                    ShardViewManager callbacks
 ```
 
 ### Design Principles
 
-- **Active component**: Directly calls `Catalog` for persistence and `ReliableSyncer` for node sync.
-- **Callback-driven**: Node responses are delivered via `OnSyncResponse` registered with `ReliableSyncer`. QueryNode loss for an active QN-targeted sync is delivered via `OnQueryNodeLost`. StreamingNode loss is not a per-view event.
-- **Self-contained**: Once a view is added via `AddPreparing`, all subsequent state transitions are driven internally through callbacks. External input is only `AddPreparing` and `RequestRelease`.
-- **Up-then-Down**: When a new view reaches Up, all older Up views are automatically transitioned to Down.
-- **Preemption**: A new `AddPreparing` preempts any existing Preparing/Ready view by injecting a synthetic Unrecoverable response.
-- **Batch I/O**: All persist and sync operations within a single method call are batched into one `SaveQueryViews` + one `SyncViews` call for atomicity.
-- **Builds on CoordQueryViewStateMachine**: Per-view state machine logic is delegated to `CoordQueryViewStateMachine`. ShardViewManager consumes its `ConsumePersist()` / `ConsumeSync()` outputs and orchestrates multi-view interactions.
+- **In-memory state owner**: `ShardViewManager` performs state transitions and
+  maintains fast pointers and statistics, but does not block on external I/O.
+- **Keyed shared batching**: One task can contain multiple shards, multiple tasks
+  can run concurrently, and one `ShardID` never appears in two running tasks.
+- **Write-ahead ordering**: Every flush batch completes `SaveQueryViews` before
+  calling `SyncViews`.
+- **Latest-state coalescing**: Unflushed persist and sync effects are replaced
+  independently by newer transitions, allowing the state machine to fast-forward
+  without queuing every intermediate state.
+- **Callback-driven**: `ReliableSyncer` delivers node responses and QueryNode-loss
+  notifications through callbacks registered by the manager.
+- **Node-level scheduling**: QueryView flush tasks reuse the common
+  `NodeScheduler`; the QueryView package owns no dedicated worker goroutine.
+- **No external I/O under manager lock**: A manager consumes pending effects into
+  an immutable event while holding `m.mu`, then submits it after releasing the
+  lock.
 
-## 2. Dependencies
+## 2. Components and Dependencies
 
-### 2.1 QueryViewCatalog (existing)
+### 2.1 ShardViewRegistry
 
-ETCD persistence layer. Implemented in `internal/metastore/kv/queryview/kv_catalog.go`.
+`ShardViewRegistry` owns all `ShardViewManager` instances and exactly one
+`DirtyViewFlushScheduler`. Recovery opens one explicit Begin/Commit batch,
+reconstructs every manager, commits all emitted recovery events, and waits for
+the resulting keyed tasks before returning.
+
+`Close` closes the flush scheduler before the QueryView runtime closes the
+underlying `ReliableSyncer`.
+
+### 2.2 QueryViewCatalog
+
+The ETCD persistence layer is implemented in
+`internal/metastore/kv/queryview/kv_catalog.go`.
 
 Persisted key format:
 
-- `coord/qv/{collectionID}/{replicaID}/{vchannel}/{streamingVersion}/{compactVersion}/{queryVersion}` — `QueryViewOfShard` proto.
+- `coord/qv/{collectionID}/{replicaID}/{vchannel}/{streamingVersion}/{compactVersion}/{queryVersion}`
 
-The key keeps the full vchannel name and the QueryView/DataView version tuple so
-multiple in-flight views for the same shard do not overwrite each other.
+The key retains the full vchannel and version tuple, so multiple in-flight views
+for one shard do not overwrite each other.
 
-### 2.2 ReliableSyncer (existing)
+### 2.3 ReliableSyncer
 
-Reliable delivery of QueryView syncs from Coord to work nodes. Defined in `internal/views/coord/coordview/syncer/reliable_syncer.go`.
+`ReliableSyncer` provides resumable delivery from Coord to StreamingNode and
+QueryNode.
 
-Key properties used by ShardViewManager:
+Properties used by this design:
 
-- **Delivery guarantee**: Every outstanding sync eventually receives either a real node response (via `OnSyncResponse`) or, for QueryNode targets, a QueryNode-lost notification (via `OnQueryNodeLost`).
-- **Callback model**: Each `SyncView` carries `OnSyncResponse` (invoked on response) and optionally `OnQueryNodeLost` (invoked only for QueryNode loss). The syncer removes the entry after the current sync completes or after draining the lost QueryNode.
-- **Pre-grouped**: `SyncGroup.ViewsByNode` is a map keyed by `WorkNodeKey`, pre-grouping views by target node.
-- **Replace semantics**: Calling `SyncViews` for a viewKey that already has an outstanding entry replaces the old entry and its callbacks.
-- **Non-blocking**: `SyncViews` returns after enqueuing.
+- `SyncGroup.ViewsByNode` groups syncs by `WorkNodeKey`.
+- Each `SyncView` carries `OnSyncResponse` and, for QueryNode targets,
+  `OnQueryNodeLost`.
+- A newer sync for the same QueryView and node replaces the older pending sync
+  and its callbacks.
+- `SyncViews` returns after the views have been accepted by the reliable syncer.
 
-### 2.3 CoordQueryViewStateMachine (existing)
+### 2.4 CoordQueryViewStateMachine
 
-Per-view state machine. Defined in `internal/views/coord/coordview/state_machine.go`. Key interface used:
-- `OnNodeStateReported(report)` — process a node response
-- `ConsumePersist() / ConsumeSync()` — consume pending I/O signals
-- `EnterDown()` — transition Up → Down
-- `EnterDropping()` — transition Unrecoverable → Dropping
-- `State()` — current state
-
-## 3. Interface
+The per-view state machine owns the latest pending external effect:
 
 ```go
-// NewShardViewManager creates a new ShardViewManager for the given shard.
-// ctx: lifecycle context for Catalog calls within callbacks.
-// recoveredViews: views loaded from ETCD during crash recovery.
-// Unrecoverable views remain Unrecoverable after construction, waiting for
-// AddPreparing or RequestRelease to advance them to Dropping.
-// Active views in other states are pushed to their target nodes via syncer.
-func NewShardViewManager(ctx, shardID, catalog, syncer, recoveredViews) *ShardViewManager
-
-// AddPreparing adds a new view in Preparing state from a builder.
-// The manager assigns QueryVersion automatically:
-//   - Same DataVersion as existing views: QV = max(existing QV for same DV) + 1
-//   - New DataVersion: QV = 1
-// Preempts any existing Preparing/Ready view.
-// Validates no DataVersion rollback against existing views.
-func (m *ShardViewManager) AddPreparing(ctx, builder *qviews.QueryViewAtCoordBuilder) error
-
-// RequestRelease initiates teardown of all views in this shard.
-// Up views → Down (normal teardown). Preparing/Ready views → Unrecoverable → Dropping.
-// Actual cleanup completes asynchronously through callbacks.
-func (m *ShardViewManager) RequestRelease(ctx) error
+type queryViewFlush struct {
+    Persist *viewpb.QueryViewOfShard
+    Sync    []qviews.QueryViewAtWorkNode
+}
 ```
+
+`Persist` and `Sync` have replace semantics. `ConsumeFlush` atomically drains
+both values. This is distinct from the reliable syncer's own pending map: the
+state-machine pending value represents effects not yet handed to the external
+systems, while the syncer pending map represents accepted but not yet
+acknowledged RPC work.
+
+### 2.5 DirtyViewFlushScheduler
+
+The Registry-level scheduler owns:
+
+- Pending immutable events merged by `ShardID` and versioned QueryView key.
+- The set of inflight `ShardID` lanes.
+- Explicit Begin/Commit-held shard lanes.
+- Multiple queued or running one-shot batch tasks.
+- Batch sizing using `MetaStoreCfg.MaxEtcdTxnNum`.
+- Persist-before-sync execution.
+- Lifecycle cancellation and explicit waiting for recovery and tests.
+
+Every task runs through the global `NodeScheduler`. A task claims only shard
+lanes that are not already inflight. New work for an inflight shard stays pending
+until that task finishes; work for an unrelated shard may immediately enter a
+different task.
+
+## 3. Interfaces
+
+Managers are constructed only by `ShardViewRegistry`:
+
+```go
+func newShardViewManager(
+    ctx context.Context,
+    shardID qviews.ShardID,
+    eventSubmitter dirtyViewEventSubmitter,
+    recoveredViews []*viewpb.QueryViewOfShard,
+) *ShardViewManager
+```
+
+External lifecycle operations remain:
+
+```go
+func (m *ShardViewManager) AddPreparing(
+    ctx context.Context,
+    builder *qviews.QueryViewAtCoordBuilder,
+) error
+
+func (m *ShardViewManager) RequestRelease(ctx context.Context) error
+```
+
+`AddPreparing` assigns QueryVersion automatically, rejects DataVersion rollback,
+and preempts an existing Preparing or Ready view. `RequestRelease` starts the
+normal teardown of all views in the shard. Both methods mutate state under
+`m.mu`, atomically consume the resulting effects into one `dirtyViewEvent`,
+release the lock, and submit that event to the Scheduler.
 
 ## 4. Internal Flow
 
-### 4.1 Batch I/O
+### 4.1 State Transition and Event Submission
 
-All operations accumulate persist and sync entries into `ShardViewManager`'s inline fields:
+Every state-changing entry point follows the same pattern:
 
-- `pendingPersists []*viewpb.QueryViewOfShard` — accumulated persist entries.
-- `pendingSyncs []syncEntry` — accumulated sync entries (`sm` + per-node views pairs).
+1. Acquire `m.mu`.
+2. Apply the state-machine input.
+3. Run `processStateMachine` for each changed state machine. It consumes that
+   state machine's `ConsumeFlush` result into manager-local pending slices and
+   updates `preparingView`, `upView`, and cascading Up-then-Down state.
+4. Move the accumulated effects into one immutable shard-scoped event with
+   persistence, node-sync, and callback information.
+5. Release `m.mu`.
+6. Call `DirtyViewFlushScheduler.Submit(event)`.
 
-After all state machine processing is complete, `flush()` executes:
-1. One `catalog.SaveQueryViews()` call for all accumulated persists.
-2. One `syncer.SyncViews()` call with all accumulated syncs merged into a single `ViewsByNode` map.
-
-This ensures atomicity at the persistence layer and reduces I/O overhead.
+The same pattern is used by `AddPreparing`, `RequestRelease`,
+`OnSyncResponse`, and `OnQueryNodeLost`. The Scheduler never calls back into a
+manager to scan its state.
 
 ### 4.2 processStateMachine
 
-After any state machine event (node response, AddPreparing, RequestRelease), `processStateMachine(sm)` is called:
+`processStateMachine` consumes the current state machine's pending external
+effects and handles its in-memory cross-view effects:
 
-1. `ConsumePersist()` → if non-nil, append to `pendingPersists`.
-2. `ConsumeSync()` → if non-nil, append to `pendingSyncs`.
-3. Handle cascading effects based on current state:
-   - **Preparing/Ready**: Update `preparingView` pointer.
-   - **Up**: Clear `preparingView` if it was this SM, call `downOlderUpView` to cascade older Up view to Down, update `upView` pointer.
-   - **Down**: Clear `upView` if it was this SM.
-   - **Unrecoverable**: Clear `preparingView`/`upView` if they were this SM. Stay in Unrecoverable — the Manager defers advancement to Dropping until `AddPreparing` or `RequestRelease`, so that the old view's Dropped sync and the new view's Preparing sync can be batched together.
-   - **Dropping**: Return (wait for all nodes to confirm Dropped via callbacks).
-   - **Dropped**: Remove view from manager.
+- **Preparing/Ready**: Update `preparingView`.
+- **Up**: Clear `preparingView` when applicable, transition an older Up view to
+  Down, and update `upView`.
+- **Down**: Clear `upView` when applicable.
+- **Unrecoverable**: Clear the fast pointers and remain stable until
+  `AddPreparing` or `RequestRelease` advances the view to Dropping.
+- **Dropping**: Wait for node callbacks.
+- **Dropped**: The final ETCD deletion effect is first moved into the manager's
+  pending persist slice, then the state machine is removed.
 
-### 4.3 Sync Routing (collectSyncViews)
+Effects are consumed only from state machines explicitly processed by the
+current operation. Untouched resident views are not scanned.
 
-The sync proto's state determines routing:
+### 4.3 Emitting One Shard Event
+
+`consumeDirtyEventLocked` transfers the current operation's manager-local
+pending effects:
+
+1. Acquire `m.mu`.
+2. Reuse the persist effects accumulated by `processStateMachine`.
+3. Convert accumulated node targets into `syncer.SyncView` values with the
+   correct callbacks.
+4. Move both pending slices into one immutable `dirtyViewEvent` keyed by the
+   manager's `ShardID`.
+5. Clear the manager fields without retaining or reusing the event's backing
+   arrays.
+
+No Catalog or ReliableSyncer call is performed while `m.mu` is held.
+
+### 4.4 Keyed Concurrent Batch Flush
+
+The scheduler merges pending events per `ShardID`. Persist effects are latest-win
+per versioned QueryView key; sync effects are latest-win per QueryView key and
+WorkNode key. It packs ready, non-inflight shard lanes according to the configured
+maximum ETCD transaction operation count. For each claimed batch it performs:
+
+1. Flatten all `persists` and call `catalog.SaveQueryViews` once.
+2. Only after persistence succeeds, group every `syncer.SyncView` by
+   `WorkNodeKey`.
+3. Call `syncer.SyncViews` once for the grouped node syncs.
+
+The ordering is local to each packed batch: all included QueryView states are
+persisted before any included node sync is dispatched. Different tasks contain
+disjoint shard lanes and may execute concurrently.
+
+If new work for an inflight shard arrives during I/O, it remains pending until
+the task completes and is then eligible for a successor task. Unrelated shard
+work can be claimed by another task immediately.
+
+`Begin()` opens an explicit batching window without stopping existing tasks.
+Events submitted within nested windows are held from new dispatch. The outermost
+idempotent `Commit()` releases the held lanes and fans them out into as many
+disjoint batch tasks as the configured batch size requires.
+
+### 4.5 Sync Routing
+
+The target state determines routing:
 
 | Sync State | Route To |
 |---|---|
@@ -140,54 +266,104 @@ The sync proto's state determines routing:
 | Down | SN only |
 | Dropped | SN + all QNs |
 
-Views are collected into a shared `ViewsByNode` map for the batch.
+### 4.6 Callback Model
 
-### 4.4 Callback Model
+Each accepted sync registers callbacks:
 
-Each `SyncViews` call registers per-node callbacks:
-- **OnSyncResponse**: Acquires `m.mu`, finds the SM by version, calls `sm.OnNodeStateReported(resp)`, calls `processStateMachine(sm)`, flushes. Returns true when the current node-targeted sync is complete, stopping ReliableSyncer tracking for that entry.
-- **OnQueryNodeLost**: Registered only for QueryNode targets. Acquires `m.mu`, finds the SM by version, calls `sm.OnQueryNodeLost(qn)`, calls `processStateMachine(sm)`, flushes. In Preparing this transitions to Unrecoverable; in Dropping it marks the QN cleanup as complete.
+- **OnSyncResponse**: Looks up the state machine by version, applies
+  `OnNodeStateReported`, processes in-memory cascading effects, publishes stats,
+  unlocks, and submits the resulting shard event. It returns whether the current
+  node-targeted sync has completed.
+- **OnQueryNodeLost**: Registered only for QueryNode targets. It applies
+  `OnQueryNodeLost`, processes the resulting state, publishes stats, unlocks,
+  and marks the manager dirty. In Preparing this makes the view Unrecoverable;
+  in Dropping it treats the lost QueryNode cleanup as complete. The resulting
+  shard event is submitted after unlocking.
 
-### 4.5 AddPreparing
+Callbacks for an already removed view stop tracking without creating new work.
 
-1. `builder.DataVersion()` → validate no rollback against ALL views.
-2. Find existing Preparing/Ready view → preempt via `sm.EnterUnrecoverable()`, `processStateMachine(sm)`.
-3. Advance all Unrecoverable views to Dropping via `advanceUnrecoverableToDropping()`, so their Dropped sync is batched with the new Preparing sync.
-4. Compute QueryVersion: `max(QV for views with same DV) + 1`.
-5. `builder.SetQueryVersion(qv)` → `builder.Build()` → new SM → `processStateMachine(sm)`.
-6. `flush()`.
+### 4.7 AddPreparing
 
-> **TODO**: Add maxViews check (default 3) to limit total active views. During preemption, `maxViews+1` should be allowed temporarily (preempted view is draining).
+1. Validate the new DataVersion against all resident views.
+2. Preempt an existing Preparing or Ready view by entering Unrecoverable.
+3. Advance Unrecoverable views to Dropping so their Dropped sync can be batched
+   with the replacement Preparing sync.
+4. Assign `max(QueryVersion for the same DataVersion) + 1`, or 1 when the
+   DataVersion is new.
+5. Build and register the new state machine.
+6. Update in-memory pointers and stats.
+7. Emit one shard event, unlock, and submit it.
 
-### 4.6 RequestRelease
+### 4.8 RequestRelease
 
-- **Preparing/Ready view**: `sm.EnterUnrecoverable()` → `processStateMachine(sm)`.
-- **Up view**: `sm.EnterDown()` → `processStateMachine(sm)`.
-- Advance all Unrecoverable views to Dropping via `advanceUnrecoverableToDropping()`.
-- `flush()`.
+- Preparing or Ready views enter Unrecoverable.
+- Up views enter Down.
+- All Unrecoverable views advance to Dropping.
+- The manager publishes the new stats, emits one shard event, unlocks, and
+  submits it.
 
-## 5. Thread Safety
+Cleanup continues asynchronously through reliable node callbacks.
 
-All access serialized via `m.mu`. Callbacks from ReliableSyncer's recv goroutines acquire the lock. Catalog writes happen under the lock (acceptable: ETCD writes are fast, `ReliableWriteMetaKv` only fails on ctx cancellation). `SyncViews` is non-blocking.
+## 5. Recovery and Shutdown
 
-## 6. Invariants
+During recovery, persisted views are grouped by `ShardID` and reconstructed as
+state machines. Recovered Preparing and Down views create pending sync effects.
+The Registry holds all emitted events inside one Begin/Commit window, commits
+them into keyed tasks, and waits for the Scheduler to become idle before recovery
+completes.
 
-1. **Preemption**: A new Preparing view preempts any existing Preparing/Ready view. At most one non-draining Preparing/Ready view at a time.
-2. **Max Views**: *(TODO — not yet implemented)* Total active views ≤ `maxViews` (default 3). During preemption, `maxViews+1` should be allowed temporarily (preempted view is draining).
-3. **DataVersion Rollback Prevention**: New Preparing view's DataVersion must not be lower than any existing view's DataVersion.
-4. **QueryVersion Auto-Assignment**: The manager assigns QueryVersion = `max(QV for views with same DV) + 1`, or 1 if no matching DV exists.
-5. **Write-Ahead Persistence**: State persisted BEFORE pushing to nodes (batch persist then batch sync).
-6. **Batch Atomicity**: All persists within a single operation (AddPreparing, RequestRelease, callback) are flushed in one `SaveQueryViews` call. All syncs are flushed in one `SyncViews` call.
-7. **Up-then-Down**: When a new view reaches Up, all older Up views immediately transition to Down.
-8. **Deferred Dropping**: Unrecoverable views stay in Unrecoverable until `AddPreparing` or `RequestRelease` advances them to Dropping, allowing the old view's Dropped sync and the new view's Preparing sync to be batched together.
+On shutdown, the QueryView runtime stops the balancer, closes the Registry and
+its flush scheduler, then closes `ReliableSyncer`. This prevents a flush task
+from submitting new sync work after the syncer has closed.
 
-## 7. Package Location
+## 6. Thread Safety
 
-```
+- `ShardViewManager.mu` protects its state machines, fast pointers, and atomic
+  event creation.
+- `DirtyViewFlushScheduler.mu` protects pending events, inflight and held shard
+  lanes, queued task accounting, terminal error, and closed state.
+- No external ETCD or RPC enqueue operation runs while a manager lock is held.
+- No Catalog or ReliableSyncer I/O runs while the Scheduler lock is held.
+- The shared `NodeScheduler` queue is unbounded and non-blocking, so submitting
+  an event does not wait for a batch task to execute.
+
+## 7. Invariants
+
+1. **Preemption**: At most one non-draining Preparing or Ready view exists per
+   shard.
+2. **Max Views**: The total active-view limit is still a separate TODO; a
+   preempted draining view may temporarily coexist with its replacement.
+3. **DataVersion Rollback Prevention**: A new Preparing view cannot have a lower
+   DataVersion than any resident view.
+4. **QueryVersion Assignment**: QueryVersion is one greater than the maximum for
+   the same DataVersion, or 1 for a new DataVersion.
+5. **Write-Ahead Persistence**: A packed flush persists every included state
+   before dispatching any included node sync.
+6. **Latest-State Coalescing**: Multiple unflushed transitions may skip
+   intermediate external states, but retain the latest pending persist and sync
+   effects independently.
+7. **Dirty-State Preservation**: Work created for an inflight shard is processed
+   by a successor task after that shard lane is released.
+8. **Up-then-Down**: When a new view reaches Up, any older Up view immediately
+   enters Down.
+9. **Deferred Dropping**: Unrecoverable remains stable until replacement or
+   release logic advances it to Dropping.
+10. **Dropped Persistence**: A Dropped state machine is removed only after its
+    final ETCD deletion effect has been captured in an immutable dirty event.
+11. **Shard-Lane Serialization**: Old and new QueryView versions of one
+    `ShardID` cannot be flushed by concurrent tasks.
+12. **Cross-Shard Parallelism**: Different `ShardID` lanes may execute in
+    different NodeScheduler tasks concurrently.
+
+## 8. Package Location
+
+```text
 internal/views/coord/coordview/
-    syncer/reliable_syncer.go   // ReliableSyncer interface (existing)
-    state_machine.go            // CoordQueryViewStateMachine (existing)
-    shard_view_manager.go       // ShardViewManager implementation
-    errors.go                   // Error sentinels
-    shard_view_manager_test.go  // Tests
+    dirty_view_flush_scheduler.go       # Keyed event aggregation and batch tasks
+    dirty_view_flush_scheduler_test.go  # Begin/Commit, batching, lane concurrency
+    shard_view_registry.go        # Registry and scheduler lifecycle owner
+    shard_view_manager.go         # Per-shard in-memory orchestration
+    state_machine.go              # Per-view lifecycle and pending effects
+    syncer/reliable_syncer.go     # Reliable node delivery
+    shard_view_manager_test.go    # Manager lifecycle tests
 ```

--- a/docs/design-docs/design_docs/qviews/shard_view_management.md
+++ b/docs/design-docs/design_docs/qviews/shard_view_management.md
@@ -238,9 +238,12 @@ WorkNode key. It packs ready, non-inflight shard lanes according to the configur
 maximum ETCD transaction operation count. For each claimed batch it performs:
 
 1. Flatten all `persists` and call `catalog.SaveQueryViews` once.
-2. Only after persistence succeeds, group every `syncer.SyncView` by
+2. Emit `CoordPersistViewEvent` for each successfully persisted QueryView.
+3. Only after persistence succeeds, group every `syncer.SyncView` by
    `WorkNodeKey`.
-3. Call `syncer.SyncViews` once for the grouped node syncs.
+4. Call `syncer.SyncViews` once for the grouped node syncs.
+5. Emit `CoordSyncViewAcceptedEvent` for each QueryView accepted by the
+   ReliableSyncer.
 
 The ordering is local to each packed batch: all included QueryView states are
 persisted before any included node sync is dispatched. Different tasks contain

--- a/internal/querycoordv2/qviews_runtime.go
+++ b/internal/querycoordv2/qviews_runtime.go
@@ -180,6 +180,9 @@ func (r *qviewsRuntime) start(ctx context.Context) {
 
 func (r *qviewsRuntime) stop() {
 	r.balancer.Stop()
+	if r.shardViewRegistry != nil {
+		r.shardViewRegistry.Close()
+	}
 	_ = r.syncer.Close()
 	if r.queryNodeManager != nil {
 		r.queryNodeManager.Close()

--- a/internal/streamingnode/server/wal/interceptors/timetick/mvcc/mvcc_manager.go
+++ b/internal/streamingnode/server/wal/interceptors/timetick/mvcc/mvcc_manager.go
@@ -10,15 +10,17 @@ import (
 // NewMVCCManager creates a new per-vchannel query MVCC manager.
 func NewMVCCManager(_ uint64) *MVCCManager {
 	return &MVCCManager{
-		vchannelMVCCs: make(map[string]VChannelMVCC),
+		vchannelMVCCs:        make(map[string]VChannelMVCC),
+		unconfirmedVChannels: make(map[string]struct{}),
 	}
 }
 
 // MVCCManager is the manager that manages all the mvcc state of one wal.
 // It tracks the persisted query-plan frontiers of each recovered vchannel.
 type MVCCManager struct {
-	mu            sync.Mutex
-	vchannelMVCCs map[string]VChannelMVCC
+	mu                   sync.Mutex
+	vchannelMVCCs        map[string]VChannelMVCC
+	unconfirmedVChannels map[string]struct{}
 }
 
 // GetMVCCOfVChannel gets the query MVCC frontiers of the vchannel.
@@ -43,6 +45,7 @@ func (cm *MVCCManager) ApplyRecoveryBarrier(vchannel string, timetick uint64) {
 	mvcc.TransformingTimetick = max(mvcc.TransformingTimetick, timetick)
 	mvcc.Confirmed = true
 	cm.vchannelMVCCs[vchannel] = mvcc
+	delete(cm.unconfirmedVChannels, vchannel)
 }
 
 // UpdateMVCC updates the mvcc state by incoming message.
@@ -125,15 +128,17 @@ func (cm *MVCCManager) UpdateMVCC(msg message.MutableMessage) {
 	}
 	mvcc.Confirmed = false
 	cm.vchannelMVCCs[vchannel] = mvcc
+	cm.unconfirmedVChannels[vchannel] = struct{}{}
 }
 
-// sync syncs the mvcc state by the incoming timetick message, push forward the wal mvcc state
-// and clear the vchannel mvcc state.
+// sync confirms the unconfirmed vchannel MVCC states covered by the incoming timetick message.
 func (cm *MVCCManager) sync(tt uint64) {
-	for vchannel, mvcc := range cm.vchannelMVCCs {
+	for vchannel := range cm.unconfirmedVChannels {
+		mvcc := cm.vchannelMVCCs[vchannel]
 		if max(mvcc.GrowingTimetick, mvcc.TransformingTimetick) <= tt {
 			mvcc.Confirmed = true
 			cm.vchannelMVCCs[vchannel] = mvcc
+			delete(cm.unconfirmedVChannels, vchannel)
 		}
 	}
 }
@@ -146,6 +151,7 @@ func (cm *MVCCManager) advanceTransformingAllLocked(tt uint64) {
 		mvcc.TransformingTimetick = tt
 		mvcc.Confirmed = false
 		cm.vchannelMVCCs[vchannel] = mvcc
+		cm.unconfirmedVChannels[vchannel] = struct{}{}
 	}
 }
 

--- a/internal/streamingnode/server/wal/interceptors/timetick/mvcc/mvcc_manager_test.go
+++ b/internal/streamingnode/server/wal/interceptors/timetick/mvcc/mvcc_manager_test.go
@@ -113,6 +113,32 @@ func TestRecoveryBarrierConfirmsQueryPlanMVCC(t *testing.T) {
 	assert.Equal(t, VChannelMVCC{GrowingTimetick: 130, TransformingTimetick: 120, Confirmed: true}, mvcc)
 }
 
+func TestMVCCManagerTracksUnconfirmedVChannels(t *testing.T) {
+	cm := NewMVCCManager(100)
+	cm.ApplyRecoveryBarrier("vc1", 120)
+	cm.ApplyRecoveryBarrier("vc2", 120)
+	assert.Empty(t, cm.unconfirmedVChannels)
+
+	cm.UpdateMVCC(createTestMessage(t, 130, "vc1", message.MessageTypeInsert, false, true))
+	assert.Equal(t, map[string]struct{}{"vc1": {}}, cm.unconfirmedVChannels)
+
+	cm.UpdateMVCC(createTestMessage(t, 129, "", message.MessageTypeTimeTick, false, true))
+	assert.Equal(t, map[string]struct{}{"vc1": {}}, cm.unconfirmedVChannels)
+
+	cm.UpdateMVCC(createTestMessage(t, 130, "", message.MessageTypeTimeTick, false, true))
+	assert.Empty(t, cm.unconfirmedVChannels)
+
+	cm.UpdateMVCC(createTestMessage(t, 140, "vc1", message.MessageTypeInsert, false, true))
+	cm.ApplyRecoveryBarrier("vc1", 140)
+	assert.Empty(t, cm.unconfirmedVChannels)
+
+	cm.UpdateMVCC(createTestMessage(t, 150, "", message.MessageTypeFlushAll, false, true))
+	assert.Equal(t, map[string]struct{}{"vc1": {}, "vc2": {}}, cm.unconfirmedVChannels)
+
+	cm.UpdateMVCC(createTestMessage(t, 150, "", message.MessageTypeTimeTick, false, true))
+	assert.Empty(t, cm.unconfirmedVChannels)
+}
+
 func TestTransformBarrierMessagesAdvanceTransformingMVCC(t *testing.T) {
 	cm := NewMVCCManager(100)
 	cm.ApplyRecoveryBarrier("vc1", 120)

--- a/internal/views/coord/balancer/balancer.go
+++ b/internal/views/coord/balancer/balancer.go
@@ -151,6 +151,8 @@ func (b *DefaultBalancer) apply(ctx context.Context, plan *BalancePlan) error {
 	if plan == nil {
 		return nil
 	}
+	batch := b.viewRegistry.Begin()
+	defer batch.Commit()
 	var errs []error
 	for _, shardID := range plan.Releases {
 		mgr := b.viewRegistry.Get(shardID)

--- a/internal/views/coord/coordview/dirty_view_flush_scheduler.go
+++ b/internal/views/coord/coordview/dirty_view_flush_scheduler.go
@@ -1,0 +1,429 @@
+package coordview
+
+import (
+	"context"
+	"sync"
+
+	"github.com/milvus-io/milvus/internal/metastore/kv/queryview"
+	"github.com/milvus-io/milvus/internal/views/coord/coordview/syncer"
+	"github.com/milvus-io/milvus/internal/views/qviews"
+	qvobserve "github.com/milvus-io/milvus/internal/views/qviews/observe"
+	"github.com/milvus-io/milvus/pkg/v3/proto/viewpb"
+	"github.com/milvus-io/milvus/pkg/v3/util/nodescheduler"
+)
+
+// dirtyViewEvent is one immutable shard-scoped set of external effects emitted
+// by ShardViewManager after an in-memory state transition.
+type dirtyViewEvent struct {
+	shardID  qviews.ShardID
+	persists []*viewpb.QueryViewOfShard
+	syncs    []syncer.SyncView
+}
+
+type dirtyViewEventSubmitter interface {
+	Submit(dirtyViewEvent)
+}
+
+func (e dirtyViewEvent) empty() bool {
+	return len(e.persists) == 0 && len(e.syncs) == 0
+}
+
+type pendingDirtyViewEvent struct {
+	persists map[qviews.QueryViewKey]*viewpb.QueryViewOfShard
+	syncs    map[dirtyViewSyncKey]syncer.SyncView
+}
+
+type dirtyViewSyncKey struct {
+	view qviews.QueryViewKey
+	node qviews.WorkNodeKey
+}
+
+func newPendingDirtyViewEvent() *pendingDirtyViewEvent {
+	return &pendingDirtyViewEvent{
+		persists: make(map[qviews.QueryViewKey]*viewpb.QueryViewOfShard),
+		syncs:    make(map[dirtyViewSyncKey]syncer.SyncView),
+	}
+}
+
+func (e *pendingDirtyViewEvent) merge(event dirtyViewEvent) {
+	for _, view := range event.persists {
+		e.persists[queryViewKeyFromProto(view)] = view
+	}
+	for _, view := range event.syncs {
+		key := dirtyViewSyncKey{
+			view: view.View.QueryViewKey(),
+			node: view.View.WorkNode().Key(),
+		}
+		e.syncs[key] = view
+	}
+}
+
+func (e *pendingDirtyViewEvent) operationCount() int {
+	return max(1, len(e.persists))
+}
+
+func queryViewKeyFromProto(view *viewpb.QueryViewOfShard) qviews.QueryViewKey {
+	meta := view.GetMeta()
+	return qviews.QueryViewKey{
+		ShardID:          qviews.NewShardIDFromQVMeta(meta),
+		QueryViewVersion: qviews.FromProtoQueryViewVersion(meta.GetVersion()),
+	}
+}
+
+// DirtyViewFlushScheduler batches shard-scoped QueryView effects and submits
+// disjoint batches to the node-level NodeScheduler. Effects within one ShardID
+// lane are serialized; different lanes may execute concurrently.
+type DirtyViewFlushScheduler struct {
+	catalog       queryview.QueryViewCatalog
+	syncer        syncer.ReliableSyncer
+	maxTxnOps     int
+	nodeScheduler nodescheduler.Scheduler
+
+	mu          sync.Mutex
+	pending     map[qviews.ShardID]*pendingDirtyViewEvent
+	ready       map[qviews.ShardID]struct{}
+	readyOps    int
+	inflight    map[qviews.ShardID]struct{}
+	held        map[qviews.ShardID]struct{}
+	batchDepth  int
+	queuedTasks int
+	tasks       map[*dirtyViewFlushTask]nodescheduler.TaskHandle
+	err         error
+	closed      bool
+	notify      chan struct{}
+}
+
+type dirtyViewBatchCommit struct {
+	scheduler *DirtyViewFlushScheduler
+	once      sync.Once
+}
+
+type DirtyViewBatch interface {
+	Commit()
+}
+
+func (c *dirtyViewBatchCommit) Commit() {
+	if c == nil || c.scheduler == nil {
+		return
+	}
+	c.once.Do(c.scheduler.commit)
+}
+
+type dirtyViewFlushTask struct {
+	scheduler *DirtyViewFlushScheduler
+}
+
+func newDirtyViewFlushScheduler(
+	catalog queryview.QueryViewCatalog,
+	s syncer.ReliableSyncer,
+	maxTxnOps int,
+	nodeScheduler nodescheduler.Scheduler,
+) *DirtyViewFlushScheduler {
+	if maxTxnOps <= 0 {
+		maxTxnOps = 1
+	}
+	return &DirtyViewFlushScheduler{
+		catalog:       catalog,
+		syncer:        s,
+		maxTxnOps:     maxTxnOps,
+		nodeScheduler: nodeScheduler,
+		pending:       make(map[qviews.ShardID]*pendingDirtyViewEvent),
+		ready:         make(map[qviews.ShardID]struct{}),
+		inflight:      make(map[qviews.ShardID]struct{}),
+		held:          make(map[qviews.ShardID]struct{}),
+		tasks:         make(map[*dirtyViewFlushTask]nodescheduler.TaskHandle),
+		notify:        make(chan struct{}, 1),
+	}
+}
+
+// Begin opens an explicit batching window. Existing tasks continue running;
+// events submitted while any window is open are held until the outermost
+// Commit.
+func (s *DirtyViewFlushScheduler) Begin() DirtyViewBatch {
+	commit := &dirtyViewBatchCommit{scheduler: s}
+	if s == nil {
+		return commit
+	}
+	s.mu.Lock()
+	if !s.closed {
+		s.batchDepth++
+	}
+	s.mu.Unlock()
+	return commit
+}
+
+func (s *DirtyViewFlushScheduler) commit() {
+	s.mu.Lock()
+	if s.batchDepth > 0 {
+		s.batchDepth--
+		if s.batchDepth == 0 {
+			held := s.held
+			s.held = make(map[qviews.ShardID]struct{})
+			for shardID := range held {
+				s.markReadyLocked(shardID)
+			}
+			s.scheduleReadyTasksLocked()
+		}
+	}
+	s.signalLocked()
+	s.mu.Unlock()
+}
+
+// Submit merges one shard-scoped event and opportunistically schedules enough
+// batch tasks to process all currently ready lanes.
+func (s *DirtyViewFlushScheduler) Submit(event dirtyViewEvent) {
+	if s == nil || event.empty() {
+		return
+	}
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	if s.closed || s.err != nil {
+		return
+	}
+	pending := s.pending[event.shardID]
+	if pending == nil {
+		pending = newPendingDirtyViewEvent()
+		s.pending[event.shardID] = pending
+	}
+	_, wasReady := s.ready[event.shardID]
+	if wasReady {
+		s.readyOps -= pending.operationCount()
+	}
+	pending.merge(event)
+	if wasReady {
+		s.readyOps += pending.operationCount()
+	}
+	if s.batchDepth > 0 {
+		s.removeReadyLocked(event.shardID)
+		s.held[event.shardID] = struct{}{}
+	} else {
+		s.markReadyLocked(event.shardID)
+		s.scheduleReadyTasksLocked()
+	}
+	s.signalLocked()
+}
+
+func (s *DirtyViewFlushScheduler) scheduleReadyTasksLocked() {
+	if s.closed || s.err != nil || s.batchDepth > 0 {
+		return
+	}
+	if len(s.ready) == 0 {
+		return
+	}
+	desiredTasks := min(len(s.ready), (s.readyOps+s.maxTxnOps-1)/s.maxTxnOps)
+	for s.queuedTasks < desiredTasks {
+		task := &dirtyViewFlushTask{scheduler: s}
+		s.queuedTasks++
+		handle := s.nodeScheduler.Submit(task)
+		s.tasks[task] = handle
+	}
+}
+
+func (s *DirtyViewFlushScheduler) claim() map[qviews.ShardID]*pendingDirtyViewEvent {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	if s.queuedTasks > 0 {
+		s.queuedTasks--
+	}
+	claimed := make(map[qviews.ShardID]*pendingDirtyViewEvent)
+	if s.closed || s.err != nil {
+		return claimed
+	}
+	usedOps := 0
+	for shardID := range s.ready {
+		event := s.pending[shardID]
+		ops := event.operationCount()
+		if len(claimed) > 0 && usedOps+ops > s.maxTxnOps {
+			continue
+		}
+		claimed[shardID] = event
+		s.removeReadyLocked(shardID)
+		delete(s.pending, shardID)
+		s.inflight[shardID] = struct{}{}
+		usedOps += ops
+		if usedOps >= s.maxTxnOps {
+			break
+		}
+	}
+	s.scheduleReadyTasksLocked()
+	s.signalLocked()
+	return claimed
+}
+
+func (s *DirtyViewFlushScheduler) complete(
+	task *dirtyViewFlushTask,
+	claimed map[qviews.ShardID]*pendingDirtyViewEvent,
+	err error,
+) {
+	s.mu.Lock()
+	delete(s.tasks, task)
+	for shardID := range claimed {
+		delete(s.inflight, shardID)
+		if _, held := s.held[shardID]; !held {
+			s.markReadyLocked(shardID)
+		}
+	}
+	if err != nil && !s.closed {
+		s.err = err
+	}
+	if err == nil {
+		s.scheduleReadyTasksLocked()
+	}
+	s.signalLocked()
+	s.mu.Unlock()
+}
+
+func (t *dirtyViewFlushTask) Execute(ctx context.Context) error {
+	claimed := t.scheduler.claim()
+	err := t.scheduler.flushBatch(ctx, claimed)
+	t.scheduler.complete(t, claimed, err)
+	return err
+}
+
+func (s *DirtyViewFlushScheduler) flushBatch(
+	ctx context.Context,
+	batch map[qviews.ShardID]*pendingDirtyViewEvent,
+) error {
+	if len(batch) == 0 {
+		return nil
+	}
+	persists := make([]*viewpb.QueryViewOfShard, 0)
+	viewsByNode := make(map[qviews.WorkNodeKey][]syncer.SyncView)
+	for _, event := range batch {
+		for _, view := range event.persists {
+			persists = append(persists, view)
+		}
+		for _, view := range event.syncs {
+			nodeKey := view.View.WorkNode().Key()
+			viewsByNode[nodeKey] = append(viewsByNode[nodeKey], view)
+		}
+	}
+	if len(persists) > 0 {
+		if err := s.catalog.SaveQueryViews(ctx, persists); err != nil {
+			return err
+		}
+	}
+	if len(viewsByNode) == 0 {
+		return nil
+	}
+	if err := s.syncer.SyncViews(ctx, syncer.SyncGroup{ViewsByNode: viewsByNode}); err != nil {
+		observeDirtyViewSyncFailure(ctx, batch, err)
+		return err
+	}
+	return nil
+}
+
+func observeDirtyViewSyncFailure(
+	ctx context.Context,
+	batch map[qviews.ShardID]*pendingDirtyViewEvent,
+	err error,
+) {
+	type failedView struct {
+		key   qviews.QueryViewKey
+		state qviews.QueryViewState
+	}
+	failed := make(map[failedView]struct{})
+	for _, event := range batch {
+		for key, view := range event.syncs {
+			item := failedView{key: key.view, state: view.View.State()}
+			if _, ok := failed[item]; ok {
+				continue
+			}
+			failed[item] = struct{}{}
+			qvobserve.Observe(ctx, qvobserve.CoordSyncViewBatchFailedEvent{
+				View:  item.key,
+				State: item.state,
+				Err:   err,
+			})
+		}
+	}
+}
+
+// Flush waits until all committed events have been processed. Callers must not
+// leave an explicit Begin window open while waiting.
+func (s *DirtyViewFlushScheduler) Flush(ctx context.Context) error {
+	if s == nil {
+		return nil
+	}
+	for {
+		s.mu.Lock()
+		err := s.err
+		idle := len(s.pending) == 0 && len(s.inflight) == 0 && len(s.tasks) == 0 && s.queuedTasks == 0
+		notify := s.notify
+		s.mu.Unlock()
+		if err != nil || idle {
+			return err
+		}
+		select {
+		case <-notify:
+		case <-ctx.Done():
+			return ctx.Err()
+		}
+	}
+}
+
+func (s *DirtyViewFlushScheduler) Close() {
+	if s == nil {
+		return
+	}
+	s.mu.Lock()
+	if s.closed {
+		s.mu.Unlock()
+		return
+	}
+	s.closed = true
+	clear(s.pending)
+	clear(s.ready)
+	s.readyOps = 0
+	clear(s.held)
+	handles := make([]nodescheduler.TaskHandle, 0, len(s.tasks))
+	for _, handle := range s.tasks {
+		handles = append(handles, handle)
+	}
+	s.signalLocked()
+	s.mu.Unlock()
+
+	for _, handle := range handles {
+		handle.Cancel()
+	}
+	for _, handle := range handles {
+		_ = handle.Wait(context.Background())
+	}
+}
+
+func (s *DirtyViewFlushScheduler) signalLocked() {
+	select {
+	case s.notify <- struct{}{}:
+	default:
+	}
+}
+
+func (s *DirtyViewFlushScheduler) markReadyLocked(shardID qviews.ShardID) {
+	if _, ok := s.ready[shardID]; ok {
+		return
+	}
+	if _, ok := s.inflight[shardID]; ok {
+		return
+	}
+	if _, ok := s.held[shardID]; ok {
+		return
+	}
+	event := s.pending[shardID]
+	if event == nil {
+		return
+	}
+	s.ready[shardID] = struct{}{}
+	s.readyOps += event.operationCount()
+}
+
+func (s *DirtyViewFlushScheduler) removeReadyLocked(shardID qviews.ShardID) {
+	if _, ok := s.ready[shardID]; !ok {
+		return
+	}
+	delete(s.ready, shardID)
+	if event := s.pending[shardID]; event != nil {
+		s.readyOps -= event.operationCount()
+	}
+}
+
+var _ nodescheduler.Task = (*dirtyViewFlushTask)(nil)

--- a/internal/views/coord/coordview/dirty_view_flush_scheduler.go
+++ b/internal/views/coord/coordview/dirty_view_flush_scheduler.go
@@ -302,41 +302,28 @@ func (s *DirtyViewFlushScheduler) flushBatch(
 		if err := s.catalog.SaveQueryViews(ctx, persists); err != nil {
 			return err
 		}
-	}
-	if len(viewsByNode) == 0 {
-		return nil
-	}
-	if err := s.syncer.SyncViews(ctx, syncer.SyncGroup{ViewsByNode: viewsByNode}); err != nil {
-		observeDirtyViewSyncFailure(ctx, batch, err)
-		return err
-	}
-	return nil
-}
-
-func observeDirtyViewSyncFailure(
-	ctx context.Context,
-	batch map[qviews.ShardID]*pendingDirtyViewEvent,
-	err error,
-) {
-	type failedView struct {
-		key   qviews.QueryViewKey
-		state qviews.QueryViewState
-	}
-	failed := make(map[failedView]struct{})
-	for _, event := range batch {
-		for key, view := range event.syncs {
-			item := failedView{key: key.view, state: view.View.State()}
-			if _, ok := failed[item]; ok {
-				continue
-			}
-			failed[item] = struct{}{}
-			qvobserve.Observe(ctx, qvobserve.CoordSyncViewBatchFailedEvent{
-				View:  item.key,
-				State: item.state,
-				Err:   err,
+		for _, view := range persists {
+			qvobserve.Observe(ctx, qvobserve.CoordPersistViewEvent{
+				View:  queryViewKeyFromProto(view),
+				State: qviews.QueryViewState(view.GetMeta().GetState()),
 			})
 		}
 	}
+	if len(viewsByNode) > 0 {
+		if err := s.syncer.SyncViews(ctx, syncer.SyncGroup{ViewsByNode: viewsByNode}); err != nil {
+			return err
+		}
+	}
+	for _, views := range viewsByNode {
+		for _, view := range views {
+			qvobserve.Observe(ctx, qvobserve.CoordSyncViewAcceptedEvent{
+				View:  view.View.QueryViewKey(),
+				Node:  view.View.WorkNode(),
+				State: view.View.State(),
+			})
+		}
+	}
+	return nil
 }
 
 // Flush waits until all committed events have been processed. Callers must not

--- a/internal/views/coord/coordview/dirty_view_flush_scheduler_test.go
+++ b/internal/views/coord/coordview/dirty_view_flush_scheduler_test.go
@@ -1,0 +1,279 @@
+package coordview
+
+import (
+	"context"
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/milvus-io/milvus/internal/metastore/kv/queryview"
+	"github.com/milvus-io/milvus/internal/views/coord/coordview/syncer"
+	"github.com/milvus-io/milvus/internal/views/qviews"
+	"github.com/milvus-io/milvus/pkg/v3/proto/viewpb"
+	"github.com/milvus-io/milvus/pkg/v3/util/nodescheduler"
+)
+
+type capturedDirtyViewTaskScheduler struct {
+	mu    sync.Mutex
+	tasks []nodescheduler.Task
+}
+
+func (s *capturedDirtyViewTaskScheduler) Submit(task nodescheduler.Task) nodescheduler.TaskHandle {
+	s.mu.Lock()
+	s.tasks = append(s.tasks, task)
+	s.mu.Unlock()
+	return noopDirtyViewTaskHandle{}
+}
+
+func (s *capturedDirtyViewTaskScheduler) snapshot() []nodescheduler.Task {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	return append([]nodescheduler.Task(nil), s.tasks...)
+}
+
+type noopDirtyViewTaskHandle struct{}
+
+func (noopDirtyViewTaskHandle) Cancel()                    {}
+func (noopDirtyViewTaskHandle) Wait(context.Context) error { return nil }
+
+type capturedDirtyViewEventSubmitter struct {
+	mu     sync.Mutex
+	events []dirtyViewEvent
+}
+
+func (s *capturedDirtyViewEventSubmitter) Submit(event dirtyViewEvent) {
+	s.mu.Lock()
+	s.events = append(s.events, event)
+	s.mu.Unlock()
+}
+
+func (s *capturedDirtyViewEventSubmitter) snapshot() []dirtyViewEvent {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	return append([]dirtyViewEvent(nil), s.events...)
+}
+
+type concurrentSaveCatalog struct {
+	queryview.QueryViewCatalog
+	started chan struct{}
+	release chan struct{}
+}
+
+type blockingFlushCatalog struct {
+	*mockCatalog
+	started chan struct{}
+	release chan struct{}
+	once    sync.Once
+}
+
+func (c *blockingFlushCatalog) SaveQueryViews(ctx context.Context, views []*viewpb.QueryViewOfShard) error {
+	c.once.Do(func() { close(c.started) })
+	select {
+	case <-c.release:
+	case <-ctx.Done():
+		return ctx.Err()
+	}
+	return c.mockCatalog.SaveQueryViews(ctx, views)
+}
+
+func newTestDirtyViewFlushScheduler(
+	t *testing.T,
+	catalog queryview.QueryViewCatalog,
+	s syncer.ReliableSyncer,
+	maxTxnOps int,
+) *DirtyViewFlushScheduler {
+	t.Helper()
+	nodeScheduler := nodescheduler.New(1)
+	t.Cleanup(nodeScheduler.Close)
+	scheduler := newDirtyViewFlushScheduler(catalog, s, maxTxnOps, nodeScheduler)
+	t.Cleanup(scheduler.Close)
+	return scheduler
+}
+
+func (c *concurrentSaveCatalog) SaveQueryViews(ctx context.Context, _ []*viewpb.QueryViewOfShard) error {
+	c.started <- struct{}{}
+	select {
+	case <-c.release:
+		return nil
+	case <-ctx.Done():
+		return ctx.Err()
+	}
+}
+
+func dirtyPersistEvent(shardID qviews.ShardID, queryVersion int64) dirtyViewEvent {
+	view := buildTestViewWithVersion(1, 1, 1, queryVersion)
+	view.Meta.ReplicaId = shardID.ReplicaID
+	view.Meta.Vchannel = shardID.VChannel
+	return dirtyViewEvent{
+		shardID:  shardID,
+		persists: []*viewpb.QueryViewOfShard{view},
+	}
+}
+
+func testBuilderForShard(collectionID int64, shardID qviews.ShardID) *qviews.QueryViewAtCoordBuilder {
+	dataView := &viewpb.DataViewOfCollection{
+		CollectionId: collectionID,
+		Shards: []*viewpb.DataViewOfShard{
+			{Vchannel: shardID.VChannel},
+		},
+		DataVersion: &viewpb.DataVersion{StreamingVersion: 1, CompactVersion: 1},
+	}
+	builder := qviews.NewQueryViewAtCoordBuilder(shardID.ReplicaID, dataView, shardID.VChannel)
+	builder.SetAssignments(map[int64]map[int64][]int64{1: {10: {1001}}})
+	return builder
+}
+
+func TestDirtyViewFlushSchedulerBeginCommitBatchesAcrossShards(t *testing.T) {
+	catalog := newMockCatalog()
+	s := newMockSyncer()
+	nodeScheduler := &capturedDirtyViewTaskScheduler{}
+	scheduler := newDirtyViewFlushScheduler(catalog, s, 128, nodeScheduler)
+	t.Cleanup(scheduler.Close)
+
+	batch := scheduler.Begin()
+	scheduler.Submit(dirtyPersistEvent(qviews.ShardID{ReplicaID: 1, VChannel: "v1"}, 1))
+	scheduler.Submit(dirtyPersistEvent(qviews.ShardID{ReplicaID: 1, VChannel: "v2"}, 1))
+	assert.Empty(t, nodeScheduler.snapshot())
+
+	batch.Commit()
+	tasks := nodeScheduler.snapshot()
+	require.Len(t, tasks, 1)
+	require.NoError(t, tasks[0].Execute(context.Background()))
+	assert.Equal(t, 1, catalog.numSaveCalls())
+	assert.Len(t, catalog.saved, 2)
+}
+
+func TestDirtyViewFlushSchedulerNestedCommitDispatchesOnce(t *testing.T) {
+	nodeScheduler := &capturedDirtyViewTaskScheduler{}
+	scheduler := newDirtyViewFlushScheduler(newMockCatalog(), newMockSyncer(), 128, nodeScheduler)
+	t.Cleanup(scheduler.Close)
+
+	outer := scheduler.Begin()
+	inner := scheduler.Begin()
+	scheduler.Submit(dirtyPersistEvent(qviews.ShardID{ReplicaID: 1, VChannel: "v1"}, 1))
+	inner.Commit()
+	assert.Empty(t, nodeScheduler.snapshot())
+	outer.Commit()
+	assert.Len(t, nodeScheduler.snapshot(), 1)
+	outer.Commit()
+	assert.Len(t, nodeScheduler.snapshot(), 1)
+}
+
+func TestDirtyViewFlushSchedulerCommitSplitsLargeBatch(t *testing.T) {
+	nodeScheduler := &capturedDirtyViewTaskScheduler{}
+	scheduler := newDirtyViewFlushScheduler(newMockCatalog(), newMockSyncer(), 1, nodeScheduler)
+	t.Cleanup(scheduler.Close)
+
+	batch := scheduler.Begin()
+	for i := int64(1); i <= 3; i++ {
+		scheduler.Submit(dirtyPersistEvent(qviews.ShardID{ReplicaID: 1, VChannel: "v" + string(rune('0'+i))}, 1))
+	}
+	batch.Commit()
+	assert.Len(t, nodeScheduler.snapshot(), 3)
+}
+
+func TestDirtyViewFlushSchedulerRunsDifferentShardsConcurrently(t *testing.T) {
+	catalog := &concurrentSaveCatalog{
+		started: make(chan struct{}, 2),
+		release: make(chan struct{}),
+	}
+	nodeScheduler := nodescheduler.New(2)
+	t.Cleanup(nodeScheduler.Close)
+	scheduler := newDirtyViewFlushScheduler(catalog, newMockSyncer(), 1, nodeScheduler)
+	t.Cleanup(scheduler.Close)
+
+	scheduler.Submit(dirtyPersistEvent(qviews.ShardID{ReplicaID: 1, VChannel: "v1"}, 1))
+	scheduler.Submit(dirtyPersistEvent(qviews.ShardID{ReplicaID: 1, VChannel: "v2"}, 1))
+
+	for range 2 {
+		select {
+		case <-catalog.started:
+		case <-time.After(5 * time.Second):
+			t.Fatal("different shard batches did not execute concurrently")
+		}
+	}
+	close(catalog.release)
+	require.NoError(t, scheduler.Flush(context.Background()))
+}
+
+func TestDirtyViewFlushSchedulerSerializesSameShard(t *testing.T) {
+	catalog := &concurrentSaveCatalog{
+		started: make(chan struct{}, 2),
+		release: make(chan struct{}),
+	}
+	nodeScheduler := nodescheduler.New(2)
+	t.Cleanup(nodeScheduler.Close)
+	scheduler := newDirtyViewFlushScheduler(catalog, newMockSyncer(), 1, nodeScheduler)
+	t.Cleanup(scheduler.Close)
+	shardID := qviews.ShardID{ReplicaID: 1, VChannel: "v1"}
+
+	scheduler.Submit(dirtyPersistEvent(shardID, 1))
+	select {
+	case <-catalog.started:
+	case <-time.After(5 * time.Second):
+		t.Fatal("first shard batch did not start")
+	}
+
+	scheduler.Submit(dirtyPersistEvent(shardID, 2))
+	select {
+	case <-catalog.started:
+		t.Fatal("same shard executed concurrently")
+	case <-time.After(100 * time.Millisecond):
+	}
+
+	close(catalog.release)
+	select {
+	case <-catalog.started:
+	case <-time.After(5 * time.Second):
+		t.Fatal("successor batch for the same shard did not start")
+	}
+	require.NoError(t, scheduler.Flush(context.Background()))
+}
+
+func TestDirtyViewFlushSchedulerPersistsBeforeSync(t *testing.T) {
+	catalog := &blockingFlushCatalog{
+		mockCatalog: newMockCatalog(),
+		started:     make(chan struct{}),
+		release:     make(chan struct{}),
+	}
+	s := newMockSyncer()
+	nodeScheduler := nodescheduler.New(1)
+	t.Cleanup(nodeScheduler.Close)
+	scheduler := newDirtyViewFlushScheduler(catalog, s, 128, nodeScheduler)
+	t.Cleanup(scheduler.Close)
+
+	view := buildTestViewWithVersion(1, 1, 1, 1)
+	event := dirtyViewEvent{
+		shardID:  testShardID,
+		persists: []*viewpb.QueryViewOfShard{view},
+		syncs: []syncer.SyncView{{
+			View: qviews.NewFullQueryViewAtStreamingNode(view.Meta, view.StreamingNode, view.QueryNode),
+		}},
+	}
+	scheduler.Submit(event)
+
+	select {
+	case <-catalog.started:
+	case <-time.After(5 * time.Second):
+		t.Fatal("catalog persist did not start")
+	}
+	assert.Zero(t, s.numSyncCalls())
+	close(catalog.release)
+	require.NoError(t, scheduler.Flush(context.Background()))
+	assert.Equal(t, 1, s.numSyncCalls())
+}
+
+func TestShardViewManagerSubmitsOneShardScopedDirtyEvent(t *testing.T) {
+	submitter := &capturedDirtyViewEventSubmitter{}
+	manager := newShardViewManager(context.Background(), testShardID, submitter, nil)
+
+	require.NoError(t, manager.AddPreparing(context.Background(), testBuilder(1, 1, 1)))
+	events := submitter.snapshot()
+	require.Len(t, events, 1)
+	assert.Equal(t, testShardID, events[0].shardID)
+	assert.Len(t, events[0].persists, 1)
+	assert.Len(t, events[0].syncs, 2)
+}

--- a/internal/views/coord/coordview/dirty_view_flush_scheduler_test.go
+++ b/internal/views/coord/coordview/dirty_view_flush_scheduler_test.go
@@ -12,6 +12,7 @@ import (
 	"github.com/milvus-io/milvus/internal/metastore/kv/queryview"
 	"github.com/milvus-io/milvus/internal/views/coord/coordview/syncer"
 	"github.com/milvus-io/milvus/internal/views/qviews"
+	qvobserve "github.com/milvus-io/milvus/internal/views/qviews/observe"
 	"github.com/milvus-io/milvus/pkg/v3/proto/viewpb"
 	"github.com/milvus-io/milvus/pkg/v3/util/nodescheduler"
 )
@@ -44,6 +45,37 @@ type capturedDirtyViewEventSubmitter struct {
 	events []dirtyViewEvent
 }
 
+type recordedQueryViewEvents struct {
+	mu     sync.Mutex
+	events []qvobserve.Event
+}
+
+func (r *recordedQueryViewEvents) Observe(_ context.Context, event qvobserve.Event) {
+	r.mu.Lock()
+	r.events = append(r.events, event)
+	r.mu.Unlock()
+}
+
+func (r *recordedQueryViewEvents) ioEvents(shardID qviews.ShardID) (int, []qvobserve.CoordSyncViewAcceptedEvent) {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+	persisted := 0
+	accepted := make([]qvobserve.CoordSyncViewAcceptedEvent, 0)
+	for _, event := range r.events {
+		switch event := event.(type) {
+		case qvobserve.CoordPersistViewEvent:
+			if event.View.ShardID == shardID {
+				persisted++
+			}
+		case qvobserve.CoordSyncViewAcceptedEvent:
+			if event.View.ShardID == shardID {
+				accepted = append(accepted, event)
+			}
+		}
+	}
+	return persisted, accepted
+}
+
 func (s *capturedDirtyViewEventSubmitter) Submit(event dirtyViewEvent) {
 	s.mu.Lock()
 	s.events = append(s.events, event)
@@ -69,6 +101,13 @@ type blockingFlushCatalog struct {
 	once    sync.Once
 }
 
+type blockingFlushSyncer struct {
+	*mockSyncer
+	started chan struct{}
+	release chan struct{}
+	once    sync.Once
+}
+
 func (c *blockingFlushCatalog) SaveQueryViews(ctx context.Context, views []*viewpb.QueryViewOfShard) error {
 	c.once.Do(func() { close(c.started) })
 	select {
@@ -77,6 +116,16 @@ func (c *blockingFlushCatalog) SaveQueryViews(ctx context.Context, views []*view
 		return ctx.Err()
 	}
 	return c.mockCatalog.SaveQueryViews(ctx, views)
+}
+
+func (s *blockingFlushSyncer) SyncViews(ctx context.Context, group syncer.SyncGroup) error {
+	s.once.Do(func() { close(s.started) })
+	select {
+	case <-s.release:
+	case <-ctx.Done():
+		return ctx.Err()
+	}
+	return s.mockSyncer.SyncViews(ctx, group)
 }
 
 func newTestDirtyViewFlushScheduler(
@@ -264,6 +313,63 @@ func TestDirtyViewFlushSchedulerPersistsBeforeSync(t *testing.T) {
 	close(catalog.release)
 	require.NoError(t, scheduler.Flush(context.Background()))
 	assert.Equal(t, 1, s.numSyncCalls())
+}
+
+func TestDirtyViewFlushSchedulerObservesCompletedIO(t *testing.T) {
+	catalog := &blockingFlushCatalog{
+		mockCatalog: newMockCatalog(),
+		started:     make(chan struct{}),
+		release:     make(chan struct{}),
+	}
+	s := &blockingFlushSyncer{
+		mockSyncer: newMockSyncer(),
+		started:    make(chan struct{}),
+		release:    make(chan struct{}),
+	}
+	scheduler := newTestDirtyViewFlushScheduler(t, catalog, s, 128)
+	recorder := &recordedQueryViewEvents{}
+	qvobserve.Register(recorder)
+
+	shardID := qviews.ShardID{ReplicaID: 10001, VChannel: "io-event-boundary"}
+	event := dirtyPersistEvent(shardID, 1)
+	view := event.persists[0]
+	event.syncs = []syncer.SyncView{
+		{View: qviews.NewFullQueryViewAtStreamingNode(view.Meta, view.StreamingNode, view.QueryNode)},
+		{View: qviews.NewQueryViewAtQueryNode(view.Meta, view.QueryNode[0])},
+	}
+	scheduler.Submit(event)
+
+	select {
+	case <-catalog.started:
+	case <-time.After(5 * time.Second):
+		t.Fatal("catalog persist did not start")
+	}
+	persisted, accepted := recorder.ioEvents(shardID)
+	assert.Zero(t, persisted)
+	assert.Empty(t, accepted)
+
+	close(catalog.release)
+	select {
+	case <-s.started:
+	case <-time.After(5 * time.Second):
+		t.Fatal("sync enqueue did not start")
+	}
+	persisted, accepted = recorder.ioEvents(shardID)
+	assert.Equal(t, 1, persisted)
+	assert.Empty(t, accepted)
+
+	close(s.release)
+	require.NoError(t, scheduler.Flush(context.Background()))
+	persisted, accepted = recorder.ioEvents(shardID)
+	assert.Equal(t, 1, persisted)
+	require.Len(t, accepted, 2)
+	assert.Equal(t, 1, s.numSyncCalls())
+	nodes := map[qviews.WorkNodeKey]struct{}{}
+	for _, event := range accepted {
+		nodes[event.Node.Key()] = struct{}{}
+	}
+	assert.Contains(t, nodes, event.syncs[0].View.WorkNode().Key())
+	assert.Contains(t, nodes, event.syncs[1].View.WorkNode().Key())
 }
 
 func TestShardViewManagerSubmitsOneShardScopedDirtyEvent(t *testing.T) {

--- a/internal/views/coord/coordview/shard_stats_test.go
+++ b/internal/views/coord/coordview/shard_stats_test.go
@@ -12,7 +12,7 @@ import (
 )
 
 func TestStats_Empty(t *testing.T) {
-	mgr := newTestManager(newMockCatalog(), newMockSyncer())
+	mgr := newTestManager(t, newMockCatalog(), newMockSyncer())
 
 	stats := mgr.Stats()
 	require.NotNil(t, stats)
@@ -23,7 +23,7 @@ func TestStats_Empty(t *testing.T) {
 }
 
 func TestStats_PreparingOnly(t *testing.T) {
-	mgr := newTestManager(newMockCatalog(), newMockSyncer())
+	mgr := newTestManager(t, newMockCatalog(), newMockSyncer())
 
 	require.NoError(t, mgr.AddPreparing(context.Background(), testBuilder(1, 1, 2)))
 
@@ -47,7 +47,7 @@ func TestStats_PreparingOnly(t *testing.T) {
 }
 
 func TestStats_EmptyPreparingView(t *testing.T) {
-	mgr := newTestManager(newMockCatalog(), newMockSyncer())
+	mgr := newTestManager(t, newMockCatalog(), newMockSyncer())
 	b := testBuilder(1, 1, 1)
 	b.SetAssignments(map[int64]map[int64][]int64{})
 
@@ -63,7 +63,7 @@ func TestStats_EmptyPreparingView(t *testing.T) {
 
 func TestStats_UpOnly(t *testing.T) {
 	s := newMockSyncer()
-	mgr := newTestManager(newMockCatalog(), s)
+	mgr := newTestManager(t, newMockCatalog(), s)
 
 	// Drive v1 to Up.
 	ver1 := testVersion(1, 1, 1)
@@ -94,7 +94,7 @@ func TestStats_UpOnly(t *testing.T) {
 
 func TestStats_UpAndPreparing(t *testing.T) {
 	s := newMockSyncer()
-	mgr := newTestManager(newMockCatalog(), s)
+	mgr := newTestManager(t, newMockCatalog(), s)
 
 	// Drive v1 to Up.
 	ver1 := testVersion(1, 1, 1)
@@ -137,7 +137,7 @@ func TestStats_ReadyViewStillAppearsAsPending(t *testing.T) {
 	// A view in Ready state is still considered "not Up" for Stats purposes;
 	// its placements should show Up=false.
 	s := newMockSyncer()
-	mgr := newTestManager(newMockCatalog(), s)
+	mgr := newTestManager(t, newMockCatalog(), s)
 
 	ver := testVersion(1, 1, 1)
 	require.NoError(t, mgr.AddPreparing(context.Background(), testBuilder(1, 1, 1)))
@@ -162,7 +162,7 @@ func TestStats_ReadyViewStillAppearsAsPending(t *testing.T) {
 
 func TestStats_PartialReadySegments(t *testing.T) {
 	s := newMockSyncer()
-	mgr := newTestManager(newMockCatalog(), s)
+	mgr := newTestManager(t, newMockCatalog(), s)
 
 	b := testBuilder(1, 1, 1)
 	b.SetAssignments(map[int64]map[int64][]int64{
@@ -192,7 +192,7 @@ func TestStats_PartialReadySegments(t *testing.T) {
 
 func TestStats_UnrecoverableIncludedByNode(t *testing.T) {
 	s := newMockSyncer()
-	mgr := newTestManager(newMockCatalog(), s)
+	mgr := newTestManager(t, newMockCatalog(), s)
 
 	ver := testVersion(1, 1, 1)
 	require.NoError(t, mgr.AddPreparing(context.Background(), testBuilder(1, 1, 1)))
@@ -216,7 +216,7 @@ func TestStats_UnrecoverableIncludedByNode(t *testing.T) {
 
 func TestStats_UnrecoverableSegmentWithoutReady(t *testing.T) {
 	s := newMockSyncer()
-	mgr := newTestManager(newMockCatalog(), s)
+	mgr := newTestManager(t, newMockCatalog(), s)
 
 	ver := testVersion(1, 1, 1)
 	require.NoError(t, mgr.AddPreparing(context.Background(), testBuilder(1, 1, 1)))
@@ -269,7 +269,7 @@ func TestStats_DownViewMappedToReady(t *testing.T) {
 	// QNs do not receive Down, so v1 placements remain loaded and are exposed
 	// as Ready-level reusable placements.
 	s := newMockSyncer()
-	mgr := newTestManager(newMockCatalog(), s)
+	mgr := newTestManager(t, newMockCatalog(), s)
 
 	// Drive v1 to Up (node 1, seg 1001).
 	ver1 := testVersion(1, 1, 1)

--- a/internal/views/coord/coordview/shard_view_manager.go
+++ b/internal/views/coord/coordview/shard_view_manager.go
@@ -5,11 +5,9 @@ import (
 	"sort"
 	"sync"
 
-	"github.com/milvus-io/milvus/internal/metastore/kv/queryview"
 	"github.com/milvus-io/milvus/internal/views/coord/coordview/syncer"
 	"github.com/milvus-io/milvus/internal/views/qviews"
 	qvobserve "github.com/milvus-io/milvus/internal/views/qviews/observe"
-	"github.com/milvus-io/milvus/pkg/v3/mlog"
 	"github.com/milvus-io/milvus/pkg/v3/proto/viewpb"
 )
 
@@ -17,8 +15,8 @@ import (
 // within a single replica on the Coord side.
 //
 // It orchestrates CoordQueryViewStateMachine instances and their cross-view
-// interactions, calling Catalog for ETCD persistence and ReliableSyncer for
-// node sync. Node responses are delivered via callbacks registered with the syncer.
+// interactions. After each operation it emits one immutable shard-scoped dirty
+// event; DirtyViewFlushScheduler owns all cross-shard batching and I/O.
 //
 // Invariants (maintained by all methods):
 //   - At most one view in Preparing or Ready state (tracked by preparingView).
@@ -26,12 +24,11 @@ import (
 //
 // Thread-safety: All methods are thread-safe.
 type ShardViewManager struct {
-	ctx     context.Context // lifecycle context for Catalog calls within callbacks
-	mu      sync.Mutex
-	shardID qviews.ShardID
-	catalog queryview.QueryViewCatalog
-	syncer  syncer.ReliableSyncer
-	observe func(qviews.ShardID, *ShardStats)
+	ctx            context.Context // lifecycle context used by callbacks and event observation
+	mu             sync.Mutex
+	shardID        qviews.ShardID
+	eventSubmitter dirtyViewEventSubmitter
+	observe        func(qviews.ShardID, *ShardStats)
 
 	// All active views keyed by version for O(1) lookup.
 	views map[qviews.QueryViewVersion]*CoordQueryViewStateMachine
@@ -42,40 +39,38 @@ type ShardViewManager struct {
 	upView        *CoordQueryViewStateMachine // Up state; nil if none
 
 	// Accumulates persist and sync operations within a single lock-hold scope.
-	// All persists are flushed in a single SaveQueryViews call, then all syncs
-	// are flushed in a single SyncViews call. This ensures atomicity at the
-	// persistence layer and reduces the number of I/O calls.
+	// The accumulated effects are moved into one immutable dirtyViewEvent before
+	// the manager releases the lock.
 	// Must only be accessed under m.mu.
 	pendingPersists []*viewpb.QueryViewOfShard
 	pendingSyncs    []syncEntry
 }
 
-// syncEntry pairs a state machine with its per-node views for deferred sync dispatch.
+// syncEntry pairs a state machine with its per-node views for deferred event submission.
 type syncEntry struct {
 	sm    *CoordQueryViewStateMachine
 	views []qviews.QueryViewAtWorkNode
 }
 
-// NewShardViewManager creates a new ShardViewManager for the given shard.
+// newShardViewManager creates a new ShardViewManager for the given shard.
 //
-// ctx is the lifecycle context used for Catalog calls within callbacks.
+// ctx is the lifecycle context used by callbacks and event observation.
 // recoveredViews are views loaded from ETCD during crash recovery.
 // Unrecoverable views remain Unrecoverable after construction, waiting for
 // AddPreparing or RequestRelease to advance them to Dropping.
-// Active views in other states are pushed to their target nodes via syncer.
-func NewShardViewManager(
+// Active views in other states are emitted through eventSubmitter for the
+// DirtyViewFlushScheduler to persist and push to their target nodes.
+func newShardViewManager(
 	ctx context.Context,
 	shardID qviews.ShardID,
-	catalog queryview.QueryViewCatalog,
-	s syncer.ReliableSyncer,
+	eventSubmitter dirtyViewEventSubmitter,
 	recoveredViews []*viewpb.QueryViewOfShard,
 ) *ShardViewManager {
 	m := &ShardViewManager{
-		ctx:     ctx,
-		shardID: shardID,
-		catalog: catalog,
-		syncer:  s,
-		views:   make(map[qviews.QueryViewVersion]*CoordQueryViewStateMachine, len(recoveredViews)),
+		ctx:            ctx,
+		shardID:        shardID,
+		eventSubmitter: eventSubmitter,
+		views:          make(map[qviews.QueryViewVersion]*CoordQueryViewStateMachine, len(recoveredViews)),
 	}
 
 	// Recover state machines from persisted views.
@@ -98,7 +93,7 @@ func NewShardViewManager(
 	for _, sm := range recovered {
 		m.processStateMachine(sm)
 	}
-	m.flush()
+	m.submitDirtyEvent(m.consumeDirtyEventLocked())
 	return m
 }
 
@@ -229,12 +224,12 @@ func segmentSet(segments []int64) map[int64]bool {
 // Validation: The new DataVersion must not be lower than any existing view's DataVersion.
 func (m *ShardViewManager) AddPreparing(ctx context.Context, builder *qviews.QueryViewAtCoordBuilder) error {
 	m.mu.Lock()
-	defer m.mu.Unlock()
 
 	newDV := builder.DataVersion()
 
 	// Validate no DataVersion rollback.
 	if err := m.validateDataVersionLocked(newDV); err != nil {
+		m.mu.Unlock()
 		return err
 	}
 
@@ -275,12 +270,14 @@ func (m *ShardViewManager) AddPreparing(ctx context.Context, builder *qviews.Que
 		State:        sm.State(),
 	})
 
-	// Process: persist write-ahead + collect sync.
+	// Process: collect persist and sync effects.
 	m.processStateMachine(sm)
 
-	// Flush all accumulated I/O.
-	m.flush()
+	// Move all accumulated effects into one shard-scoped event.
+	event := m.consumeDirtyEventLocked()
 	m.publishStatsLocked()
+	m.mu.Unlock()
+	m.submitDirtyEvent(event)
 	return nil
 }
 
@@ -293,7 +290,6 @@ func (m *ShardViewManager) AddPreparing(ctx context.Context, builder *qviews.Que
 // The actual cleanup completes asynchronously through callbacks.
 func (m *ShardViewManager) RequestRelease(ctx context.Context) error {
 	m.mu.Lock()
-	defer m.mu.Unlock()
 
 	if m.preparingView != nil {
 		key := m.keyForStateMachine(m.preparingView)
@@ -330,36 +326,40 @@ func (m *ShardViewManager) RequestRelease(ctx context.Context) error {
 	// Advance all Unrecoverable views (preempted or naturally failed) to Dropping.
 	m.advanceUnrecoverableToDropping()
 
-	m.flush()
+	event := m.consumeDirtyEventLocked()
 	m.publishStatsLocked()
+	m.mu.Unlock()
+	m.submitDirtyEvent(event)
 	return nil
 }
 
 // processStateMachine consumes pending I/O from a state machine and handles
 // cascading effects (Up-then-Down, Unrecoverable→Dropping, Dropped removal).
-// I/O is collected into pendingPersists/pendingSyncs for deferred execution.
+// I/O is collected into pendingPersists/pendingSyncs for deferred event
+// submission.
 //
 // Also maintains preparingView/upView pointers on state transitions.
 //
 // Must be called under m.mu.
 func (m *ShardViewManager) processStateMachine(sm *CoordQueryViewStateMachine) {
 	for {
-		// 1. ConsumePersist → collect into pending batch.
-		if persist := sm.ConsumePersist(); persist != nil {
+		// 1. ConsumeFlush persist effect → collect into pending batch.
+		flush := sm.ConsumeFlush()
+		if flush.Persist != nil {
 			qvobserve.Observe(m.ctx, qvobserve.CoordPersistViewEvent{
 				View:  m.keyForStateMachine(sm),
-				State: qviews.QueryViewState(persist.GetMeta().GetState()),
+				State: qviews.QueryViewState(flush.Persist.GetMeta().GetState()),
 			})
-			m.pendingPersists = append(m.pendingPersists, persist)
+			m.pendingPersists = append(m.pendingPersists, flush.Persist)
 		}
 
-		// 2. ConsumeSync → collect into pending batch.
-		if views := sm.ConsumeSync(); len(views) > 0 {
+		// 2. ConsumeFlush sync effects → collect into pending batch.
+		if len(flush.Sync) > 0 {
 			qvobserve.Observe(m.ctx, qvobserve.CoordSyncViewBatchEvent{
 				View:  m.keyForStateMachine(sm),
-				State: views[0].State(),
+				State: flush.Sync[0].State(),
 			})
-			m.pendingSyncs = append(m.pendingSyncs, syncEntry{sm: sm, views: views})
+			m.pendingSyncs = append(m.pendingSyncs, syncEntry{sm: sm, views: flush.Sync})
 		}
 
 		// 3. Handle cascading effects based on current state.
@@ -453,73 +453,31 @@ func (m *ShardViewManager) downOlderUpView(newUp *CoordQueryViewStateMachine) {
 	}
 }
 
-// flush executes all accumulated I/O: first persist all, then sync all.
-//
-// Both Catalog (ETCD) and ReliableSyncer provide reliable delivery:
-// they only return errors when the Coordinator is shutting down (context
-// canceled). In that case the Coordinator will perform a full recovery
-// on next startup, reconstructing all state machines from ETCD, so
-// transient in-memory / persisted inconsistencies are self-healing.
-//
-// Must be called under m.mu.
-func (m *ShardViewManager) flush() {
-	// 1. Persist all in a single call.
-	if len(m.pendingPersists) > 0 {
-		if err := m.catalog.SaveQueryViews(m.ctx, m.pendingPersists); err != nil {
-			// SaveQueryViews only fails when the Coordinator is shutting down
-			// (ctx canceled). On next startup a full recovery from ETCD will
-			// reconstruct all state machines, so this is safe to log-and-skip.
-			mlog.Warn(m.ctx, "failed to persist query views",
-				mlog.String("shardID", m.shardID.String()),
-				mlog.Int("count", len(m.pendingPersists)),
-				mlog.Err(err),
-			)
-		}
-		m.pendingPersists = m.pendingPersists[:0]
+// consumeDirtyEventLocked moves the current operation's accumulated effects
+// into an immutable shard event. Cross-shard merging and batch execution belong
+// to DirtyViewFlushScheduler.
+func (m *ShardViewManager) consumeDirtyEventLocked() dirtyViewEvent {
+	event := dirtyViewEvent{
+		shardID:  m.shardID,
+		persists: m.pendingPersists,
 	}
-
-	// 2. Sync all in a single call.
-	if len(m.pendingSyncs) > 0 {
-		viewsByNode := make(map[qviews.WorkNodeKey][]syncer.SyncView)
-		for _, entry := range m.pendingSyncs {
-			version := entry.sm.Version()
-			for _, view := range entry.views {
-				node := view.WorkNode()
-				key := node.Key()
-				var onQueryNodeLost func(qviews.QueryNode)
-				if _, ok := node.(qviews.QueryNode); ok {
-					onQueryNodeLost = m.makeOnQueryNodeLost(version)
-				}
-				viewsByNode[key] = append(viewsByNode[key], syncer.SyncView{
-					View:            view,
-					OnSyncResponse:  m.makeOnSyncResponse(version, view),
-					OnQueryNodeLost: onQueryNodeLost,
-				})
+	for _, entry := range m.pendingSyncs {
+		version := entry.sm.Version()
+		for _, view := range entry.views {
+			var onQueryNodeLost func(qviews.QueryNode)
+			if _, ok := view.WorkNode().(qviews.QueryNode); ok {
+				onQueryNodeLost = m.makeOnQueryNodeLost(version)
 			}
+			event.syncs = append(event.syncs, syncer.SyncView{
+				View:            view,
+				OnSyncResponse:  m.makeOnSyncResponse(version, view),
+				OnQueryNodeLost: onQueryNodeLost,
+			})
 		}
-		if len(viewsByNode) > 0 {
-			if err := m.syncer.SyncViews(m.ctx, syncer.SyncGroup{ViewsByNode: viewsByNode}); err != nil {
-				for _, entry := range m.pendingSyncs {
-					if len(entry.views) == 0 {
-						continue
-					}
-					qvobserve.Observe(m.ctx, qvobserve.CoordSyncViewBatchFailedEvent{
-						View:  m.keyForStateMachine(entry.sm),
-						State: entry.views[0].State(),
-						Err:   err,
-					})
-				}
-				// SyncViews only fails when the Coordinator is shutting down
-				// (ctx canceled or syncer closed). On next startup a full
-				// recovery will re-push all outstanding syncs.
-				mlog.Warn(m.ctx, "failed to sync views to nodes",
-					mlog.String("shardID", m.shardID.String()),
-					mlog.Err(err),
-				)
-			}
-		}
-		m.pendingSyncs = m.pendingSyncs[:0]
 	}
+	m.pendingPersists = nil
+	m.pendingSyncs = nil
+	return event
 }
 
 // makeOnSyncResponse creates a callback that processes node responses for a view sync.
@@ -529,10 +487,10 @@ func (m *ShardViewManager) flush() {
 func (m *ShardViewManager) makeOnSyncResponse(version qviews.QueryViewVersion, target qviews.QueryViewAtWorkNode) func(resp qviews.QueryViewAtWorkNode) bool {
 	return func(resp qviews.QueryViewAtWorkNode) bool {
 		m.mu.Lock()
-		defer m.mu.Unlock()
 
 		sm, ok := m.views[version]
 		if !ok {
+			m.mu.Unlock()
 			return true // view already removed, stop tracking
 		}
 
@@ -550,11 +508,14 @@ func (m *ShardViewManager) makeOnSyncResponse(version qviews.QueryViewVersion, t
 			ResourceReadyPercent: resourceReadyPercent(resp),
 		})
 		m.processStateMachine(sm)
-		m.flush()
+		event := m.consumeDirtyEventLocked()
 		m.publishStatsLocked()
 
 		_, exists := m.views[version]
-		return !exists || syncResponseCompletesTarget(target.State(), resp.State())
+		completed := !exists || syncResponseCompletesTarget(target.State(), resp.State())
+		m.mu.Unlock()
+		m.submitDirtyEvent(event)
+		return completed
 	}
 }
 
@@ -580,10 +541,10 @@ func syncResponseCompletesTarget(target, reported qviews.QueryViewState) bool {
 func (m *ShardViewManager) makeOnQueryNodeLost(version qviews.QueryViewVersion) func(qviews.QueryNode) {
 	return func(node qviews.QueryNode) {
 		m.mu.Lock()
-		defer m.mu.Unlock()
 
 		sm, ok := m.views[version]
 		if !ok {
+			m.mu.Unlock()
 			return // view already removed
 		}
 
@@ -603,8 +564,16 @@ func (m *ShardViewManager) makeOnQueryNodeLost(version qviews.QueryViewVersion) 
 			Node: node,
 		})
 		m.processStateMachine(sm)
-		m.flush()
+		event := m.consumeDirtyEventLocked()
 		m.publishStatsLocked()
+		m.mu.Unlock()
+		m.submitDirtyEvent(event)
+	}
+}
+
+func (m *ShardViewManager) submitDirtyEvent(event dirtyViewEvent) {
+	if !event.empty() {
+		m.eventSubmitter.Submit(event)
 	}
 }
 

--- a/internal/views/coord/coordview/shard_view_manager.go
+++ b/internal/views/coord/coordview/shard_view_manager.go
@@ -346,19 +346,11 @@ func (m *ShardViewManager) processStateMachine(sm *CoordQueryViewStateMachine) {
 		// 1. ConsumeFlush persist effect → collect into pending batch.
 		flush := sm.ConsumeFlush()
 		if flush.Persist != nil {
-			qvobserve.Observe(m.ctx, qvobserve.CoordPersistViewEvent{
-				View:  m.keyForStateMachine(sm),
-				State: qviews.QueryViewState(flush.Persist.GetMeta().GetState()),
-			})
 			m.pendingPersists = append(m.pendingPersists, flush.Persist)
 		}
 
 		// 2. ConsumeFlush sync effects → collect into pending batch.
 		if len(flush.Sync) > 0 {
-			qvobserve.Observe(m.ctx, qvobserve.CoordSyncViewBatchEvent{
-				View:  m.keyForStateMachine(sm),
-				State: flush.Sync[0].State(),
-			})
 			m.pendingSyncs = append(m.pendingSyncs, syncEntry{sm: sm, views: flush.Sync})
 		}
 

--- a/internal/views/coord/coordview/shard_view_manager_test.go
+++ b/internal/views/coord/coordview/shard_view_manager_test.go
@@ -80,6 +80,7 @@ type mockSyncer struct {
 	mu          sync.Mutex
 	syncedViews []syncer.SyncView  // accumulated across all calls
 	syncCalls   []syncer.SyncGroup // per-call groups
+	waitFlush   func()
 }
 
 func newMockSyncer() *mockSyncer {
@@ -101,27 +102,45 @@ func (s *mockSyncer) Close() error { return nil }
 // findOnSyncResponse returns the latest OnSyncResponse callback for the given work node and version.
 func (s *mockSyncer) findOnSyncResponse(node qviews.WorkNode, version qviews.QueryViewVersion) func(resp qviews.QueryViewAtWorkNode) bool {
 	s.mu.Lock()
-	defer s.mu.Unlock()
 	// Search in reverse to find the latest.
 	for i := len(s.syncedViews) - 1; i >= 0; i-- {
 		sv := s.syncedViews[i]
 		if sv.View.Version().EQ(version) && sv.View.WorkNode().Key() == node.Key() {
-			return sv.OnSyncResponse
+			callback, waitFlush := sv.OnSyncResponse, s.waitFlush
+			s.mu.Unlock()
+			return func(resp qviews.QueryViewAtWorkNode) bool {
+				done := callback(resp)
+				if waitFlush != nil {
+					waitFlush()
+				}
+				return done
+			}
 		}
 	}
+	s.mu.Unlock()
 	return nil
 }
 
 // findOnQueryNodeLost returns the latest OnQueryNodeLost callback for the given node and version.
 func (s *mockSyncer) findOnQueryNodeLost(node qviews.WorkNode, version qviews.QueryViewVersion) func(qviews.QueryNode) {
 	s.mu.Lock()
-	defer s.mu.Unlock()
 	for i := len(s.syncedViews) - 1; i >= 0; i-- {
 		sv := s.syncedViews[i]
 		if sv.View.Version().EQ(version) && sv.View.WorkNode().Key() == node.Key() {
-			return sv.OnQueryNodeLost
+			callback, waitFlush := sv.OnQueryNodeLost, s.waitFlush
+			s.mu.Unlock()
+			if callback == nil {
+				return nil
+			}
+			return func(node qviews.QueryNode) {
+				callback(node)
+				if waitFlush != nil {
+					waitFlush()
+				}
+			}
 		}
 	}
+	s.mu.Unlock()
 	return nil
 }
 
@@ -194,14 +213,46 @@ func buildTestViewWithVersion(numQN int, sv, cv, qv int64) *viewpb.QueryViewOfSh
 	return view
 }
 
-func newTestManager(catalog *mockCatalog, s *mockSyncer, recovered ...*viewpb.QueryViewOfShard) *ShardViewManager {
-	return NewShardViewManager(
-		context.Background(),
-		testShardID,
-		catalog,
-		s,
-		recovered,
-	)
+type testShardViewManager struct {
+	*ShardViewManager
+	t         *testing.T
+	scheduler *DirtyViewFlushScheduler
+}
+
+func (m *testShardViewManager) AddPreparing(ctx context.Context, builder *qviews.QueryViewAtCoordBuilder) error {
+	err := m.ShardViewManager.AddPreparing(ctx, builder)
+	if err == nil {
+		m.waitFlush()
+	}
+	return err
+}
+
+func (m *testShardViewManager) RequestRelease(ctx context.Context) error {
+	err := m.ShardViewManager.RequestRelease(ctx)
+	if err == nil {
+		m.waitFlush()
+	}
+	return err
+}
+
+func (m *testShardViewManager) waitFlush() {
+	m.t.Helper()
+	require.NoError(m.t, m.scheduler.Flush(context.Background()))
+}
+
+func newTestManager(t *testing.T, catalog *mockCatalog, s *mockSyncer, recovered ...*viewpb.QueryViewOfShard) *testShardViewManager {
+	t.Helper()
+	scheduler := newTestDirtyViewFlushScheduler(t, catalog, s, 128)
+	manager := &testShardViewManager{
+		ShardViewManager: newShardViewManager(context.Background(), testShardID, scheduler, recovered),
+		t:                t,
+		scheduler:        scheduler,
+	}
+	s.mu.Lock()
+	s.waitFlush = manager.waitFlush
+	s.mu.Unlock()
+	manager.waitFlush()
+	return manager
 }
 
 // simulateNodeResponse simulates a node responding by finding and invoking the OnSyncResponse callback.
@@ -240,7 +291,7 @@ func simulateNodeResponse(t *testing.T, s *mockSyncer, node qviews.WorkNode, ver
 func TestAddPreparing_Success(t *testing.T) {
 	catalog := newMockCatalog()
 	s := newMockSyncer()
-	mgr := newTestManager(catalog, s)
+	mgr := newTestManager(t, catalog, s)
 
 	b := testBuilder(1, 1, 2)
 	err := mgr.AddPreparing(context.Background(), b)
@@ -268,7 +319,7 @@ func TestAddPreparing_Success(t *testing.T) {
 func TestAddPreparing_SameDataVersionIncrementsQueryVersion(t *testing.T) {
 	catalog := newMockCatalog()
 	s := newMockSyncer()
-	mgr := newTestManager(catalog, s)
+	mgr := newTestManager(t, catalog, s)
 
 	// Add first view with DV(1,1) → QV=1.
 	b1 := testBuilder(1, 1, 1)
@@ -298,7 +349,7 @@ func TestAddPreparing_SameDataVersionIncrementsQueryVersion(t *testing.T) {
 func TestAddPreparing_PreemptsPreparing(t *testing.T) {
 	catalog := newMockCatalog()
 	s := newMockSyncer()
-	mgr := newTestManager(catalog, s)
+	mgr := newTestManager(t, catalog, s)
 
 	// Add v1 Preparing.
 	b1 := testBuilder(1, 1, 1)
@@ -314,9 +365,10 @@ func TestAddPreparing_PreemptsPreparing(t *testing.T) {
 	// Unrecoverable(v1) + Preparing(v2).
 	require.Equal(t, 1, catalog.numSaveCalls())
 	states := catalog.savedStates()
-	require.Len(t, states, 2)
-	assert.Equal(t, viewpb.QueryViewState_QueryViewStateUnrecoverable, states[0]) // v1 preempted
-	assert.Equal(t, viewpb.QueryViewState_QueryViewStatePreparing, states[1])     // v2 new
+	assert.ElementsMatch(t, []viewpb.QueryViewState{
+		viewpb.QueryViewState_QueryViewStateUnrecoverable,
+		viewpb.QueryViewState_QueryViewStatePreparing,
+	}, states)
 
 	// Should have synced in ONE SyncViews call.
 	assert.Equal(t, 1, s.numSyncCalls())
@@ -330,7 +382,7 @@ func TestAddPreparing_PreemptsPreparing(t *testing.T) {
 func TestAddPreparing_PreemptsReady(t *testing.T) {
 	catalog := newMockCatalog()
 	s := newMockSyncer()
-	mgr := newTestManager(catalog, s)
+	mgr := newTestManager(t, catalog, s)
 
 	// Add and drive v1 to Ready.
 	b1 := testBuilder(1, 1, 1)
@@ -364,7 +416,7 @@ func TestAddPreparing_PreemptsReady(t *testing.T) {
 func TestAddPreparing_DataVersionRollbackRejected(t *testing.T) {
 	catalog := newMockCatalog()
 	s := newMockSyncer()
-	mgr := newTestManager(catalog, s)
+	mgr := newTestManager(t, catalog, s)
 
 	// Add v1 with DV(2,1).
 	b1 := testBuilder(2, 1, 1)
@@ -379,7 +431,7 @@ func TestAddPreparing_DataVersionRollbackRejected(t *testing.T) {
 func TestAddPreparing_BatchPersistAtomicity(t *testing.T) {
 	catalog := newMockCatalog()
 	s := newMockSyncer()
-	mgr := newTestManager(catalog, s)
+	mgr := newTestManager(t, catalog, s)
 
 	// Add v1 Preparing.
 	b1 := testBuilder(1, 1, 1)
@@ -402,7 +454,7 @@ func TestAddPreparing_BatchPersistAtomicity(t *testing.T) {
 func TestNormalFlow_PrepareToUpCascade(t *testing.T) {
 	catalog := newMockCatalog()
 	s := newMockSyncer()
-	mgr := newTestManager(catalog, s)
+	mgr := newTestManager(t, catalog, s)
 
 	// Add v1 and drive it to Up.
 	b1 := testBuilder(1, 1, 1)
@@ -437,9 +489,10 @@ func TestNormalFlow_PrepareToUpCascade(t *testing.T) {
 	// After v2 reaches Up, v1 should be cascaded to Down.
 	// Persisted: v2 Up + v1 Down.
 	states := catalog.savedStates()
-	require.Len(t, states, 2)
-	assert.Equal(t, viewpb.QueryViewState_QueryViewStateUp, states[0])   // v2 Up
-	assert.Equal(t, viewpb.QueryViewState_QueryViewStateDown, states[1]) // v1 Down
+	assert.ElementsMatch(t, []viewpb.QueryViewState{
+		viewpb.QueryViewState_QueryViewStateUp,
+		viewpb.QueryViewState_QueryViewStateDown,
+	}, states)
 
 	// SN should have received Down push for v1.
 	cb := s.findOnSyncResponse(testSN, ver1)
@@ -449,7 +502,7 @@ func TestNormalFlow_PrepareToUpCascade(t *testing.T) {
 func TestSyncResponseCompletesCurrentNodeSync(t *testing.T) {
 	catalog := newMockCatalog()
 	s := newMockSyncer()
-	mgr := newTestManager(catalog, s)
+	mgr := newTestManager(t, catalog, s)
 
 	b := testBuilder(1, 1, 1)
 	ver1 := testVersion(1, 1, 1)
@@ -483,7 +536,7 @@ func TestSyncResponseCompletesCurrentNodeSync(t *testing.T) {
 
 func TestStreamingNodeSyncHasNoQueryNodeLostCallback(t *testing.T) {
 	s := newMockSyncer()
-	mgr := newTestManager(newMockCatalog(), s)
+	mgr := newTestManager(t, newMockCatalog(), s)
 
 	ver1 := testVersion(1, 1, 1)
 	require.NoError(t, mgr.AddPreparing(context.Background(), testBuilder(1, 1, 1)))
@@ -499,7 +552,7 @@ func TestStreamingNodeSyncHasNoQueryNodeLostCallback(t *testing.T) {
 func TestFullLifecycle_DownToDropped(t *testing.T) {
 	catalog := newMockCatalog()
 	s := newMockSyncer()
-	mgr := newTestManager(catalog, s)
+	mgr := newTestManager(t, catalog, s)
 
 	// Add and drive v1 to Up.
 	b1 := testBuilder(1, 1, 1)
@@ -550,7 +603,7 @@ func TestFullLifecycle_DownToDropped(t *testing.T) {
 func TestQueryNodeLost_TriggersUnrecoverable(t *testing.T) {
 	catalog := newMockCatalog()
 	s := newMockSyncer()
-	mgr := newTestManager(catalog, s)
+	mgr := newTestManager(t, catalog, s)
 
 	b := testBuilder(1, 1, 1)
 	ver1 := testVersion(1, 1, 1)
@@ -603,7 +656,7 @@ func TestQueryNodeLost_TriggersUnrecoverable(t *testing.T) {
 func TestQueryNodeLost_DroppingCleanupCompletes(t *testing.T) {
 	catalog := newMockCatalog()
 	s := newMockSyncer()
-	mgr := newTestManager(catalog, s)
+	mgr := newTestManager(t, catalog, s)
 
 	b := testBuilder(1, 1, 2)
 	ver1 := testVersion(1, 1, 1)
@@ -650,7 +703,7 @@ func TestQueryNodeLost_DroppingCleanupCompletes(t *testing.T) {
 func TestRequestRelease_UpView(t *testing.T) {
 	catalog := newMockCatalog()
 	s := newMockSyncer()
-	mgr := newTestManager(catalog, s)
+	mgr := newTestManager(t, catalog, s)
 
 	// Drive v1 to Up.
 	b := testBuilder(1, 1, 1)
@@ -679,7 +732,7 @@ func TestRequestRelease_UpView(t *testing.T) {
 func TestRequestRelease_PreparingView(t *testing.T) {
 	catalog := newMockCatalog()
 	s := newMockSyncer()
-	mgr := newTestManager(catalog, s)
+	mgr := newTestManager(t, catalog, s)
 
 	b := testBuilder(1, 1, 1)
 	require.NoError(t, mgr.AddPreparing(context.Background(), b))
@@ -708,7 +761,7 @@ func TestRequestRelease_PreparingView(t *testing.T) {
 func TestRequestRelease_MixedViews(t *testing.T) {
 	catalog := newMockCatalog()
 	s := newMockSyncer()
-	mgr := newTestManager(catalog, s)
+	mgr := newTestManager(t, catalog, s)
 
 	// v1: drive to Up.
 	b1 := testBuilder(1, 1, 1)
@@ -746,7 +799,7 @@ func TestRecovery_PreparingView(t *testing.T) {
 	// Recover a Preparing view.
 	v1 := buildTestViewWithVersion(1, 1, 1, 1)
 	v1.Meta.State = viewpb.QueryViewState_QueryViewStatePreparing
-	mgr := newTestManager(catalog, s, v1)
+	mgr := newTestManager(t, catalog, s, v1)
 
 	// Should re-push Preparing to all nodes.
 	assert.Equal(t, 2, s.syncViewCount()) // SN + QN1
@@ -766,7 +819,7 @@ func TestRecovery_UnrecoverableView(t *testing.T) {
 	// Recover an Unrecoverable view.
 	v1 := buildTestViewWithVersion(1, 1, 1, 1)
 	v1.Meta.State = viewpb.QueryViewState_QueryViewStateUnrecoverable
-	mgr := newTestManager(catalog, s, v1)
+	mgr := newTestManager(t, catalog, s, v1)
 
 	// Stays Unrecoverable, waits for AddPreparing to advance to Dropping.
 	ver1 := testVersion(1, 1, 1)
@@ -786,7 +839,7 @@ func TestRecovery_FastForward_SNReportsUp(t *testing.T) {
 	// Recover a Preparing view. SN already has Up from previous run.
 	v1 := buildTestViewWithVersion(1, 1, 1, 1)
 	v1.Meta.State = viewpb.QueryViewState_QueryViewStatePreparing
-	mgr := newTestManager(catalog, s, v1)
+	mgr := newTestManager(t, catalog, s, v1)
 	ver1 := testVersion(1, 1, 1)
 
 	// QN1 Ready.
@@ -815,7 +868,7 @@ func TestRecovery_FastForward_SNReportsUp(t *testing.T) {
 func TestCallback_RemovedView_ReturnsTrue(t *testing.T) {
 	catalog := newMockCatalog()
 	s := newMockSyncer()
-	mgr := newTestManager(catalog, s)
+	mgr := newTestManager(t, catalog, s)
 
 	b := testBuilder(1, 1, 1)
 	ver1 := testVersion(1, 1, 1)
@@ -850,7 +903,7 @@ func TestCallback_RemovedView_ReturnsTrue(t *testing.T) {
 func TestOnQueryNodeLost_RemovedView_NoOp(t *testing.T) {
 	catalog := newMockCatalog()
 	s := newMockSyncer()
-	mgr := newTestManager(catalog, s)
+	mgr := newTestManager(t, catalog, s)
 
 	b := testBuilder(1, 1, 1)
 	ver1 := testVersion(1, 1, 1)
@@ -875,4 +928,27 @@ func TestOnQueryNodeLost_RemovedView_NoOp(t *testing.T) {
 	mgr.mu.Lock()
 	assert.Empty(t, mgr.views)
 	mgr.mu.Unlock()
+}
+
+func TestShardViewManagerConsumesOnlyProcessedStateMachineEffects(t *testing.T) {
+	untouched := NewCoordQueryViewStateMachine(buildTestViewWithVersion(1, 1, 1, 1))
+	processed := NewCoordQueryViewStateMachine(buildTestViewWithVersion(1, 1, 1, 2))
+	manager := &ShardViewManager{
+		ctx:     context.Background(),
+		shardID: testShardID,
+		views: map[qviews.QueryViewVersion]*CoordQueryViewStateMachine{
+			untouched.Version(): untouched,
+			processed.Version(): processed,
+		},
+	}
+
+	manager.mu.Lock()
+	manager.processStateMachine(processed)
+	event := manager.consumeDirtyEventLocked()
+	manager.mu.Unlock()
+
+	require.Len(t, event.persists, 1)
+	assert.Equal(t, processed.Version(), qviews.FromProtoQueryViewVersion(event.persists[0].GetMeta().GetVersion()))
+	assert.Len(t, event.syncs, 2)
+	assert.False(t, untouched.ConsumeFlush().Empty())
 }

--- a/internal/views/coord/coordview/shard_view_registry.go
+++ b/internal/views/coord/coordview/shard_view_registry.go
@@ -8,6 +8,8 @@ import (
 	"github.com/milvus-io/milvus/internal/views/coord/coordview/syncer"
 	"github.com/milvus-io/milvus/internal/views/qviews"
 	"github.com/milvus-io/milvus/pkg/v3/proto/viewpb"
+	"github.com/milvus-io/milvus/pkg/v3/util/nodescheduler"
+	"github.com/milvus-io/milvus/pkg/v3/util/paramtable"
 )
 
 // ShardViewRegistry owns the lifecycle of every ShardViewManager on this Coord
@@ -19,10 +21,9 @@ import (
 //
 // All methods are safe for concurrent use.
 type ShardViewRegistry struct {
-	mu      sync.RWMutex
-	ctx     context.Context
-	catalog queryview.QueryViewCatalog
-	syncer  syncer.ReliableSyncer
+	mu             sync.RWMutex
+	ctx            context.Context
+	flushScheduler *DirtyViewFlushScheduler
 
 	version  uint64
 	shards   map[qviews.ShardID]*ShardViewManager
@@ -57,22 +58,33 @@ func RecoverShardViewRegistry(
 		byShardID[sid] = append(byShardID[sid], v)
 	}
 
+	flushScheduler := newDirtyViewFlushScheduler(
+		catalog,
+		s,
+		paramtable.Get().MetaStoreCfg.MaxEtcdTxnNum.GetAsInt(),
+		nodescheduler.Get(),
+	)
+	batch := flushScheduler.Begin()
 	shards := make(map[qviews.ShardID]*ShardViewManager, len(byShardID))
 	for sid, recovered := range byShardID {
-		shards[sid] = NewShardViewManager(ctx, sid, catalog, s, recovered)
+		shards[sid] = newShardViewManager(ctx, sid, flushScheduler, recovered)
 	}
+	batch.Commit()
 
 	registry := &ShardViewRegistry{
-		ctx:     ctx,
-		catalog: catalog,
-		syncer:  s,
-		version: 1,
-		shards:  shards,
-		stats:   make(map[qviews.ShardID]*ShardStats, len(shards)),
+		ctx:            ctx,
+		flushScheduler: flushScheduler,
+		version:        1,
+		shards:         shards,
+		stats:          make(map[qviews.ShardID]*ShardStats, len(shards)),
 	}
 	for sid, mgr := range shards {
 		mgr.SetStatsObserver(registry.onShardStatsChanged)
 		registry.stats[sid] = mgr.Stats()
+	}
+	if err := flushScheduler.Flush(ctx); err != nil {
+		flushScheduler.Close()
+		return nil, err
 	}
 	return registry, nil
 }
@@ -88,7 +100,7 @@ func (r *ShardViewRegistry) Ensure(shardID qviews.ShardID) *ShardViewManager {
 	}
 	r.mu.RUnlock()
 
-	mgr := NewShardViewManager(r.ctx, shardID, r.catalog, r.syncer, nil)
+	mgr := newShardViewManager(r.ctx, shardID, r.flushScheduler, nil)
 	mgr.SetStatsObserver(r.onShardStatsChanged)
 	stats := emptyShardStats()
 
@@ -103,6 +115,20 @@ func (r *ShardViewRegistry) Ensure(shardID qviews.ShardID) *ShardViewManager {
 	r.version++
 	r.mu.Unlock()
 	return mgr
+}
+
+func (r *ShardViewRegistry) Close() {
+	if r == nil || r.flushScheduler == nil {
+		return
+	}
+	r.flushScheduler.Close()
+}
+
+// Begin opens an explicit cross-shard QueryView flush batch. Existing flush
+// tasks continue running; events emitted before the returned token is committed
+// are held and dispatched together as disjoint ShardID-lane tasks.
+func (r *ShardViewRegistry) Begin() DirtyViewBatch {
+	return r.flushScheduler.Begin()
 }
 
 // Get returns the ShardViewManager for shardID, or nil if absent.

--- a/internal/views/coord/coordview/shard_view_registry_test.go
+++ b/internal/views/coord/coordview/shard_view_registry_test.go
@@ -17,7 +17,26 @@ func newTestRegistry(t *testing.T, catalog *mockCatalog, s *mockSyncer) *ShardVi
 	t.Helper()
 	reg, err := RecoverShardViewRegistry(context.Background(), catalog, s)
 	require.NoError(t, err)
+	t.Cleanup(reg.Close)
 	return reg
+}
+
+func TestRegistry_FlushesAcrossManagers(t *testing.T) {
+	catalog := newMockCatalog()
+	s := newMockSyncer()
+	reg := newTestRegistry(t, catalog, s)
+
+	shard1 := qviews.ShardID{ReplicaID: 1, VChannel: "v1"}
+	shard2 := qviews.ShardID{ReplicaID: 1, VChannel: "v2"}
+	batch := reg.Begin()
+	require.NoError(t, reg.Ensure(shard1).AddPreparing(context.Background(), testBuilderForShard(1, shard1)))
+	require.NoError(t, reg.Ensure(shard2).AddPreparing(context.Background(), testBuilderForShard(2, shard2)))
+	assert.Zero(t, catalog.numSaveCalls())
+	batch.Commit()
+	require.NoError(t, reg.flushScheduler.Flush(context.Background()))
+
+	assert.Equal(t, 1, catalog.numSaveCalls())
+	assert.Len(t, catalog.saved, 2)
 }
 
 func TestRegistry_EmptyRecovery(t *testing.T) {
@@ -64,6 +83,7 @@ func TestRegistry_RecoverWithPersistedViews(t *testing.T) {
 
 	reg, err := RecoverShardViewRegistry(context.Background(), catalog, newMockSyncer())
 	require.NoError(t, err)
+	t.Cleanup(reg.Close)
 
 	assert.Len(t, reg.Snapshot().StatsMap(), 2)
 

--- a/internal/views/coord/coordview/state_machine.go
+++ b/internal/views/coord/coordview/state_machine.go
@@ -11,8 +11,9 @@ import (
 // query view on the Coordinator.
 //
 // The state machine is purely in-memory and non-blocking.
-// All I/O (ETCD persistence, node sync) is signaled through pending proto
-// consumed by the Manager via ConsumePersist / ConsumeSync.
+// All I/O (ETCD persistence, node sync) is represented by the latest pending
+// external effect and atomically drained by the shared flush scheduler through
+// ShardViewManager.
 //
 // State flow:
 //
@@ -35,17 +36,28 @@ type CoordQueryViewStateMachine struct {
 	// Used by Balancer/Manager for progress tracking and decision-making.
 	qnReadySegments map[int64][]int64
 
-	// Pending I/O signals, consumed once by Manager.
-	pendingPersist *viewpb.QueryViewOfShard
-	pendingSync    []qviews.QueryViewAtWorkNode
+	// Pending external effects, atomically drained through ShardViewManager by
+	// the Coordinator flush scheduler.
+	pending queryViewFlush
+}
+
+// queryViewFlush is the latest unflushed external effect of a state machine.
+// Persist and Sync are replaced independently so multiple transitions that
+// have not been externalized can fast-forward to their latest desired state.
+type queryViewFlush struct {
+	Persist *viewpb.QueryViewOfShard
+	Sync    []qviews.QueryViewAtWorkNode
+}
+
+func (f queryViewFlush) Empty() bool {
+	return f.Persist == nil && len(f.Sync) == 0
 }
 
 // NewCoordQueryViewStateMachine creates a state machine for a freshly
 // generated query view.
 //
-// After construction:
-//   - ConsumePersist returns the Preparing view (write-ahead).
-//   - ConsumeSync returns the Preparing view (push to all nodes).
+// After construction, the pending flush contains the Preparing view for
+// write-ahead persistence and the Preparing targets for all work nodes.
 func NewCoordQueryViewStateMachine(view *viewpb.QueryViewOfShard) *CoordQueryViewStateMachine {
 	sm := &CoordQueryViewStateMachine{
 		state:           qviews.QueryViewStatePreparing,
@@ -57,8 +69,8 @@ func NewCoordQueryViewStateMachine(view *viewpb.QueryViewOfShard) *CoordQueryVie
 	for _, qn := range view.QueryNode {
 		sm.qnStates[qn.NodeId] = qviews.QueryViewStateNil
 	}
-	sm.pendingPersist = sm.viewWithState(qviews.QueryViewStatePreparing)
-	sm.pendingSync = sm.syncViewsForState(qviews.QueryViewStatePreparing)
+	sm.pending.Persist = sm.viewWithState(qviews.QueryViewStatePreparing)
+	sm.pending.Sync = sm.syncViewsForState(qviews.QueryViewStatePreparing)
 	return sm
 }
 
@@ -86,13 +98,13 @@ func RecoverCoordQueryViewStateMachine(view *viewpb.QueryViewOfShard) *CoordQuer
 	switch recoveredState {
 	case qviews.QueryViewStatePreparing:
 		// Already persisted; re-push to all nodes.
-		sm.pendingSync = sm.syncViewsForState(qviews.QueryViewStatePreparing)
+		sm.pending.Sync = sm.syncViewsForState(qviews.QueryViewStatePreparing)
 	case qviews.QueryViewStateUp:
 		// Active view; no re-push needed. Up is persisted precisely to
 		// avoid unnecessary Coord↔node communication on recovery.
 	case qviews.QueryViewStateDown:
 		// Re-push Down to SN.
-		sm.pendingSync = sm.syncViewsForState(qviews.QueryViewStateDown)
+		sm.pending.Sync = sm.syncViewsForState(qviews.QueryViewStateDown)
 	case qviews.QueryViewStateUnrecoverable:
 		// Stable state; wait for Manager to call EnterDropping.
 	default:
@@ -168,7 +180,7 @@ func (sm *CoordQueryViewStateMachine) OnQueryNodeLost(node qviews.QueryNode) {
 		sm.qnStates[node.ID] = qviews.QueryViewStateDropped
 		if sm.allNodesDropped() {
 			sm.state = qviews.QueryViewStateDropped
-			sm.pendingPersist = sm.viewWithState(qviews.QueryViewStateDropped)
+			sm.pending.Persist = sm.viewWithState(qviews.QueryViewStateDropped)
 		}
 	}
 }
@@ -181,8 +193,8 @@ func (sm *CoordQueryViewStateMachine) EnterDown() {
 		return
 	}
 	sm.state = qviews.QueryViewStateDown
-	sm.pendingPersist = sm.viewWithState(qviews.QueryViewStateDown)
-	sm.pendingSync = sm.syncViewsForState(qviews.QueryViewStateDown)
+	sm.pending.Persist = sm.viewWithState(qviews.QueryViewStateDown)
+	sm.pending.Sync = sm.syncViewsForState(qviews.QueryViewStateDown)
 }
 
 // EnterDropping is called by the Manager to transition this view from
@@ -194,26 +206,14 @@ func (sm *CoordQueryViewStateMachine) EnterDropping() {
 		return
 	}
 	sm.state = qviews.QueryViewStateDropping
-	sm.pendingSync = sm.syncViewsForState(qviews.QueryViewStateDropped)
+	sm.pending.Sync = sm.syncViewsForState(qviews.QueryViewStateDropped)
 }
 
-// ConsumePersist returns the view to persist to ETCD and clears the flag.
-// Returns nil if no persistence is needed.
-//
-//   - Meta.State == Dropped → Manager should delete from ETCD.
-//   - Meta.State == other   → Manager should save/overwrite in ETCD.
-func (sm *CoordQueryViewStateMachine) ConsumePersist() *viewpb.QueryViewOfShard {
-	v := sm.pendingPersist
-	sm.pendingPersist = nil
-	return v
-}
-
-// ConsumeSync returns the per-node views to push and clears the flag.
-// Returns nil if no sync is needed.
-func (sm *CoordQueryViewStateMachine) ConsumeSync() []qviews.QueryViewAtWorkNode {
-	v := sm.pendingSync
-	sm.pendingSync = nil
-	return v
+// ConsumeFlush atomically drains the latest pending persist and sync effects.
+func (sm *CoordQueryViewStateMachine) ConsumeFlush() queryViewFlush {
+	flush := sm.pending
+	sm.pending = queryViewFlush{}
+	return flush
 }
 
 // --- State handlers ---
@@ -233,11 +233,11 @@ func (sm *CoordQueryViewStateMachine) handlePreparing(report qviews.QueryViewAtW
 	if sm.snState == qviews.QueryViewStateUp {
 		// Fast-forward: SN already Up from recovery.
 		sm.state = qviews.QueryViewStateUp
-		sm.pendingPersist = sm.viewWithState(qviews.QueryViewStateUp)
+		sm.pending.Persist = sm.viewWithState(qviews.QueryViewStateUp)
 	} else {
 		// Normal flow: all Ready → Ready, push Up to SN.
 		sm.state = qviews.QueryViewStateReady
-		sm.pendingSync = sm.syncViewsForState(qviews.QueryViewStateUp)
+		sm.pending.Sync = sm.syncViewsForState(qviews.QueryViewStateUp)
 	}
 }
 
@@ -255,11 +255,11 @@ func (sm *CoordQueryViewStateMachine) handleReady(report qviews.QueryViewAtWorkN
 	}
 	if report.State() == qviews.QueryViewStateUp {
 		sm.state = qviews.QueryViewStateUp
-		sm.pendingPersist = sm.viewWithState(qviews.QueryViewStateUp)
+		sm.pending.Persist = sm.viewWithState(qviews.QueryViewStateUp)
 		return
 	}
 	// SN not Up yet (e.g., still Ready) → re-push Up.
-	sm.pendingSync = sm.syncViewsForState(qviews.QueryViewStateUp)
+	sm.pending.Sync = sm.syncViewsForState(qviews.QueryViewStateUp)
 }
 
 // Up: active view serving queries.
@@ -287,11 +287,11 @@ func (sm *CoordQueryViewStateMachine) handleDown(report qviews.QueryViewAtWorkNo
 	}
 	if report.State() == qviews.QueryViewStateDown || report.State() == qviews.QueryViewStateDropped {
 		sm.state = qviews.QueryViewStateDropping
-		sm.pendingSync = sm.syncViewsForState(qviews.QueryViewStateDropped)
+		sm.pending.Sync = sm.syncViewsForState(qviews.QueryViewStateDropped)
 		return
 	}
 	// SN not Down yet → re-push Down.
-	sm.pendingSync = sm.syncViewsForState(qviews.QueryViewStateDown)
+	sm.pending.Sync = sm.syncViewsForState(qviews.QueryViewStateDown)
 }
 
 // Dropping: wait for all nodes to confirm Dropped.
@@ -301,19 +301,19 @@ func (sm *CoordQueryViewStateMachine) handleDropping(report qviews.QueryViewAtWo
 	if report.State() == qviews.QueryViewStateDropped {
 		if sm.allNodesDropped() {
 			sm.state = qviews.QueryViewStateDropped
-			sm.pendingPersist = sm.viewWithState(qviews.QueryViewStateDropped)
+			sm.pending.Persist = sm.viewWithState(qviews.QueryViewStateDropped)
 		}
 		return
 	}
 	// Node not Dropped → re-push Dropped.
-	sm.pendingSync = sm.syncViewsForState(qviews.QueryViewStateDropped)
+	sm.pending.Sync = sm.syncViewsForState(qviews.QueryViewStateDropped)
 }
 
 // transitionToUnrecoverable persists Unrecoverable and stays.
 // The Manager must call EnterDropping to advance to Dropping.
 func (sm *CoordQueryViewStateMachine) transitionToUnrecoverable() {
 	sm.state = qviews.QueryViewStateUnrecoverable
-	sm.pendingPersist = sm.viewWithState(qviews.QueryViewStateUnrecoverable)
+	sm.pending.Persist = sm.viewWithState(qviews.QueryViewStateUnrecoverable)
 }
 
 // --- Helpers ---

--- a/internal/views/coord/coordview/state_machine_test.go
+++ b/internal/views/coord/coordview/state_machine_test.go
@@ -1,6 +1,7 @@
 package coordview
 
 import (
+	"reflect"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
@@ -82,7 +83,7 @@ func qnReport(view *viewpb.QueryViewOfShard, nodeID int64, state qviews.QueryVie
 // expected state, then clears it.
 func assertPendingPersistState(t *testing.T, sm *CoordQueryViewStateMachine, expected qviews.QueryViewState) {
 	t.Helper()
-	v := sm.ConsumePersist()
+	v := consumePendingPersistForTest(sm)
 	require.NotNil(t, v, "expected pending persist with state %s", expected)
 	assert.Equal(t, viewpb.QueryViewState(expected), v.Meta.State)
 }
@@ -91,7 +92,7 @@ func assertPendingPersistState(t *testing.T, sm *CoordQueryViewStateMachine, exp
 // expected state, then clears it.
 func assertPendingSyncState(t *testing.T, sm *CoordQueryViewStateMachine, expected qviews.QueryViewState) {
 	t.Helper()
-	views := sm.ConsumeSync()
+	views := consumePendingSyncForTest(sm)
 	require.NotEmpty(t, views, "expected pending sync with state %s", expected)
 	for _, v := range views {
 		assert.Equal(t, expected, v.State(), "sync view state mismatch")
@@ -101,13 +102,13 @@ func assertPendingSyncState(t *testing.T, sm *CoordQueryViewStateMachine, expect
 // assertNoPendingPersist checks that ConsumePersist returns nil.
 func assertNoPendingPersist(t *testing.T, sm *CoordQueryViewStateMachine) {
 	t.Helper()
-	assert.Nil(t, sm.ConsumePersist(), "expected no pending persist")
+	assert.Nil(t, sm.pending.Persist, "expected no pending persist")
 }
 
 // assertNoPendingSync checks that ConsumeSync returns nil/empty.
 func assertNoPendingSync(t *testing.T, sm *CoordQueryViewStateMachine) {
 	t.Helper()
-	assert.Empty(t, sm.ConsumeSync(), "expected no pending sync")
+	assert.Empty(t, sm.pending.Sync, "expected no pending sync")
 }
 
 // assertNoPending checks that both ConsumePersist and ConsumeSync return nil.
@@ -119,8 +120,19 @@ func assertNoPending(t *testing.T, sm *CoordQueryViewStateMachine) {
 
 // drainPending consumes and discards both pending persist and sync.
 func drainPending(sm *CoordQueryViewStateMachine) {
-	sm.ConsumePersist()
-	sm.ConsumeSync()
+	sm.pending = queryViewFlush{}
+}
+
+func consumePendingPersistForTest(sm *CoordQueryViewStateMachine) *viewpb.QueryViewOfShard {
+	persist := sm.pending.Persist
+	sm.pending.Persist = nil
+	return persist
+}
+
+func consumePendingSyncForTest(sm *CoordQueryViewStateMachine) []qviews.QueryViewAtWorkNode {
+	sync := sm.pending.Sync
+	sm.pending.Sync = nil
+	return sync
 }
 
 // ===========================================================================
@@ -814,32 +826,47 @@ func TestRecovery_Up_ThenUnrecoverable(t *testing.T) {
 // 6. PENDING I/O CONSUMPTION SEMANTICS
 // ===========================================================================
 
-// TestConsumePersist_ConsumeOnce: second ConsumePersist returns nil.
-func TestConsumePersist_ConsumeOnce(t *testing.T) {
-	view := buildTestView(1)
-	sm := NewCoordQueryViewStateMachine(view)
-
-	v := sm.ConsumePersist()
-	require.NotNil(t, v)
-	assert.Equal(t, viewpb.QueryViewState_QueryViewStatePreparing, v.Meta.State)
-
-	assert.Nil(t, sm.ConsumePersist())
-	assert.Nil(t, sm.ConsumePersist()) // third call also nil
+func TestCoordQueryViewStateMachineExposesOnlyAtomicFlush(t *testing.T) {
+	typ := reflect.TypeOf((*CoordQueryViewStateMachine)(nil))
+	_, hasConsumePersist := typ.MethodByName("ConsumePersist")
+	_, hasConsumeSync := typ.MethodByName("ConsumeSync")
+	assert.False(t, hasConsumePersist)
+	assert.False(t, hasConsumeSync)
 }
 
-// TestConsumeSync_ConsumeOnce: second ConsumeSync returns nil.
-func TestConsumeSync_ConsumeOnce(t *testing.T) {
+func TestConsumeFlush_CoalescesUnflushedTransitions(t *testing.T) {
 	view := buildTestView(1)
 	sm := NewCoordQueryViewStateMachine(view)
 
-	views := sm.ConsumeSync()
-	require.NotEmpty(t, views)
-	for _, v := range views {
+	// None of these intermediate transitions has been externalized yet.
+	sm.EnterUnrecoverable()
+	sm.EnterDropping()
+	sm.OnNodeStateReported(snReport(view, qviews.QueryViewStateDropped))
+	sm.OnNodeStateReported(qnReport(view, 1, qviews.QueryViewStateDropped))
+
+	flush := sm.ConsumeFlush()
+	require.NotNil(t, flush.Persist)
+	assert.Equal(t, viewpb.QueryViewState_QueryViewStateDropped, flush.Persist.GetMeta().GetState())
+	require.NotEmpty(t, flush.Sync)
+	for _, target := range flush.Sync {
+		assert.Equal(t, qviews.QueryViewStateDropped, target.State())
+	}
+	assert.True(t, sm.ConsumeFlush().Empty())
+}
+
+func TestConsumeFlush_ConsumeOnce(t *testing.T) {
+	view := buildTestView(1)
+	sm := NewCoordQueryViewStateMachine(view)
+
+	flush := sm.ConsumeFlush()
+	require.NotNil(t, flush.Persist)
+	assert.Equal(t, viewpb.QueryViewState_QueryViewStatePreparing, flush.Persist.Meta.State)
+	require.NotEmpty(t, flush.Sync)
+	for _, v := range flush.Sync {
 		assert.Equal(t, qviews.QueryViewStatePreparing, v.State())
 	}
-
-	assert.Empty(t, sm.ConsumeSync())
-	assert.Empty(t, sm.ConsumeSync()) // third call also nil
+	assert.True(t, sm.ConsumeFlush().Empty())
+	assert.True(t, sm.ConsumeFlush().Empty())
 }
 
 // TestPendingPersist_Dropped_MeansDelete: Dropped persist signals ETCD delete.
@@ -856,7 +883,7 @@ func TestPendingPersist_Dropped_MeansDelete(t *testing.T) {
 	sm.OnNodeStateReported(snReport(view, qviews.QueryViewStateDropped))
 	sm.OnNodeStateReported(qnReport(view, 1, qviews.QueryViewStateDropped))
 
-	v := sm.ConsumePersist()
+	v := consumePendingPersistForTest(sm)
 	require.NotNil(t, v)
 	assert.Equal(t, viewpb.QueryViewState_QueryViewStateDropped, v.Meta.State)
 	assertNoPendingSync(t, sm)
@@ -1336,7 +1363,7 @@ func TestPendingSync_PreservesMeta(t *testing.T) {
 	view := buildTestView(1)
 	sm := NewCoordQueryViewStateMachine(view)
 
-	views := sm.ConsumeSync()
+	views := consumePendingSyncForTest(sm)
 	require.NotEmpty(t, views)
 	expectedVersion := qviews.FromProtoQueryViewVersion(view.Meta.Version)
 	for _, v := range views {
@@ -1349,7 +1376,7 @@ func TestPendingPersist_PreservesMeta(t *testing.T) {
 	view := buildTestView(1)
 	sm := NewCoordQueryViewStateMachine(view)
 
-	persist := sm.ConsumePersist()
+	persist := consumePendingPersistForTest(sm)
 	require.NotNil(t, persist)
 	assert.Equal(t, view.Meta.CollectionId, persist.Meta.CollectionId)
 	assert.Equal(t, view.Meta.ReplicaId, persist.Meta.ReplicaId)
@@ -1361,7 +1388,7 @@ func TestViewWithState_IsClone(t *testing.T) {
 	view := buildTestView(1)
 	sm := NewCoordQueryViewStateMachine(view)
 
-	persist := sm.ConsumePersist()
+	persist := consumePendingPersistForTest(sm)
 	require.NotNil(t, persist)
 
 	persist.Meta.CollectionId = 999

--- a/internal/views/qviews/observe/event.go
+++ b/internal/views/qviews/observe/event.go
@@ -51,8 +51,7 @@ const (
 	eventSNReleaseResource                  = "SNReleaseResource"
 	eventCoordPersistView                   = "CoordPersistView"
 	eventSNPersistView                      = "SNPersistView"
-	eventCoordSyncViewBatch                 = "CoordSyncViewBatch"
-	eventCoordSyncViewBatchFailed           = "CoordSyncViewBatchFailed"
+	eventCoordSyncViewAccepted              = "CoordSyncViewAccepted"
 )
 
 const (
@@ -682,8 +681,8 @@ func (e StreamingNodeReleaseResourceEvent) MarshalLogObject(enc mlog.ObjectEncod
 	return nil
 }
 
-// CoordPersistViewEvent is emitted when ShardViewManager captures one QueryView
-// persistence effect in a shard-scoped dirty event.
+// CoordPersistViewEvent is emitted after DirtyViewFlushScheduler successfully
+// persists one QueryView state.
 type CoordPersistViewEvent struct {
 	baseEvent
 	View  qviews.QueryViewKey
@@ -724,49 +723,29 @@ func (e StreamingNodePersistViewEvent) MarshalLogObject(enc mlog.ObjectEncoder) 
 	return nil
 }
 
-// CoordSyncViewBatchEvent is emitted when ShardViewManager captures one
-// QueryView sync effect for a worker node in a shard-scoped dirty event.
-type CoordSyncViewBatchEvent struct {
+// CoordSyncViewAcceptedEvent is emitted after ReliableSyncer accepts one
+// QueryView state for delivery to a worker node. It does not mean the worker
+// has applied the state.
+type CoordSyncViewAcceptedEvent struct {
 	baseEvent
 	View  qviews.QueryViewKey
+	Node  qviews.WorkNode
 	State qviews.QueryViewState
 }
 
-func (e CoordSyncViewBatchEvent) LogLevel() mlog.Level {
+func (e CoordSyncViewAcceptedEvent) LogLevel() mlog.Level {
 	return mlog.InfoLevel
 }
 
-func (e CoordSyncViewBatchEvent) MarshalLogObject(enc mlog.ObjectEncoder) error {
-	enc.AddString(fieldType, eventCoordSyncViewBatch)
+func (e CoordSyncViewAcceptedEvent) MarshalLogObject(enc mlog.ObjectEncoder) error {
+	enc.AddString(fieldType, eventCoordSyncViewAccepted)
 	enc.AddString(fieldSID, e.View.ShardID.String())
 	enc.AddString(fieldQV, e.View.QueryViewVersion.String())
 	enc.AddString(fieldDV, e.View.QueryViewVersion.DataVersion.String())
-	enc.AddString(fieldState, e.State.String())
-	return nil
-}
-
-// CoordSyncViewBatchFailedEvent is emitted when a DirtyViewFlushScheduler task
-// fails to sync a view state to one worker-node batch.
-type CoordSyncViewBatchFailedEvent struct {
-	baseEvent
-	View  qviews.QueryViewKey
-	State qviews.QueryViewState
-	Err   error
-}
-
-func (e CoordSyncViewBatchFailedEvent) LogLevel() mlog.Level {
-	return mlog.WarnLevel
-}
-
-func (e CoordSyncViewBatchFailedEvent) MarshalLogObject(enc mlog.ObjectEncoder) error {
-	enc.AddString(fieldType, eventCoordSyncViewBatchFailed)
-	enc.AddString(fieldSID, e.View.ShardID.String())
-	enc.AddString(fieldQV, e.View.QueryViewVersion.String())
-	enc.AddString(fieldDV, e.View.QueryViewVersion.DataVersion.String())
-	enc.AddString(fieldState, e.State.String())
-	if e.Err != nil {
-		enc.AddString(fieldError, e.Err.Error())
+	if e.Node != nil {
+		enc.AddString(fieldWN, e.Node.String())
 	}
+	enc.AddString(fieldState, e.State.String())
 	return nil
 }
 
@@ -806,11 +785,7 @@ func (e CoordPersistViewEvent) ComponentInfo() string {
 	return componentCoord
 }
 
-func (e CoordSyncViewBatchEvent) ComponentInfo() string {
-	return componentCoord
-}
-
-func (e CoordSyncViewBatchFailedEvent) ComponentInfo() string {
+func (e CoordSyncViewAcceptedEvent) ComponentInfo() string {
 	return componentCoord
 }
 

--- a/internal/views/qviews/observe/event.go
+++ b/internal/views/qviews/observe/event.go
@@ -682,8 +682,8 @@ func (e StreamingNodeReleaseResourceEvent) MarshalLogObject(enc mlog.ObjectEncod
 	return nil
 }
 
-// CoordPersistViewEvent is emitted when ShardViewManager.flush persists a view
-// state.
+// CoordPersistViewEvent is emitted when ShardViewManager captures one QueryView
+// persistence effect in a shard-scoped dirty event.
 type CoordPersistViewEvent struct {
 	baseEvent
 	View  qviews.QueryViewKey
@@ -724,8 +724,8 @@ func (e StreamingNodePersistViewEvent) MarshalLogObject(enc mlog.ObjectEncoder) 
 	return nil
 }
 
-// CoordSyncViewBatchEvent is emitted when ShardViewManager.flush syncs a view
-// state to one worker-node batch.
+// CoordSyncViewBatchEvent is emitted when ShardViewManager captures one
+// QueryView sync effect for a worker node in a shard-scoped dirty event.
 type CoordSyncViewBatchEvent struct {
 	baseEvent
 	View  qviews.QueryViewKey
@@ -745,8 +745,8 @@ func (e CoordSyncViewBatchEvent) MarshalLogObject(enc mlog.ObjectEncoder) error 
 	return nil
 }
 
-// CoordSyncViewBatchFailedEvent is emitted when ShardViewManager.flush fails to
-// sync a view state to one worker-node batch.
+// CoordSyncViewBatchFailedEvent is emitted when a DirtyViewFlushScheduler task
+// fails to sync a view state to one worker-node batch.
 type CoordSyncViewBatchFailedEvent struct {
 	baseEvent
 	View  qviews.QueryViewKey

--- a/internal/views/qviews/observe/event_test.go
+++ b/internal/views/qviews/observe/event_test.go
@@ -37,8 +37,7 @@ func TestConcreteEventsImplementEvent(t *testing.T) {
 	var _ Event = StreamingNodeReleaseResourceEvent{}
 	var _ Event = CoordPersistViewEvent{}
 	var _ Event = StreamingNodePersistViewEvent{}
-	var _ Event = CoordSyncViewBatchEvent{}
-	var _ Event = CoordSyncViewBatchFailedEvent{}
+	var _ Event = CoordSyncViewAcceptedEvent{}
 }
 
 func TestLogObserverImplementsObserver(t *testing.T) {
@@ -244,11 +243,6 @@ func TestEventLogLevel(t *testing.T) {
 			level: mlog.WarnLevel,
 		},
 		{
-			name:  "sync batch failed event",
-			event: CoordSyncViewBatchFailedEvent{},
-			level: mlog.WarnLevel,
-		},
-		{
 			name:  "segment unrecoverable event",
 			event: QueryNodeSegmentUnrecoverableEvent{},
 			level: mlog.WarnLevel,
@@ -377,10 +371,12 @@ func TestEventComponentInfo(t *testing.T) {
 	}
 }
 
-func TestCoordSyncViewBatchEventMarshalLogObject(t *testing.T) {
+func TestCoordSyncViewAcceptedEventMarshalLogObject(t *testing.T) {
 	view := testQueryViewKey()
-	event := CoordSyncViewBatchEvent{
+	node := qviews.NewQueryNode(10)
+	event := CoordSyncViewAcceptedEvent{
 		View:  view,
+		Node:  node,
 		State: qviews.QueryViewStatePreparing,
 	}
 	enc := zapcore.NewMapObjectEncoder()
@@ -389,10 +385,11 @@ func TestCoordSyncViewBatchEventMarshalLogObject(t *testing.T) {
 		t.Fatalf("marshal event: %v", err)
 	}
 
-	assertField(t, enc, "type", "CoordSyncViewBatch")
+	assertField(t, enc, "type", "CoordSyncViewAccepted")
 	assertField(t, enc, "sid", view.ShardID.String())
 	assertField(t, enc, "qv", view.QueryViewVersion.String())
 	assertField(t, enc, "dv", view.QueryViewVersion.DataVersion.String())
+	assertField(t, enc, "wn", node.String())
 	assertField(t, enc, "state", qviews.QueryViewStatePreparing.String())
 }
 


### PR DESCRIPTION
- QueryView coordination: add a dirty-view flush scheduler that batches per-view persistence and worker synchronization through NodeScheduler.
- MVCC confirmation: index unconfirmed vchannels to avoid full-channel scans during confirmation updates.
- Observability: emit persistence and sync-accepted events only after the corresponding IO succeeds, and include the target worker node in accepted events.
- QueryView design docs: align shard-view scheduling and observability documentation with the new asynchronous event boundaries.