### PR TITLE
fix: reconcile released QueryView collections immediately

### DIFF
--- a/docs/design-docs/design_docs/qviews/balancer_design.md
+++ b/docs/design-docs/design_docs/qviews/balancer_design.md
@@ -30,10 +30,11 @@ DDL Callbacks (WAL message acknowledgment)
 │                        Balancer                              │
 │  • Work queue (deduplicated shard IDs)                       │
 │  • Single goroutine loop:                                    │
-│      1. Build BalancerSnapshot (global world view)           │
-│      2. Drain dirty shards                                   │
-│      3. policy.Plan(snapshot, dirty) → BalancePlan           │
-│      4. Apply plan (AddPreparing + ReleaseShardViews)        │
+│      1. Detach the pending trigger batch                     │
+│      2. Build BalancerSnapshot (global world view)           │
+│      3. Expand trigger scopes into dirty shards              │
+│      4. policy.Plan(snapshot, dirty) → BalancePlan           │
+│      5. Apply plan (AddPreparing + ReleaseShardViews)        │
 │  • Periodic ticker as fallback (full scan)                   │
 └────────────┬────────────────────────────┬────────────────────┘
              │ build snapshot              │ apply plan
@@ -66,7 +67,7 @@ DDL Callbacks (WAL message acknowledgment)
 
 - **Level-triggered reconciliation (Kubernetes controller pattern)**: Event sources with a notifier enqueue affected shard IDs via `Trigger(scope)`; the Balancer compares desired vs. current state and converges. The periodic full scan covers sources without a direct notifier and any missed event. Multiple enqueues for the same shard are deduplicated.
 - **Unified allocation algorithm**: A single BalancePolicy handles all scenarios. Scenario differences are encoded in input variations (available nodes, current view, data view), not separate algorithms. This prevents thrashing.
-- **Batch planning**: Each reconcile cycle builds a global snapshot, drains dirty shards, and asks the Policy for a complete plan. The Policy handles all dirty shards in one call, enabling cross-shard coordination (e.g., avoiding multiple shards targeting the same node).
+- **Batch planning**: Each reconcile cycle detaches the pending trigger batch, builds a global snapshot, expands the batch into dirty shards, and asks the Policy for a complete plan. The Policy handles all dirty shards in one call, enabling cross-shard coordination (e.g., avoiding multiple shards targeting the same node).
 - **External inputs as interfaces**: Node Manager, Replica Manager, and DataView Manager are external dependencies consumed via interfaces.
 - **Separated desired and actual state ownership**: `loadmgr` owns load-config lifecycle and desired-state snapshots; `coordview` owns actual QueryView state, shard-view aggregation, and actual-state snapshots. The Balancer composes both snapshots during reconciliation.
 
