### PR TITLE
fix: restore dedicated segment workers for write throughput

### DIFF
--- a/internal/streamingnode/server/wal/interceptors/shard/shards/partition_manager.go
+++ b/internal/streamingnode/server/wal/interceptors/shard/shards/partition_manager.go
@@ -50,7 +50,7 @@ func newPartitionSegmentManager(
 		fencedAssignTimeTick: fencedAssignTimeTick,
 		metrics:              metrics,
 	}
-	m.SetLogger(logger.With(mlog.FieldVChannel(vchannel), mlog.FieldCollectionID(collectionID), mlog.FieldPartitionID(paritionID)))
+	m.SetLogger(logger)
 	return m
 }
 

--- a/internal/streamingnode/server/wal/interceptors/shard/shards/partition_manager_test.go
+++ b/internal/streamingnode/server/wal/interceptors/shard/shards/partition_manager_test.go
@@ -27,6 +27,29 @@ import (
 	"github.com/milvus-io/milvus/pkg/v3/util/syncutil"
 )
 
+func TestPartitionManagerReusesPChannelLogger(t *testing.T) {
+	logger := mlog.With(
+		mlog.FieldComponent("shard-manager"),
+		mlog.FieldPChannel("pchannel"),
+	)
+	m := newPartitionSegmentManager(
+		context.Background(),
+		logger,
+		nil,
+		nil,
+		types.PChannelInfo{Name: "pchannel", Term: 1},
+		"vchannel",
+		1,
+		2,
+		map[int64]*segmentAllocManager{},
+		nil,
+		0,
+		nil,
+	)
+
+	assert.Same(t, logger, m.Logger())
+}
+
 func TestPartitionManager(t *testing.T) {
 	paramtable.Init()
 	resource.InitForTest(t)

--- a/internal/streamingnode/server/wal/interceptors/shard/shards/segment_alloc_worker.go
+++ b/internal/streamingnode/server/wal/interceptors/shard/shards/segment_alloc_worker.go
@@ -19,7 +19,11 @@ import (
 // asyncAllocSegment allocates a new growing segment asynchronously.
 func (m *partitionManager) asyncAllocSegment(schemaVersion int32, requiresStorageV3 bool) {
 	if m.onAllocating != nil {
-		m.Logger().Debug(context.TODO(), "segment alloc worker is already on allocating")
+		m.Logger().Debug(context.TODO(), "segment alloc worker is already on allocating",
+			mlog.FieldVChannel(m.vchannel),
+			mlog.FieldCollectionID(m.collectionID),
+			mlog.FieldPartitionID(m.partitionID),
+		)
 		// manager is already on allocating.
 		return
 	}
@@ -71,17 +75,37 @@ func (w *segmentAllocWorker) do() {
 			return
 		}
 		if status.AsStreamingError(err).IsUnrecoverable() {
-			w.Logger().Warn(w.ctx, "allocate new growing segment with unrecoverable error, stop retrying", mlog.Err(err))
+			w.Logger().Warn(w.ctx, "allocate new growing segment with unrecoverable error, stop retrying",
+				mlog.FieldVChannel(w.vchannel),
+				mlog.FieldCollectionID(w.collectionID),
+				mlog.FieldPartitionID(w.partitionID),
+				mlog.Err(err),
+			)
 			return
 		}
 		nextInterval := retryBackoff.NextBackOff()
-		w.Logger().Info(w.ctx, "failed to allocate new growing segment, retrying", mlog.Duration("nextInterval", nextInterval), mlog.Err(err))
+		w.Logger().Info(w.ctx, "failed to allocate new growing segment, retrying",
+			mlog.FieldVChannel(w.vchannel),
+			mlog.FieldCollectionID(w.collectionID),
+			mlog.FieldPartitionID(w.partitionID),
+			mlog.Duration("nextInterval", nextInterval),
+			mlog.Err(err),
+		)
 		select {
 		case <-w.ctx.Done():
-			w.Logger().Info(w.ctx, "segment allocation canceled", mlog.Err(w.ctx.Err()))
+			w.Logger().Info(w.ctx, "segment allocation canceled",
+				mlog.FieldVChannel(w.vchannel),
+				mlog.FieldCollectionID(w.collectionID),
+				mlog.FieldPartitionID(w.partitionID),
+				mlog.Err(w.ctx.Err()),
+			)
 			return
 		case <-w.wal.Available():
-			w.Logger().Warn(w.ctx, "wal is unavailable, stop alloc new segment")
+			w.Logger().Warn(w.ctx, "wal is unavailable, stop alloc new segment",
+				mlog.FieldVChannel(w.vchannel),
+				mlog.FieldCollectionID(w.collectionID),
+				mlog.FieldPartitionID(w.partitionID),
+			)
 			return
 		case <-time.After(nextInterval):
 		}
@@ -120,11 +144,24 @@ func (w *segmentAllocWorker) doOnce() error {
 
 	result, err := w.wal.Append(w.ctx, msg)
 	if err != nil {
-		w.Logger().Warn(w.ctx, "failed to append create segment message", mlog.FieldMessage(msg), mlog.Err(err))
+		w.Logger().Warn(w.ctx, "failed to append create segment message",
+			mlog.FieldVChannel(w.vchannel),
+			mlog.FieldCollectionID(w.collectionID),
+			mlog.FieldPartitionID(w.partitionID),
+			mlog.FieldMessage(msg),
+			mlog.Err(err),
+		)
 		return err
 	}
 	w.Logger().Info(w.ctx,
-		"append create segment message", mlog.FieldMessage(msg), mlog.String("messageID", result.MessageID.String()), mlog.Uint64("timetick", result.TimeTick))
+		"append create segment message",
+		mlog.FieldVChannel(w.vchannel),
+		mlog.FieldCollectionID(w.collectionID),
+		mlog.FieldPartitionID(w.partitionID),
+		mlog.FieldMessage(msg),
+		mlog.String("messageID", result.MessageID.String()),
+		mlog.Uint64("timetick", result.TimeTick),
+	)
 	return nil
 }
 
@@ -139,7 +176,12 @@ func (w *segmentAllocWorker) initSegmentConfig() error {
 	// Allocate new segment id.
 	segmentID, err := resource.Resource().IDAllocator().Allocate(w.ctx)
 	if err != nil {
-		w.Logger().Warn(w.ctx, "failed to allocate segment id", mlog.Err(err))
+		w.Logger().Warn(w.ctx, "failed to allocate segment id",
+			mlog.FieldVChannel(w.vchannel),
+			mlog.FieldCollectionID(w.collectionID),
+			mlog.FieldPartitionID(w.partitionID),
+			mlog.Err(err),
+		)
 		return err
 	}
 	w.segmentID = segmentID

--- a/internal/streamingnode/server/wal/interceptors/shard/shards/segment_alloc_worker.go
+++ b/internal/streamingnode/server/wal/interceptors/shard/shards/segment_alloc_worker.go
@@ -2,6 +2,9 @@ package shards
 
 import (
 	"context"
+	"time"
+
+	"github.com/cenkalti/backoff/v4"
 
 	"github.com/milvus-io/milvus/internal/storage"
 	"github.com/milvus-io/milvus/internal/streamingnode/server/resource"
@@ -10,7 +13,6 @@ import (
 	"github.com/milvus-io/milvus/pkg/v3/mlog"
 	"github.com/milvus-io/milvus/pkg/v3/proto/datapb"
 	"github.com/milvus-io/milvus/pkg/v3/streaming/util/message"
-	"github.com/milvus-io/milvus/pkg/v3/util/nodescheduler"
 	"github.com/milvus-io/milvus/pkg/v3/util/paramtable"
 )
 
@@ -33,7 +35,9 @@ func (m *partitionManager) asyncAllocSegment(schemaVersion int32, requiresStorag
 		requiresStorageV3: requiresStorageV3,
 	}
 	w.SetLogger(m.Logger())
-	m.scheduler.Submit(w)
+	// It should always run asynchronously. Otherwise, a deadlock may happen
+	// while the WAL is writing the CreateSegment message.
+	go w.do()
 }
 
 // segmentAllocWorker is a worker that allocates new growing segments asynchronously.
@@ -53,33 +57,42 @@ type segmentAllocWorker struct {
 	requiresStorageV3 bool
 }
 
-func (w *segmentAllocWorker) Execute(schedulerCtx context.Context) error {
-	ctx, cancel := mergeSegmentTaskContext(schedulerCtx, w.ctx)
-	defer cancel()
-	if segmentTaskStopped(ctx, w.wal) {
-		return nil
-	}
-	if err := w.doOnceWithContext(ctx); err != nil {
-		if segmentTaskStopped(ctx, w.wal) {
-			return nil
+// do is the main loop of the segment allocation worker.
+func (w *segmentAllocWorker) do() {
+	retryBackoff := backoff.NewExponentialBackOff()
+	retryBackoff.InitialInterval = 10 * time.Millisecond
+	retryBackoff.MaxInterval = time.Second
+	retryBackoff.MaxElapsedTime = 0
+	retryBackoff.Reset()
+
+	for {
+		err := w.doOnce()
+		if err == nil {
+			return
 		}
 		if status.AsStreamingError(err).IsUnrecoverable() {
-			return err
+			w.Logger().Warn(w.ctx, "allocate new growing segment with unrecoverable error, stop retrying", mlog.Err(err))
+			return
 		}
-		return nodescheduler.ErrDelay
+		nextInterval := retryBackoff.NextBackOff()
+		w.Logger().Info(w.ctx, "failed to allocate new growing segment, retrying", mlog.Duration("nextInterval", nextInterval), mlog.Err(err))
+		select {
+		case <-w.ctx.Done():
+			w.Logger().Info(w.ctx, "segment allocation canceled", mlog.Err(w.ctx.Err()))
+			return
+		case <-w.wal.Available():
+			w.Logger().Warn(w.ctx, "wal is unavailable, stop alloc new segment")
+			return
+		case <-time.After(nextInterval):
+		}
 	}
-	return nil
 }
 
 // doOnce executes the segment allocation operation.
 func (w *segmentAllocWorker) doOnce() error {
-	return w.doOnceWithContext(w.ctx)
-}
-
-func (w *segmentAllocWorker) doOnceWithContext(ctx context.Context) error {
 	// Initialize segment configuration on first attempt.
 	// These values are preserved across retries to ensure consistency.
-	if err := w.initSegmentConfigWithContext(ctx); err != nil {
+	if err := w.initSegmentConfig(); err != nil {
 		return err
 	}
 
@@ -105,12 +118,12 @@ func (w *segmentAllocWorker) doOnceWithContext(ctx context.Context) error {
 		WithBody(&message.CreateSegmentMessageBody{}).
 		MustBuildMutable()
 
-	result, err := w.wal.Append(ctx, msg)
+	result, err := w.wal.Append(w.ctx, msg)
 	if err != nil {
-		w.Logger().Warn(ctx, "failed to append create segment message", mlog.FieldMessage(msg), mlog.Err(err))
+		w.Logger().Warn(w.ctx, "failed to append create segment message", mlog.FieldMessage(msg), mlog.Err(err))
 		return err
 	}
-	w.Logger().Info(ctx,
+	w.Logger().Info(w.ctx,
 		"append create segment message", mlog.FieldMessage(msg), mlog.String("messageID", result.MessageID.String()), mlog.Uint64("timetick", result.TimeTick))
 	return nil
 }
@@ -118,19 +131,15 @@ func (w *segmentAllocWorker) doOnceWithContext(ctx context.Context) error {
 // initSegmentConfig initializes the segment configuration (segmentID, storageVersion, limitation).
 // These values are only set once and preserved across retries to ensure consistency.
 func (w *segmentAllocWorker) initSegmentConfig() error {
-	return w.initSegmentConfigWithContext(w.ctx)
-}
-
-func (w *segmentAllocWorker) initSegmentConfigWithContext(ctx context.Context) error {
 	// Skip if already initialized.
 	if w.segmentID != 0 {
 		return nil
 	}
 
 	// Allocate new segment id.
-	segmentID, err := resource.Resource().IDAllocator().Allocate(ctx)
+	segmentID, err := resource.Resource().IDAllocator().Allocate(w.ctx)
 	if err != nil {
-		w.Logger().Warn(ctx, "failed to allocate segment id", mlog.Err(err))
+		w.Logger().Warn(w.ctx, "failed to allocate segment id", mlog.Err(err))
 		return err
 	}
 	w.segmentID = segmentID
@@ -145,5 +154,3 @@ func (w *segmentAllocWorker) initSegmentConfigWithContext(ctx context.Context) e
 	w.limitation = getSegmentLimitationPolicy().GenerateLimitation(datapb.SegmentLevel_L1)
 	return nil
 }
-
-var _ nodescheduler.Task = (*segmentAllocWorker)(nil)

--- a/internal/streamingnode/server/wal/interceptors/shard/shards/segment_flush_worker.go
+++ b/internal/streamingnode/server/wal/interceptors/shard/shards/segment_flush_worker.go
@@ -24,6 +24,9 @@ func (m *partitionManager) asyncFlushSegment(
 		l, err := m.wal.GetWithContext(ctx)
 		if err != nil {
 			m.Logger().Info(ctx, "stop flushing segment before wal is ready",
+				mlog.FieldVChannel(m.vchannel),
+				mlog.FieldCollectionID(m.collectionID),
+				mlog.FieldPartitionID(m.partitionID),
 				mlog.FieldSegmentID(segment.GetSegmentID()),
 				mlog.Err(err))
 			return
@@ -34,6 +37,7 @@ func (m *partitionManager) asyncFlushSegment(
 			txnManager:   m.txnManager,
 			ctx:          ctx,
 			collectionID: m.collectionID,
+			partitionID:  m.partitionID,
 			vchannel:     m.vchannel,
 			segment:      segment,
 			wal:          l,
@@ -49,6 +53,7 @@ type segmentFlushWorker struct {
 	txnManager   TxnManager
 	ctx          context.Context
 	collectionID int64
+	partitionID  int64
 	vchannel     string
 	segment      *segmentAllocManager // the segment is belong to one collection
 	wal          wal.WAL
@@ -66,7 +71,12 @@ func (w *segmentFlushWorker) do() {
 	// recovered transactions before writing a Flush message, so all inserts stay
 	// ordered before the flush in the WAL.
 	if err := w.waitForTxnManagerRecoverDone(); err != nil {
-		w.Logger().Error(w.ctx, "failed to wait for txn manager recover ready", mlog.Err(err))
+		w.Logger().Error(w.ctx, "failed to wait for txn manager recover ready",
+			mlog.FieldVChannel(w.vchannel),
+			mlog.FieldCollectionID(w.collectionID),
+			mlog.FieldPartitionID(w.partitionID),
+			mlog.Err(err),
+		)
 		return
 	}
 
@@ -76,17 +86,37 @@ func (w *segmentFlushWorker) do() {
 			return
 		}
 		if status.AsStreamingError(err).IsUnrecoverable() {
-			w.Logger().Warn(w.ctx, "flush growing segment with unrecoverable error, stop retrying", mlog.Err(err))
+			w.Logger().Warn(w.ctx, "flush growing segment with unrecoverable error, stop retrying",
+				mlog.FieldVChannel(w.vchannel),
+				mlog.FieldCollectionID(w.collectionID),
+				mlog.FieldPartitionID(w.partitionID),
+				mlog.Err(err),
+			)
 			return
 		}
 		nextInterval := retryBackoff.NextBackOff()
-		w.Logger().Info(w.ctx, "failed to flush growing segment, retrying", mlog.Duration("nextInterval", nextInterval), mlog.Err(err))
+		w.Logger().Info(w.ctx, "failed to flush growing segment, retrying",
+			mlog.FieldVChannel(w.vchannel),
+			mlog.FieldCollectionID(w.collectionID),
+			mlog.FieldPartitionID(w.partitionID),
+			mlog.Duration("nextInterval", nextInterval),
+			mlog.Err(err),
+		)
 		select {
 		case <-w.ctx.Done():
-			w.Logger().Info(w.ctx, "flush segment canceled", mlog.Err(w.ctx.Err()))
+			w.Logger().Info(w.ctx, "flush segment canceled",
+				mlog.FieldVChannel(w.vchannel),
+				mlog.FieldCollectionID(w.collectionID),
+				mlog.FieldPartitionID(w.partitionID),
+				mlog.Err(w.ctx.Err()),
+			)
 			return
 		case <-w.wal.Available():
-			w.Logger().Warn(w.ctx, "wal is unavailable, stop flush segment")
+			w.Logger().Warn(w.ctx, "wal is unavailable, stop flush segment",
+				mlog.FieldVChannel(w.vchannel),
+				mlog.FieldCollectionID(w.collectionID),
+				mlog.FieldPartitionID(w.partitionID),
+			)
 			return
 		case <-time.After(nextInterval):
 		}
@@ -99,7 +129,12 @@ func (w *segmentFlushWorker) waitForTxnManagerRecoverDone() error {
 	case <-w.txnManager.RecoverDone():
 		return nil
 	case <-w.ctx.Done():
-		w.Logger().Info(w.ctx, "flush segment canceled", mlog.Err(w.ctx.Err()))
+		w.Logger().Info(w.ctx, "flush segment canceled",
+			mlog.FieldVChannel(w.vchannel),
+			mlog.FieldCollectionID(w.collectionID),
+			mlog.FieldPartitionID(w.partitionID),
+			mlog.Err(w.ctx.Err()),
+		)
 		return w.ctx.Err()
 	case <-w.wal.Available():
 		return status.NewOnShutdownError("wal is unavailable")
@@ -126,12 +161,21 @@ func (w *segmentFlushWorker) doOnce() error {
 
 	result, err := w.wal.Append(w.ctx, msg)
 	if err != nil {
-		w.Logger().Error(w.ctx, "failed to append flush message", mlog.FieldMessage(msg), mlog.Err(err))
+		w.Logger().Error(w.ctx, "failed to append flush message",
+			mlog.FieldVChannel(w.vchannel),
+			mlog.FieldCollectionID(w.collectionID),
+			mlog.FieldPartitionID(w.partitionID),
+			mlog.FieldMessage(msg),
+			mlog.Err(err),
+		)
 		return err
 	}
 	policy := w.segment.SealPolicy()
 	w.Logger().Info(w.ctx,
 		"segment has been flushed",
+		mlog.FieldVChannel(w.vchannel),
+		mlog.FieldCollectionID(w.collectionID),
+		mlog.FieldPartitionID(w.partitionID),
 		mlog.FieldMessage(msg),
 		mlog.String("policy", string(policy.Policy)),
 		mlog.Any("extras", policy.Extra),
@@ -145,12 +189,24 @@ func (w *segmentFlushWorker) doOnce() error {
 func (w *segmentFlushWorker) checkIfReady() bool {
 	// if there're flying acks, wait them acked, delay the flush at next retry.
 	if ackSem := w.segment.AckSem(); ackSem > 0 {
-		w.Logger().Info(w.ctx, "segment has flying insert operation, delay it", mlog.Int32("ackSem", ackSem), mlog.FieldSegmentID(w.segment.GetSegmentID()))
+		w.Logger().Info(w.ctx, "segment has flying insert operation, delay it",
+			mlog.FieldVChannel(w.vchannel),
+			mlog.FieldCollectionID(w.collectionID),
+			mlog.FieldPartitionID(w.partitionID),
+			mlog.FieldSegmentID(w.segment.GetSegmentID()),
+			mlog.Int32("ackSem", ackSem),
+		)
 		return false
 	}
 	// if there're flying txns, wait them committed, delay the flush at next retry.
 	if txnSem := w.segment.TxnSem(); txnSem > 0 {
-		w.Logger().Info(w.ctx, "segment has flying txns, delay it", mlog.Int32("txnSem", txnSem), mlog.FieldSegmentID(w.segment.GetSegmentID()))
+		w.Logger().Info(w.ctx, "segment has flying txns, delay it",
+			mlog.FieldVChannel(w.vchannel),
+			mlog.FieldCollectionID(w.collectionID),
+			mlog.FieldPartitionID(w.partitionID),
+			mlog.FieldSegmentID(w.segment.GetSegmentID()),
+			mlog.Int32("txnSem", txnSem),
+		)
 		return false
 	}
 	return true

--- a/internal/streamingnode/server/wal/interceptors/shard/shards/segment_flush_worker.go
+++ b/internal/streamingnode/server/wal/interceptors/shard/shards/segment_flush_worker.go
@@ -2,14 +2,15 @@ package shards
 
 import (
 	"context"
+	"time"
 
+	"github.com/cenkalti/backoff/v4"
 	"github.com/cockroachdb/errors"
 
 	"github.com/milvus-io/milvus/internal/streamingnode/server/wal"
 	"github.com/milvus-io/milvus/internal/util/streamingutil/status"
 	"github.com/milvus-io/milvus/pkg/v3/mlog"
 	"github.com/milvus-io/milvus/pkg/v3/streaming/util/message"
-	"github.com/milvus-io/milvus/pkg/v3/util/nodescheduler"
 )
 
 var errDelayFlush = errors.New("delay flush")
@@ -38,7 +39,7 @@ func (m *partitionManager) asyncFlushSegment(
 			wal:          l,
 		}
 		w.SetLogger(m.Logger())
-		m.scheduler.Submit(w)
+		w.do()
 	}()
 }
 
@@ -53,45 +54,60 @@ type segmentFlushWorker struct {
 	wal          wal.WAL
 }
 
-func (w *segmentFlushWorker) Execute(schedulerCtx context.Context) error {
-	ctx, cancel := mergeSegmentTaskContext(schedulerCtx, w.ctx)
-	defer cancel()
-	if segmentTaskStopped(ctx, w.wal) {
-		return nil
+// do is the main loop of the segment flush worker.
+func (w *segmentFlushWorker) do() {
+	retryBackoff := backoff.NewExponentialBackOff()
+	retryBackoff.InitialInterval = 10 * time.Millisecond
+	retryBackoff.MaxInterval = time.Second
+	retryBackoff.MaxElapsedTime = 0
+	retryBackoff.Reset()
+
+	// The recovered segment assignment state does not include txnSem. Wait for
+	// recovered transactions before writing a Flush message, so all inserts stay
+	// ordered before the flush in the WAL.
+	if err := w.waitForTxnManagerRecoverDone(); err != nil {
+		w.Logger().Error(w.ctx, "failed to wait for txn manager recover ready", mlog.Err(err))
+		return
 	}
-	if !txnManagerRecovered(w.txnManager) {
-		return nodescheduler.ErrDelay
-	}
-	if !w.checkIfReady() {
-		return nodescheduler.ErrDelay
-	}
-	if err := w.doOnceWithContext(ctx); err != nil {
-		if segmentTaskStopped(ctx, w.wal) {
-			return nil
+
+	for {
+		err := w.doOnce()
+		if err == nil {
+			return
 		}
 		if status.AsStreamingError(err).IsUnrecoverable() {
-			return err
+			w.Logger().Warn(w.ctx, "flush growing segment with unrecoverable error, stop retrying", mlog.Err(err))
+			return
 		}
-		return nodescheduler.ErrDelay
+		nextInterval := retryBackoff.NextBackOff()
+		w.Logger().Info(w.ctx, "failed to flush growing segment, retrying", mlog.Duration("nextInterval", nextInterval), mlog.Err(err))
+		select {
+		case <-w.ctx.Done():
+			w.Logger().Info(w.ctx, "flush segment canceled", mlog.Err(w.ctx.Err()))
+			return
+		case <-w.wal.Available():
+			w.Logger().Warn(w.ctx, "wal is unavailable, stop flush segment")
+			return
+		case <-time.After(nextInterval):
+		}
 	}
-	return nil
 }
 
-func txnManagerRecovered(txnManager TxnManager) bool {
+// waitForTxnManagerRecoverDone waits until transaction recovery is complete.
+func (w *segmentFlushWorker) waitForTxnManagerRecoverDone() error {
 	select {
-	case <-txnManager.RecoverDone():
-		return true
-	default:
-		return false
+	case <-w.txnManager.RecoverDone():
+		return nil
+	case <-w.ctx.Done():
+		w.Logger().Info(w.ctx, "flush segment canceled", mlog.Err(w.ctx.Err()))
+		return w.ctx.Err()
+	case <-w.wal.Available():
+		return status.NewOnShutdownError("wal is unavailable")
 	}
 }
 
 // doOnce performs the flush operation once.
 func (w *segmentFlushWorker) doOnce() error {
-	return w.doOnceWithContext(w.ctx)
-}
-
-func (w *segmentFlushWorker) doOnceWithContext(ctx context.Context) error {
 	if !w.checkIfReady() {
 		return errDelayFlush
 	}
@@ -108,9 +124,9 @@ func (w *segmentFlushWorker) doOnceWithContext(ctx context.Context) error {
 		}).
 		WithBody(&message.FlushMessageBody{}).MustBuildMutable()
 
-	result, err := w.wal.Append(ctx, msg)
+	result, err := w.wal.Append(w.ctx, msg)
 	if err != nil {
-		w.Logger().Error(ctx, "failed to append flush message", mlog.FieldMessage(msg), mlog.Err(err))
+		w.Logger().Error(w.ctx, "failed to append flush message", mlog.FieldMessage(msg), mlog.Err(err))
 		return err
 	}
 	policy := w.segment.SealPolicy()
@@ -124,31 +140,6 @@ func (w *segmentFlushWorker) doOnceWithContext(ctx context.Context) error {
 		mlog.Uint64("timetick", result.TimeTick))
 	return nil
 }
-
-func mergeSegmentTaskContext(schedulerCtx, taskCtx context.Context) (context.Context, context.CancelFunc) {
-	if taskCtx == nil {
-		taskCtx = context.Background()
-	}
-	ctx, cancel := context.WithCancel(taskCtx)
-	stop := context.AfterFunc(schedulerCtx, cancel)
-	return ctx, func() {
-		stop()
-		cancel()
-	}
-}
-
-func segmentTaskStopped(ctx context.Context, wal wal.WAL) bool {
-	select {
-	case <-ctx.Done():
-		return true
-	case <-wal.Available():
-		return true
-	default:
-		return false
-	}
-}
-
-var _ nodescheduler.Task = (*segmentFlushWorker)(nil)
 
 // checkIfReady checks if the segments are ready to be flushed.
 func (w *segmentFlushWorker) checkIfReady() bool {

--- a/internal/streamingnode/server/wal/interceptors/shard/shards/segment_workers_test.go
+++ b/internal/streamingnode/server/wal/interceptors/shard/shards/segment_workers_test.go
@@ -7,7 +7,9 @@ import (
 	"context"
 	"sync/atomic"
 	"testing"
+	"time"
 
+	"github.com/bytedance/mockey"
 	"github.com/cockroachdb/errors"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/mock"
@@ -31,11 +33,11 @@ import (
 )
 
 type capturedShardScheduler struct {
-	tasks []nodescheduler.Task
+	tasks chan nodescheduler.Task
 }
 
 func (s *capturedShardScheduler) Submit(task nodescheduler.Task) nodescheduler.TaskHandle {
-	s.tasks = append(s.tasks, task)
+	s.tasks <- task
 	return noopShardTaskHandle{}
 }
 
@@ -45,11 +47,36 @@ func (noopShardTaskHandle) Cancel() {}
 
 func (noopShardTaskHandle) Wait(context.Context) error { return nil }
 
-func TestPartitionManagerSubmitsFlushAndAllocationToNodeScheduler(t *testing.T) {
+func runShardWorkerAndWait(t *testing.T, run func()) {
+	t.Helper()
+	done := make(chan struct{})
+	go func() {
+		run()
+		close(done)
+	}()
+	select {
+	case <-done:
+	case <-time.After(5 * time.Second):
+		t.Fatal("timeout waiting for segment worker to complete")
+	}
+}
+
+func TestPartitionManagerRunsFlushAndAllocationOutsideNodeScheduler(t *testing.T) {
 	paramtable.Init()
 	resource.InitForTest(t)
 
-	scheduler := &capturedShardScheduler{}
+	flushStarted := make(chan struct{}, 1)
+	flushMock := mockey.Mock((*segmentFlushWorker).do).To(func(*segmentFlushWorker) {
+		flushStarted <- struct{}{}
+	}).Build()
+	defer flushMock.UnPatch()
+	allocStarted := make(chan struct{}, 1)
+	allocMock := mockey.Mock((*segmentAllocWorker).do).To(func(*segmentAllocWorker) {
+		allocStarted <- struct{}{}
+	}).Build()
+	defer allocMock.UnPatch()
+
+	scheduler := &capturedShardScheduler{tasks: make(chan nodescheduler.Task, 2)}
 	walFuture := syncutil.NewFuture[wal.WAL]()
 	walFuture.Set(mock_wal.NewMockWAL(t))
 	channel := types.PChannelInfo{Name: "pchannel", Term: 1}
@@ -77,111 +104,21 @@ func TestPartitionManagerSubmitsFlushAndAllocationToNodeScheduler(t *testing.T) 
 	m.asyncFlushSegment(context.Background(), segment)
 	m.asyncAllocSegment(7, true)
 
-	require.Len(t, scheduler.tasks, 2)
-	assert.IsType(t, &segmentFlushWorker{}, scheduler.tasks[0])
-	assert.IsType(t, &segmentAllocWorker{}, scheduler.tasks[1])
-}
-
-func TestSegmentFlushWorkerExecuteUsesErrDelay(t *testing.T) {
-	paramtable.Init()
-	resource.InitForTest(t)
-	channel := types.PChannelInfo{Name: "pchannel", Term: 1}
-	operator := mock_utils.NewMockSealOperator(t)
-	operator.EXPECT().Channel().Return(channel)
-	operator.EXPECT().AsyncFlushSegment(mock.Anything).Return().Maybe()
-	resource.Resource().SegmentStatsManager().RegisterSealOperator(operator, nil, nil)
-
-	t.Run("txn recovery", func(t *testing.T) {
-		mockWAL := mock_wal.NewMockWAL(t)
-		mockWAL.EXPECT().Available().Return(make(chan struct{})).Maybe()
-		w := &segmentFlushWorker{
-			txnManager: &neverReadyTxnManager{},
-			ctx:        context.Background(),
-			wal:        mockWAL,
-		}
-		w.SetLogger(mlog.With())
-		require.ErrorIs(t, w.Execute(context.Background()), nodescheduler.ErrDelay)
-	})
-
-	t.Run("ack precondition", func(t *testing.T) {
-		segment := newTestSegmentAllocManager(channel, &message.CreateSegmentMessageHeader{
-			CollectionId:   1,
-			PartitionId:    2,
-			SegmentId:      1001,
-			MaxRows:        100,
-			MaxSegmentSize: 100,
-		}, 100)
-		result, err := segment.AllocRows(&AssignSegmentRequest{TimeTick: 101, ModifiedMetrics: stats.ModifiedMetrics{Rows: 1, BinarySize: 1}})
-		require.NoError(t, err)
-		defer result.Ack()
-		mockWAL := mock_wal.NewMockWAL(t)
-		mockWAL.EXPECT().Available().Return(make(chan struct{})).Maybe()
-		w := &segmentFlushWorker{
-			txnManager: &mockedTxnManager{},
-			ctx:        context.Background(),
-			segment:    segment,
-			wal:        mockWAL,
-		}
-		w.SetLogger(mlog.With())
-		require.ErrorIs(t, w.Execute(context.Background()), nodescheduler.ErrDelay)
-	})
-
-	t.Run("transient append", func(t *testing.T) {
-		segment := newTestSegmentAllocManager(channel, &message.CreateSegmentMessageHeader{
-			CollectionId:   1,
-			PartitionId:    2,
-			SegmentId:      1002,
-			MaxRows:        100,
-			MaxSegmentSize: 100,
-		}, 100)
-		segment.Flush(policy.PolicyCapacity())
-		mockWAL := mock_wal.NewMockWAL(t)
-		mockWAL.EXPECT().Available().Return(make(chan struct{})).Maybe()
-		mockWAL.EXPECT().Append(mock.Anything, mock.Anything).Return(nil, errors.New("temporary append failure")).Once()
-		w := &segmentFlushWorker{
-			txnManager: &mockedTxnManager{},
-			ctx:        context.Background(),
-			vchannel:   "v1",
-			segment:    segment,
-			wal:        mockWAL,
-		}
-		w.SetLogger(mlog.With())
-		require.ErrorIs(t, w.Execute(context.Background()), nodescheduler.ErrDelay)
-	})
-}
-
-func TestSegmentAllocWorkerExecuteRetriesAndPreservesConfiguration(t *testing.T) {
-	paramtable.Init()
-	resource.InitForTest(t)
-
-	var attempts atomic.Int32
-	mockWAL := mock_wal.NewMockWAL(t)
-	mockWAL.EXPECT().Available().Return(make(chan struct{})).Maybe()
-	mockWAL.EXPECT().Append(mock.Anything, mock.Anything).RunAndReturn(func(context.Context, message.MutableMessage) (*wal.AppendResult, error) {
-		if attempts.Add(1) == 1 {
-			return nil, errors.New("temporary append failure")
-		}
-		return &wal.AppendResult{MessageID: rmq.NewRmqID(100), TimeTick: 200}, nil
-	}).Twice()
-	w := &segmentAllocWorker{
-		ctx:          context.Background(),
-		collectionID: 1,
-		partitionID:  2,
-		vchannel:     "v1",
-		wal:          mockWAL,
+	select {
+	case <-flushStarted:
+	case <-time.After(5 * time.Second):
+		t.Fatal("flush worker was not started directly")
 	}
-	w.SetLogger(mlog.With())
-
-	require.ErrorIs(t, w.Execute(context.Background()), nodescheduler.ErrDelay)
-	segmentID := w.segmentID
-	storageVersion := w.storageVersion
-	limitation := w.limitation
-	require.NotZero(t, segmentID)
-
-	require.NoError(t, w.Execute(context.Background()))
-	assert.Equal(t, segmentID, w.segmentID)
-	assert.Equal(t, storageVersion, w.storageVersion)
-	assert.Equal(t, limitation, w.limitation)
+	select {
+	case <-allocStarted:
+	case <-time.After(5 * time.Second):
+		t.Fatal("allocation worker was not started directly")
+	}
+	select {
+	case task := <-scheduler.tasks:
+		t.Fatalf("unexpected NodeScheduler task %T", task)
+	default:
+	}
 }
 
 // TestSegmentFlushWorker_RetryAfterAppendFailure tests that the flush worker
@@ -486,9 +423,46 @@ func TestSegmentAllocWorkerStorageVersionFollowsRequirements(t *testing.T) {
 	}
 }
 
-func TestTxnManagerRecovered(t *testing.T) {
-	assert.True(t, txnManagerRecovered(&mockedTxnManager{}))
-	assert.False(t, txnManagerRecovered(&neverReadyTxnManager{}))
+func TestSegmentFlushWorkerWaitForTxnManagerRecoverDone(t *testing.T) {
+	t.Run("txn manager ready", func(t *testing.T) {
+		mockWAL := mock_wal.NewMockWAL(t)
+		mockWAL.EXPECT().Available().Return(make(chan struct{})).Maybe()
+		w := &segmentFlushWorker{
+			txnManager: &mockedTxnManager{},
+			ctx:        context.Background(),
+			wal:        mockWAL,
+		}
+		w.SetLogger(mlog.With())
+		require.NoError(t, w.waitForTxnManagerRecoverDone())
+	})
+
+	t.Run("context canceled", func(t *testing.T) {
+		ctx, cancel := context.WithCancel(context.Background())
+		cancel()
+		mockWAL := mock_wal.NewMockWAL(t)
+		mockWAL.EXPECT().Available().Return(make(chan struct{})).Maybe()
+		w := &segmentFlushWorker{
+			txnManager: &neverReadyTxnManager{},
+			ctx:        ctx,
+			wal:        mockWAL,
+		}
+		w.SetLogger(mlog.With())
+		require.ErrorIs(t, w.waitForTxnManagerRecoverDone(), context.Canceled)
+	})
+
+	t.Run("wal unavailable", func(t *testing.T) {
+		unavailable := make(chan struct{})
+		close(unavailable)
+		mockWAL := mock_wal.NewMockWAL(t)
+		mockWAL.EXPECT().Available().Return(unavailable).Maybe()
+		w := &segmentFlushWorker{
+			txnManager: &neverReadyTxnManager{},
+			ctx:        context.Background(),
+			wal:        mockWAL,
+		}
+		w.SetLogger(mlog.With())
+		require.Error(t, w.waitForTxnManagerRecoverDone())
+	})
 }
 
 // TestSegmentAllocWorker_DoLoop tests the main do loop
@@ -522,7 +496,7 @@ func TestSegmentAllocWorker_DoLoop(t *testing.T) {
 		}
 		w.SetLogger(mlog.With())
 
-		require.NoError(t, w.Execute(context.Background()))
+		runShardWorkerAndWait(t, w.do)
 	})
 
 	t.Run("context canceled during retry", func(t *testing.T) {
@@ -549,7 +523,7 @@ func TestSegmentAllocWorker_DoLoop(t *testing.T) {
 		}
 		w.SetLogger(mlog.With())
 
-		require.NoError(t, w.Execute(context.Background()))
+		runShardWorkerAndWait(t, w.do)
 	})
 }
 
@@ -601,7 +575,7 @@ func TestSegmentFlushWorker_DoLoop(t *testing.T) {
 		}
 		w.SetLogger(mlog.With())
 
-		require.NoError(t, w.Execute(context.Background()))
+		runShardWorkerAndWait(t, w.do)
 	})
 }
 
@@ -822,9 +796,7 @@ func TestSegmentAllocWorker_UnrecoverableError(t *testing.T) {
 	}
 	w.SetLogger(mlog.With())
 
-	err := w.Execute(context.Background())
-	require.Error(t, err)
-	assert.True(t, status.AsStreamingError(err).IsUnrecoverable())
+	runShardWorkerAndWait(t, w.do)
 }
 
 // TestSegmentFlushWorker_UnrecoverableError tests handling of unrecoverable errors
@@ -871,9 +843,7 @@ func TestSegmentFlushWorker_UnrecoverableError(t *testing.T) {
 	}
 	w.SetLogger(mlog.With())
 
-	err := w.Execute(context.Background())
-	require.Error(t, err)
-	assert.True(t, status.AsStreamingError(err).IsUnrecoverable())
+	runShardWorkerAndWait(t, w.do)
 }
 
 // TestSegmentAllocWorker_WALUnavailable tests handling when WAL becomes unavailable
@@ -906,7 +876,7 @@ func TestSegmentAllocWorker_WALUnavailable(t *testing.T) {
 	}
 	w.SetLogger(mlog.With())
 
-	require.NoError(t, w.Execute(context.Background()))
+	runShardWorkerAndWait(t, w.do)
 }
 
 // TestSegmentFlushWorker_ContextCanceledDuringRetry tests context cancellation during retry
@@ -954,7 +924,7 @@ func TestSegmentFlushWorker_ContextCanceledDuringRetry(t *testing.T) {
 	}
 	w.SetLogger(mlog.With())
 
-	require.NoError(t, w.Execute(context.Background()))
+	runShardWorkerAndWait(t, w.do)
 }
 
 // TestSegmentFlushWorker_TxnManagerRecoverFailed tests when txn manager recovery fails
@@ -998,7 +968,7 @@ func TestSegmentFlushWorker_TxnManagerRecoverFailed(t *testing.T) {
 	}
 	w.SetLogger(mlog.With())
 
-	require.NoError(t, w.Execute(context.Background()))
+	runShardWorkerAndWait(t, w.do)
 }
 
 // TestSegmentFlushWorker_WALUnavailableDuringRetry tests WAL unavailable during retry
@@ -1048,5 +1018,5 @@ func TestSegmentFlushWorker_WALUnavailableDuringRetry(t *testing.T) {
 	}
 	w.SetLogger(mlog.With())
 
-	require.NoError(t, w.Execute(context.Background()))
+	runShardWorkerAndWait(t, w.do)
 }

--- a/internal/streamingnode/server/wal/interceptors/shard/stats/stats_seal_worker_test.go
+++ b/internal/streamingnode/server/wal/interceptors/shard/stats/stats_seal_worker_test.go
@@ -9,22 +9,34 @@ import (
 	"github.com/milvus-io/milvus/internal/streamingnode/server/wal/interceptors/shard/policy"
 )
 
-func TestNotifySealSegmentDropsWhenQueueIsFull(t *testing.T) {
-	worker := &sealWorker{
-		sealNotifier: make(chan sealSegmentIDWithPolicy, 1),
-	}
-	worker.sealNotifier <- sealSegmentIDWithPolicy{
-		segmentID:  1,
-		sealPolicy: policy.PolicyCapacity(),
+func TestNotifySealSegmentKeepsPendingSealWhenNotifierIsFull(t *testing.T) {
+	worker := newSealWorker(nil)
+	worker.sealNotifier <- struct{}{}
+	expectedPolicy := policy.PolicyCapacity()
+
+	done := make(chan struct{})
+	go func() {
+		worker.NotifySealSegment(2, expectedPolicy)
+		close(done)
+	}()
+	select {
+	case <-done:
+	case <-time.After(time.Second):
+		t.Fatal("seal notification blocked when notifier was full")
 	}
 
-	worker.NotifySealSegment(2, policy.PolicyCapacity())
-	first := <-worker.sealNotifier
-	assert.Equal(t, int64(1), first.segmentID)
+	pending := worker.takePendingSeals()
+	assert.Len(t, pending, 1)
+	assert.Equal(t, expectedPolicy, pending[2])
 
 	select {
-	case notification := <-worker.sealNotifier:
-		t.Fatalf("received notification for segment %d after the full queue should have dropped it", notification.segmentID)
-	case <-time.After(200 * time.Millisecond):
+	case <-worker.sealNotifier:
+	default:
+		t.Fatal("missing existing seal worker wakeup")
+	}
+	select {
+	case <-worker.sealNotifier:
+		t.Fatal("full notifier should coalesce additional wakeups")
+	default:
 	}
 }

--- a/pkg/util/nodescheduler/scheduler_test.go
+++ b/pkg/util/nodescheduler/scheduler_test.go
@@ -459,7 +459,7 @@ func TestGlobalSchedulerLazyInitializationAndDynamicResize(t *testing.T) {
 	assert.Eventually(t, func() bool {
 		scheduler.mu.Lock()
 		defer scheduler.mu.Unlock()
-		return scheduler.concurrency == cpu
+		return scheduler.concurrency == 2*cpu
 	}, time.Second, 10*time.Millisecond)
 
 	ratioForTwoWorkers := 2 / float64(cpu)
@@ -480,7 +480,7 @@ func TestGlobalSchedulerLazyInitializationAndDynamicResize(t *testing.T) {
 	assert.Eventually(t, func() bool {
 		scheduler.mu.Lock()
 		defer scheduler.mu.Unlock()
-		return scheduler.concurrency == cpu
+		return scheduler.concurrency == 2*cpu
 	}, time.Second, 10*time.Millisecond)
 }
 

--- a/pkg/util/paramtable/component_param.go
+++ b/pkg/util/paramtable/component_param.go
@@ -1394,8 +1394,8 @@ If enabled, IPv6 ULA/global addresses will be prioritized ahead of IPv4.`,
 	p.NodeSchedulerMaxConcurrencyRatio = ParamItem{
 		Key:          "common.nodeScheduler.maxConcurrencyRatio",
 		Version:      "3.0",
-		DefaultValue: "1",
-		Doc:          "Maximum number of tasks executed concurrently by the process-level node scheduler, expressed as a ratio of CPU cores. Must be greater than zero.",
+		DefaultValue: "2",
+		Doc:          "Maximum number of tasks executed concurrently by the process-level node scheduler, expressed as a ratio of CPU cores. Must be greater than zero; 2 by default.",
 		Export:       true,
 	}
 	p.NodeSchedulerMaxConcurrencyRatio.Init(base.mgr)

--- a/pkg/util/paramtable/component_param_test.go
+++ b/pkg/util/paramtable/component_param_test.go
@@ -184,11 +184,11 @@ func TestComponentParam(t *testing.T) {
 		params.Save("common.sync.taskPoolReleaseTimeoutSeconds", "100")
 		assert.Equal(t, 100*time.Second, params.CommonCfg.SyncTaskPoolReleaseTimeoutSeconds.GetAsDuration(time.Second))
 
-		assert.Equal(t, 1.0, Params.NodeSchedulerMaxConcurrencyRatio.GetAsFloat())
+		assert.Equal(t, 2.0, Params.NodeSchedulerMaxConcurrencyRatio.GetAsFloat())
 		params.Save(Params.NodeSchedulerMaxConcurrencyRatio.Key, "0.5")
 		assert.Equal(t, 0.5, Params.NodeSchedulerMaxConcurrencyRatio.GetAsFloat())
 		params.Reset(Params.NodeSchedulerMaxConcurrencyRatio.Key)
-		assert.Equal(t, 1.0, Params.NodeSchedulerMaxConcurrencyRatio.GetAsFloat())
+		assert.Equal(t, 2.0, Params.NodeSchedulerMaxConcurrencyRatio.GetAsFloat())
 
 		assert.Equal(t, 1, params.CommonCfg.StorageZstdConcurrency.GetAsInt())
 		params.Save("common.storage.zstd.concurrency", "2")


### PR DESCRIPTION
issue: milvus-io/milvus#40451

- segment allocation and flush: restore dedicated goroutine workers with local retry and backoff so CreateSegment and Flush WAL writes no longer compete in NodeScheduler
- scheduler capacity: increase the default NodeScheduler maximum concurrency ratio from 1 to 2
- logging: reuse the pchannel-level logger in partition and segment workers while adding vchannel, collection, and partition fields only to emitted records
- seal notification regression: align the full-notifier test with qv pending-seal and coalesced-wakeup semantics