@@ -94,7 +95,7 @@ type TriggerScope struct {
 ```
 
 - `Trigger()` with no scopes triggers a full scan.
-- `Trigger(scope)` enqueues only affected shards (expanded from the latest load-config and shard-view snapshots).
+- `Trigger(scope)` records only the affected scope; the reconcile cycle expands it into shard IDs from its load-config and shard-view snapshots.
 - A periodic ticker (e.g., 10s) calls `Trigger()` as a safety net for missed events and steady-state balance checks.
 
 #### Main Loop
@@ -109,8 +110,13 @@ for {
         return
     }
 
+    pending := b.queue.TakePending()
+    if pending.Empty() {
+        continue
+    }
+
     snap  := b.buildSnapshot()
-    dirty := b.queue.Drain()
+    dirty := pending.Expand(snap)
     if len(dirty) == 0 {
         continue
     }
@@ -119,6 +125,11 @@ for {
     b.apply(ctx, plan)
 }
 ```
+
+`TakePending` establishes the reconcile-cycle boundary before snapshot
+construction. Triggers arriving during snapshot construction remain queued for
+the next cycle, so a trigger batch is expanded only against a snapshot built
+after that batch was detached from the queue.
 
 The loop is purely infrastructural: the Policy is where all business decisions happen.
 
@@ -840,11 +851,13 @@ rebuilding it per shard, or double-counting the replacement view.
 
 ```
 1. Node Manager detects QN3 crash → Trigger(NodeChanged: true)
-2. Balancer loop wakes and builds snapshot
-3. Meanwhile, Syncer's OnNodeLost marks affected views as Unrecoverable
-4. Balancer drains queue and expands dirty nodes by scanning snapshot shard stats → dirty = [A, B, C]
+2. Balancer loop wakes and detaches the pending full-scan trigger batch
+3. Balancer builds snapshot; QN3 is unavailable, and shard stats may already
+   reflect Syncer's OnNodeLost transitions
+4. Balancer expands the full-scan batch from the completed snapshot → dirty = [A, B, C]
 5. policy.Plan(snap, dirty):
-   Phase 1: each shard's current view references QN3 → all actionMust
+   Phase 1: each shard either references unavailable QN3 or is already
+            Unrecoverable → all actionMust
    Phase 2: order by size desc; for each shard:
      - QN3 is ineligible → its segments have no reusable location and receive
        neutral stickiness

--- a/internal/views/coord/balancer/balancer.go
+++ b/internal/views/coord/balancer/balancer.go
@@ -138,8 +138,14 @@ func (b *DefaultBalancer) Reconcile(ctx context.Context) error {
 	if b.snapshotBuilder == nil || b.viewRegistry == nil || b.policy == nil {
 		return nil
 	}
+	// Take this cycle's work before building the snapshot so triggers arriving
+	// during snapshot construction remain queued for the next cycle.
+	pending := b.queue.takePending()
+	if pending.empty() {
+		return nil
+	}
 	snap := b.snapshotBuilder.Build(ctx)
-	dirty := b.queue.drain(snap)
+	dirty := pending.expand(snap)
 	if len(dirty) == 0 {
 		return nil
 	}

--- a/internal/views/coord/balancer/balancer_test.go
+++ b/internal/views/coord/balancer/balancer_test.go
@@ -8,9 +8,23 @@ import (
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 
+	"github.com/milvus-io/milvus/internal/views/coord/loadmgr"
 	"github.com/milvus-io/milvus/internal/views/qviews"
 	"github.com/milvus-io/milvus/pkg/v3/proto/viewpb"
 )
+
+type testSnapshotSource struct {
+	snapshot     *BalancerSnapshot
+	afterCapture func()
+}
+
+func (s *testSnapshotSource) Build(context.Context) *BalancerSnapshot {
+	snapshot := s.snapshot
+	if s.afterCapture != nil {
+		s.afterCapture()
+	}
+	return snapshot
+}
 
 func TestBalancer_ReconcileDirtyShardAppliesPrepare(t *testing.T) {
 	const collID, replicaID int64 = 1, 10
@@ -85,6 +99,52 @@ func TestBalancer_ReconcileDirtyCollectionExpandsTrackedShards(t *testing.T) {
 
 	stats := reg.Get(shardID).Stats()
 	assert.NotNil(t, stats.PreparingVersion)
+}
+
+func TestBalancer_ReconcilePreservesTriggerArrivingDuringSnapshotBuild(t *testing.T) {
+	const collID, replicaID int64 = 1, 10
+	shardID := qviews.ShardID{
+		ReplicaID: replicaID,
+		VChannel:  "by-dev-rootcoord-dml_0_1v0",
+	}
+
+	reg := emptyRegistry(t)
+	addShardWithPreparingView(t, reg, shardID, map[int64]map[int64][]int64{
+		1: {100: {101}},
+	})
+
+	viewSnapshot := reg.Snapshot()
+	source := &testSnapshotSource{
+		snapshot: &BalancerSnapshot{
+			LoadConfigSnapshot: loadmgr.NewLoadConfigSnapshot(1, map[int64]*loadmgr.LoadConfig{
+				collID: cfgFor(collID, replicaID, nil, nil),
+			}),
+			ShardViewSnapshot: viewSnapshot,
+		},
+	}
+	b := &DefaultBalancer{
+		snapshotBuilder: source,
+		viewRegistry:    reg,
+		policy:          NewDefaultBalancePolicy(),
+		queue:           newTriggerQueue(),
+	}
+	source.afterCapture = func() {
+		source.afterCapture = nil
+		source.snapshot = &BalancerSnapshot{
+			LoadConfigSnapshot: loadmgr.NewLoadConfigSnapshot(2, map[int64]*loadmgr.LoadConfig{}),
+			ShardViewSnapshot:  viewSnapshot,
+		}
+		b.Trigger(TriggerScope{DirtyCollections: []int64{collID}})
+	}
+
+	b.Trigger(TriggerScope{DirtyShards: []qviews.ShardID{shardID}})
+	require.NoError(t, b.Reconcile(context.Background()))
+	require.NotNil(t, reg.Get(shardID).Stats().PreparingVersion)
+
+	require.NoError(t, b.Reconcile(context.Background()))
+	stats := reg.Get(shardID).Stats()
+	assert.Nil(t, stats.PreparingVersion)
+	assert.Empty(t, stats.Segments)
 }
 
 func TestBalancer_NodeChangedNotifierTriggersFullScan(t *testing.T) {

--- a/internal/views/coord/balancer/trigger.go
+++ b/internal/views/coord/balancer/trigger.go
@@ -5,6 +5,7 @@ import (
 	"sync"
 
 	"github.com/milvus-io/milvus/internal/views/qviews"
+	"github.com/milvus-io/milvus/pkg/v3/util/funcutil"
 )
 
 // TriggerScope describes the external event scope that dirtied the Balancer.
@@ -28,6 +29,17 @@ type triggerQueue struct {
 	dirtyColls  map[int64]struct{}
 
 	signal chan struct{}
+}
+
+type triggerBatch struct {
+	full        bool
+	dirtyNodes  map[int64]struct{}
+	dirtyShards map[qviews.ShardID]struct{}
+	dirtyColls  map[int64]struct{}
+}
+
+func (b triggerBatch) empty() bool {
+	return !b.full && len(b.dirtyNodes) == 0 && len(b.dirtyShards) == 0 && len(b.dirtyColls) == 0
 }
 
 func newTriggerQueue() *triggerQueue {
@@ -77,27 +89,26 @@ func (q *triggerQueue) signalCh() <-chan struct{} {
 	return q.signal
 }
 
-func (q *triggerQueue) drain(snap *BalancerSnapshot) []qviews.ShardID {
-	full, dirtyNodes, dirtyShards, dirtyColls := q.takePending()
+func (b triggerBatch) expand(snap *BalancerSnapshot) []qviews.ShardID {
 	if snap == nil {
 		return nil
 	}
 
 	out := make(map[qviews.ShardID]struct{})
-	if full {
+	if b.full {
 		for _, shardID := range allSnapshotShards(snap) {
 			out[shardID] = struct{}{}
 		}
 	}
-	for shardID := range dirtyShards {
+	for shardID := range b.dirtyShards {
 		out[shardID] = struct{}{}
 	}
-	for nodeID := range dirtyNodes {
+	for nodeID := range b.dirtyNodes {
 		for _, shardID := range snapshotShardsByNode(snap, nodeID) {
 			out[shardID] = struct{}{}
 		}
 	}
-	for collectionID := range dirtyColls {
+	for collectionID := range b.dirtyColls {
 		for _, shardID := range snapshotShardsByCollection(snap, collectionID) {
 			out[shardID] = struct{}{}
 		}
@@ -113,25 +124,22 @@ func (q *triggerQueue) drain(snap *BalancerSnapshot) []qviews.ShardID {
 	return shards
 }
 
-func (q *triggerQueue) takePending() (
-	bool,
-	map[int64]struct{},
-	map[qviews.ShardID]struct{},
-	map[int64]struct{},
-) {
+func (q *triggerQueue) takePending() triggerBatch {
 	q.mu.Lock()
 	defer q.mu.Unlock()
 
-	full := q.full
-	dirtyNodes := q.dirtyNodes
-	dirtyShards := q.dirtyShards
-	dirtyColls := q.dirtyColls
+	pending := triggerBatch{
+		full:        q.full,
+		dirtyNodes:  q.dirtyNodes,
+		dirtyShards: q.dirtyShards,
+		dirtyColls:  q.dirtyColls,
+	}
 
 	q.full = false
 	q.dirtyNodes = make(map[int64]struct{})
 	q.dirtyShards = make(map[qviews.ShardID]struct{})
 	q.dirtyColls = make(map[int64]struct{})
-	return full, dirtyNodes, dirtyShards, dirtyColls
+	return pending
 }
 
 func allSnapshotShards(snap *BalancerSnapshot) []qviews.ShardID {
@@ -175,7 +183,15 @@ func snapshotShardsByNode(snap *BalancerSnapshot, nodeID int64) []qviews.ShardID
 func snapshotShardsByCollection(snap *BalancerSnapshot, collectionID int64) []qviews.ShardID {
 	seen := make(map[qviews.ShardID]struct{})
 	for shardID := range snap.ShardStatsMap() {
-		if cfg := snap.ConfigForShard(shardID); cfg != nil && cfg.CollectionID == collectionID {
+		cfg := snap.ConfigForShard(shardID)
+		if cfg != nil && cfg.CollectionID == collectionID {
+			seen[shardID] = struct{}{}
+			continue
+		}
+		// ReleaseCollection removes the load config before triggering the
+		// collection reconcile. Recover the collection from the vchannel so
+		// residual shard views are released without waiting for a full scan.
+		if cfg == nil && funcutil.GetCollectionIDFromVChannel(shardID.VChannel) == collectionID {
 			seen[shardID] = struct{}{}
 		}
 	}

--- a/internal/views/coord/balancer/trigger_test.go
+++ b/internal/views/coord/balancer/trigger_test.go
@@ -28,8 +28,8 @@ func TestTriggerQueueDirtyNodeExpandsOnlyAffectedShards(t *testing.T) {
 	queue := newTriggerQueue()
 	queue.add(TriggerScope{DirtyNodes: []int64{10, 10}})
 
-	assert.Equal(t, []qviews.ShardID{shardA}, queue.drain(snap))
-	assert.Empty(t, queue.drain(snap), "drain must clear the pending node set")
+	assert.Equal(t, []qviews.ShardID{shardA}, queue.takePending().expand(snap))
+	assert.Empty(t, queue.takePending().expand(snap), "takePending must clear the pending node set")
 }
 
 func TestTriggerQueueNilSnapshotDropsPendingWork(t *testing.T) {
@@ -40,6 +40,22 @@ func TestTriggerQueueNilSnapshotDropsPendingWork(t *testing.T) {
 		DirtyCollections: []int64{10},
 	})
 
-	assert.Nil(t, queue.drain(nil))
-	assert.Empty(t, queue.drain(&BalancerSnapshot{}))
+	assert.Nil(t, queue.takePending().expand(nil))
+	assert.Empty(t, queue.takePending().expand(&BalancerSnapshot{}))
+}
+
+func TestTriggerBatchExpandReleasedCollectionIncludesResidualShards(t *testing.T) {
+	const collectionID int64 = 1
+	residualShard := qviews.ShardID{ReplicaID: 10, VChannel: "by-dev-rootcoord-dml_0_1v0"}
+	unrelatedShard := qviews.ShardID{ReplicaID: 20, VChannel: "by-dev-rootcoord-dml_0_2v0"}
+	snap := &BalancerSnapshot{
+		ShardViewSnapshot: coordview.NewShardViewSnapshot(1, map[qviews.ShardID]*coordview.ShardStats{
+			residualShard:  testShardStats(nil, 0),
+			unrelatedShard: testShardStats(nil, 0),
+		}),
+	}
+
+	pending := triggerBatch{dirtyColls: map[int64]struct{}{collectionID: {}}}
+
+	assert.Equal(t, []qviews.ShardID{residualShard}, pending.expand(snap))
 }


### PR DESCRIPTION
## What problem does this solve?

`ReleaseCollection` removes the collection LoadConfig before enqueueing a dirty-collection trigger. The balancer previously expanded that trigger only through LoadConfig ownership, so after the config was deleted it could no longer map residual shard views back to the released collection. The immediate reconcile then did no work, and cleanup could be delayed until the next periodic full scan (10 seconds by default), which did not match the QueryView design.

There was also a reconcile-cycle race: the balancer built a snapshot before draining the trigger queue. A trigger arriving during snapshot construction could therefore be drained and expanded against a snapshot that predates the event, then be lost instead of being retried with a fresh snapshot.

## What does this change do?

- Detaches the pending trigger batch before snapshot construction, then expands that fixed batch against the completed snapshot.
- Keeps triggers arriving during snapshot construction queued for the next reconcile cycle.
- When a released shard no longer has a LoadConfig, recovers its collection ID from the canonical vchannel name so the dirty-collection trigger still includes residual shard views.
- Updates the balancer design document to describe the reconcile-cycle boundary.
- Adds focused coverage for residual-shard expansion and deterministic coverage for a trigger arriving during snapshot construction.

## Verification

```text
source scripts/setenv.sh
go test -count=1 -tags dynamic,test -gcflags="all=-N -l" ./internal/views/coord/... -timeout 300s
```

issue: https://github.com/milvus-io/milvus/issues/40451