### PR TITLE
enhance: reduce streaming node recovery allocations

### DIFF
--- a/internal/storage/serde.go
+++ b/internal/storage/serde.go
@@ -1366,6 +1366,86 @@ func NewSimpleArrowRecord(r arrow.Record, field2Col map[FieldID]int) *simpleArro
 	}
 }
 
+func appendTypedFieldData(builder array.Builder, fieldData FieldData) (bool, error) {
+	validity := func(nullable bool, valid []bool) []bool {
+		if nullable {
+			return valid
+		}
+		return nil
+	}
+	switch data := fieldData.(type) {
+	case *BoolFieldData:
+		b, ok := builder.(*array.BooleanBuilder)
+		if !ok {
+			return true, merr.WrapErrServiceInternalMsg("expected *array.BooleanBuilder, got %T", builder)
+		}
+		b.AppendValues(data.Data, validity(data.Nullable, data.ValidData))
+	case *Int8FieldData:
+		b, ok := builder.(*array.Int8Builder)
+		if !ok {
+			return true, merr.WrapErrServiceInternalMsg("expected *array.Int8Builder, got %T", builder)
+		}
+		b.AppendValues(data.Data, validity(data.Nullable, data.ValidData))
+	case *Int16FieldData:
+		b, ok := builder.(*array.Int16Builder)
+		if !ok {
+			return true, merr.WrapErrServiceInternalMsg("expected *array.Int16Builder, got %T", builder)
+		}
+		b.AppendValues(data.Data, validity(data.Nullable, data.ValidData))
+	case *Int32FieldData:
+		b, ok := builder.(*array.Int32Builder)
+		if !ok {
+			return true, merr.WrapErrServiceInternalMsg("expected *array.Int32Builder, got %T", builder)
+		}
+		b.AppendValues(data.Data, validity(data.Nullable, data.ValidData))
+	case *Int64FieldData:
+		b, ok := builder.(*array.Int64Builder)
+		if !ok {
+			return true, merr.WrapErrServiceInternalMsg("expected *array.Int64Builder, got %T", builder)
+		}
+		b.AppendValues(data.Data, validity(data.Nullable, data.ValidData))
+	case *TimestamptzFieldData:
+		b, ok := builder.(*array.Int64Builder)
+		if !ok {
+			return true, merr.WrapErrServiceInternalMsg("expected *array.Int64Builder, got %T", builder)
+		}
+		b.AppendValues(data.Data, validity(data.Nullable, data.ValidData))
+	case *FloatFieldData:
+		b, ok := builder.(*array.Float32Builder)
+		if !ok {
+			return true, merr.WrapErrServiceInternalMsg("expected *array.Float32Builder, got %T", builder)
+		}
+		b.AppendValues(data.Data, validity(data.Nullable, data.ValidData))
+	case *DoubleFieldData:
+		b, ok := builder.(*array.Float64Builder)
+		if !ok {
+			return true, merr.WrapErrServiceInternalMsg("expected *array.Float64Builder, got %T", builder)
+		}
+		b.AppendValues(data.Data, validity(data.Nullable, data.ValidData))
+	case *StringFieldData:
+		b, ok := builder.(*array.StringBuilder)
+		if !ok {
+			return true, merr.WrapErrServiceInternalMsg("expected *array.StringBuilder, got %T", builder)
+		}
+		b.AppendValues(data.Data, validity(data.Nullable, data.ValidData))
+	case *JSONFieldData:
+		b, ok := builder.(*array.BinaryBuilder)
+		if !ok {
+			return true, merr.WrapErrServiceInternalMsg("expected *array.BinaryBuilder, got %T", builder)
+		}
+		b.AppendValues(data.Data, validity(data.Nullable, data.ValidData))
+	case *GeometryFieldData:
+		b, ok := builder.(*array.BinaryBuilder)
+		if !ok {
+			return true, merr.WrapErrServiceInternalMsg("expected *array.BinaryBuilder, got %T", builder)
+		}
+		b.AppendValues(data.Data, validity(data.Nullable, data.ValidData))
+	default:
+		return false, nil
+	}
+	return true, nil
+}
+
 func BuildRecord(b *array.RecordBuilder, data *InsertData, schema *schemapb.CollectionSchema) error {
 	if data == nil {
 		return nil
@@ -1385,6 +1465,9 @@ func BuildRecord(b *array.RecordBuilder, data *InsertData, schema *schemapb.Coll
 
 		if fieldData.RowNum() == 0 {
 			return merr.WrapErrServiceInternalMsg("row num is 0 for field %s", field.Name)
+		}
+		if handled, err := appendTypedFieldData(fBuilder, fieldData); handled {
+			return err
 		}
 
 		// Get element type for ArrayOfVector, otherwise use None

--- a/internal/storage/serde_test.go
+++ b/internal/storage/serde_test.go
@@ -128,6 +128,22 @@ func TestSerDe(t *testing.T) {
 	}
 }
 
+func TestAppendTypedFieldDataDoesNotAllocatePerInt64Row(t *testing.T) {
+	const rows = 1024
+	builder := array.NewInt64Builder(memory.DefaultAllocator)
+	defer builder.Release()
+	builder.Reserve(rows * 100)
+	fieldData := &Int64FieldData{Data: make([]int64, rows)}
+
+	allocs := testing.AllocsPerRun(100, func() {
+		handled, err := appendTypedFieldData(builder, fieldData)
+		if err != nil || !handled {
+			panic("typed field data was not appended")
+		}
+	})
+	assert.Zero(t, allocs)
+}
+
 func TestSerDeCopy(t *testing.T) {
 	tests := []struct {
 		name string

--- a/internal/storage/stats.go
+++ b/internal/storage/stats.go
@@ -147,12 +147,21 @@ func (stats *PrimaryKeyStats) UpdateByMsgs(msgs FieldData) {
 			return
 		}
 
-		b := make([]byte, 8)
+		minValue, maxValue := data[0], data[0]
+		var buffer [8]byte
 		for _, int64Value := range data {
-			pk := NewInt64PrimaryKey(int64Value)
-			stats.UpdateMinMax(pk)
-			common.Endian.PutUint64(b, uint64(int64Value))
-			stats.BF.Add(b)
+			if int64Value < minValue {
+				minValue = int64Value
+			}
+			if int64Value > maxValue {
+				maxValue = int64Value
+			}
+			common.Endian.PutUint64(buffer[:], uint64(int64Value))
+			stats.BF.Add(buffer[:])
+		}
+		stats.UpdateMinMax(NewInt64PrimaryKey(minValue))
+		if maxValue != minValue {
+			stats.UpdateMinMax(NewInt64PrimaryKey(maxValue))
 		}
 	case schemapb.DataType_VarChar:
 		data := msgs.(*StringFieldData).Data
@@ -161,10 +170,19 @@ func (stats *PrimaryKeyStats) UpdateByMsgs(msgs FieldData) {
 			return
 		}
 
+		minValue, maxValue := data[0], data[0]
 		for _, str := range data {
-			pk := NewVarCharPrimaryKey(str)
-			stats.UpdateMinMax(pk)
+			if str < minValue {
+				minValue = str
+			}
+			if str > maxValue {
+				maxValue = str
+			}
 			stats.BF.AddString(str)
+		}
+		stats.UpdateMinMax(NewVarCharPrimaryKey(minValue))
+		if maxValue != minValue {
+			stats.UpdateMinMax(NewVarCharPrimaryKey(maxValue))
 		}
 	default:
 		// TODO::

--- a/internal/storage/stats_test.go
+++ b/internal/storage/stats_test.go
@@ -65,6 +65,21 @@ func TestStatsWriter_Int64PrimaryKey(t *testing.T) {
 	assert.NoError(t, err)
 }
 
+func TestPrimaryKeyStatsUpdateByMsgsAllocatesOnlyFinalMinMax(t *testing.T) {
+	paramtable.Init()
+	stats, err := NewPrimaryKeyStats(100, int64(schemapb.DataType_Int64), 1024)
+	assert.NoError(t, err)
+	data := &Int64FieldData{Data: make([]int64, 1024)}
+	for i := range data.Data {
+		data.Data[i] = int64(i)
+	}
+
+	allocs := testing.AllocsPerRun(10, func() {
+		stats.UpdateByMsgs(data)
+	})
+	assert.Less(t, allocs, float64(10))
+}
+
 func TestStatsWriter_BF(t *testing.T) {
 	value := make([]int64, 1000000)
 	for i := 0; i < 1000000; i++ {

--- a/internal/streamingnode/server/wal/adaptor/opener.go
+++ b/internal/streamingnode/server/wal/adaptor/opener.go
@@ -241,8 +241,14 @@ func (o *openerAdaptorImpl) openRWWAL(ctx context.Context, l walimpls.WALImpls, 
 	if resMgr == nil {
 		return nil, errors.New("recovered vchannel manager is nil")
 	}
-	for vchannel := range snapshot.VChannels {
-		param.MVCCManager.ApplyRecoveryBarrier(vchannel, param.LastTimeTickMessage.TimeTick())
+	if snapshot.WritePathRecovery != nil {
+		for vchannel := range snapshot.WritePathRecovery.VChannels {
+			param.MVCCManager.ApplyRecoveryBarrier(vchannel, param.LastTimeTickMessage.TimeTick())
+		}
+	} else {
+		for vchannel := range snapshot.VChannels {
+			param.MVCCManager.ApplyRecoveryBarrier(vchannel, param.LastTimeTickMessage.TimeTick())
+		}
 	}
 	snHandler := snview.RecoverPChannelSNQueryViewHandler(opt.Channel.Name, queryViewCatalog, resMgr, persistedViews)
 
@@ -258,11 +264,12 @@ func (o *openerAdaptorImpl) openRWWAL(ctx context.Context, l walimpls.WALImpls, 
 	param.InitialRecoverSnapshot = snapshot
 	param.TxnManager = txn.NewTxnManager(param.ChannelInfo, snapshot.TxnBuffer.GetUncommittedMessageBuilder())
 	param.ShardManager = shards.RecoverShardManager(&shards.ShardManagerRecoverParam{
-		ChannelInfo:            param.ChannelInfo,
-		WAL:                    param.WAL,
-		Scheduler:              nodescheduler.Get(),
-		InitialRecoverSnapshot: snapshot,
-		TxnManager:             param.TxnManager,
+		ChannelInfo:        param.ChannelInfo,
+		WAL:                param.WAL,
+		Scheduler:          nodescheduler.Get(),
+		WritePathRecovery:  snapshot.WritePathRecovery,
+		CheckpointTimeTick: snapshot.Checkpoint.TimeTick,
+		TxnManager:         param.TxnManager,
 	})
 	// Load salvage checkpoints from etcd (one per source cluster that was force-promoted from).
 	var salvageCheckpoints []*utility.ReplicateCheckpoint

--- a/internal/streamingnode/server/wal/adaptor/recovery_snapshot_test.go
+++ b/internal/streamingnode/server/wal/adaptor/recovery_snapshot_test.go
@@ -1,0 +1,20 @@
+package adaptor
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+
+	"github.com/milvus-io/milvus/internal/streamingnode/server/wal/interceptors"
+	"github.com/milvus-io/milvus/internal/streamingnode/server/wal/recovery"
+)
+
+func TestBuildInterceptorsReleasesInitialRecoverySnapshot(t *testing.T) {
+	param := &interceptors.InterceptorBuildParam{
+		InitialRecoverSnapshot: &recovery.RecoverySnapshot{},
+	}
+	result := buildInterceptorsAndReleaseInitialSnapshot(nil, param)
+	t.Cleanup(result.Close)
+
+	assert.Nil(t, param.InitialRecoverSnapshot)
+}

--- a/internal/streamingnode/server/wal/adaptor/wal_adaptor.go
+++ b/internal/streamingnode/server/wal/adaptor/wal_adaptor.go
@@ -81,13 +81,14 @@ func adaptImplsToRWWAL(
 		panic("wal should be read-write")
 	}
 	// build append interceptor for a wal.
+	interceptorBuildResult := buildInterceptorsAndReleaseInitialSnapshot(builders, interceptorParam)
 	wal := &walAdaptorImpl{
 		roWALAdaptorImpl: roWAL,
 		rwWALImpls:       roWAL.roWALImpls.(walimpls.WALImpls),
 		// TODO: remove the pool, use a queue instead.
 		appendExecutionPool:    conc.NewPool[struct{}](0),
 		param:                  interceptorParam,
-		interceptorBuildResult: buildInterceptor(builders, interceptorParam),
+		interceptorBuildResult: interceptorBuildResult,
 		writeMetrics:           metricsutil.NewWriteMetrics(roWAL.Channel(), roWAL.WALName()),
 		isFenced:               atomic.NewBool(false),
 		appendRateCounter:      utility.NewAverageRateCounter(10 * time.Second), // 10 second sliding window
@@ -656,4 +657,13 @@ func buildInterceptor(builders []interceptors.InterceptorBuilder, param *interce
 			}
 		},
 	}
+}
+
+func buildInterceptorsAndReleaseInitialSnapshot(
+	builders []interceptors.InterceptorBuilder,
+	param *interceptors.InterceptorBuildParam,
+) interceptorBuildResult {
+	result := buildInterceptor(builders, param)
+	param.InitialRecoverSnapshot = nil
+	return result
 }

--- a/internal/streamingnode/server/wal/interceptors/shard/shards/partition_manager.go
+++ b/internal/streamingnode/server/wal/interceptors/shard/shards/partition_manager.go
@@ -16,6 +16,12 @@ import (
 	"github.com/milvus-io/milvus/pkg/v3/util/syncutil"
 )
 
+var partitionReady = func() <-chan struct{} {
+	ready := make(chan struct{})
+	close(ready)
+	return ready
+}()
+
 // newPartitionSegmentManager creates a new partition segment assign manager.
 func newPartitionSegmentManager(
 	ctx context.Context,
@@ -82,6 +88,9 @@ func (m *partitionManager) AddSegment(s *segmentAllocManager) {
 	if s.CreateSegmentTimeTick() <= m.fencedAssignTimeTick {
 		panic("critical bug: create segment time tick is less than fenced assign time tick")
 	}
+	if m.segments == nil {
+		m.segments = make(map[int64]*segmentAllocManager)
+	}
 	m.segments[s.GetSegmentID()] = s
 	m.metrics.ObserveCreateSegment()
 }
@@ -109,9 +118,7 @@ func (m *partitionManager) WaitPendingGrowingSegmentReady() <-chan struct{} {
 	if m.onAllocating != nil {
 		return m.onAllocating
 	}
-	ready := make(chan struct{})
-	close(ready)
-	return ready
+	return partitionReady
 }
 
 // FlushAndDropPartition flushes all segments in the partition.
@@ -133,7 +140,7 @@ func (m *partitionManager) FlushAndDropPartition(policy policy.SealPolicy) []int
 		)
 		segmentIDs = append(segmentIDs, segment.GetSegmentID())
 	}
-	m.segments = make(map[int64]*segmentAllocManager)
+	m.segments = nil
 	return segmentIDs
 }
 
@@ -155,7 +162,7 @@ func (m *partitionManager) FlushAndFenceSegmentUntil(timeTick uint64) []int64 {
 		)
 		segmentIDs = append(segmentIDs, segment.GetSegmentID())
 	}
-	m.segments = make(map[int64]*segmentAllocManager)
+	m.segments = nil
 
 	// fence the assign operation until the incoming time tick or latest assigned timetick.
 	// The new incoming assignment request will be fenced.

--- a/internal/streamingnode/server/wal/interceptors/shard/shards/segment_manager.go
+++ b/internal/streamingnode/server/wal/interceptors/shard/shards/segment_manager.go
@@ -2,16 +2,32 @@ package shards
 
 import (
 	"go.uber.org/atomic"
+	"google.golang.org/protobuf/proto"
 
 	"github.com/milvus-io/milvus/internal/streamingnode/server/resource"
 	"github.com/milvus-io/milvus/internal/streamingnode/server/wal/interceptors/shard/policy"
 	"github.com/milvus-io/milvus/internal/streamingnode/server/wal/interceptors/shard/stats"
 	"github.com/milvus-io/milvus/internal/streamingnode/server/wal/interceptors/shard/utils"
+	"github.com/milvus-io/milvus/internal/streamingnode/server/wal/moduleapi"
 	"github.com/milvus-io/milvus/pkg/v3/proto/streamingpb"
 	"github.com/milvus-io/milvus/pkg/v3/streaming/util/message"
 	"github.com/milvus-io/milvus/pkg/v3/streaming/util/types"
 	"github.com/milvus-io/milvus/pkg/v3/util/tsoutil"
 )
+
+func newSegmentAllocManagerFromRecovery(pchannel types.PChannelInfo, state moduleapi.SegmentWritePathRecoveryState) *segmentAllocManager {
+	meta := &streamingpb.SegmentAssignmentMeta{
+		CollectionId: state.CollectionID,
+		PartitionId:  state.PartitionID,
+		SegmentId:    state.SegmentID,
+		Vchannel:     state.VChannel,
+		State:        streamingpb.SegmentAssignmentState_SEGMENT_ASSIGNMENT_STATE_GROWING,
+	}
+	if state.Stat != nil {
+		meta.Stat = proto.Clone(state.Stat).(*streamingpb.SegmentAssignmentStat)
+	}
+	return newSegmentAllocManagerFromProto(pchannel, meta)
+}
 
 // newSegmentAllocManagerFromProto creates a new segment assignment meta from proto.
 // if the segment is growing, the stat should be registered to stats manager,
@@ -24,8 +40,6 @@ func newSegmentAllocManagerFromProto(pchannel types.PChannelInfo, inner *streami
 	return &segmentAllocManager{
 		pchannel: pchannel,
 		inner:    inner,
-		ackSem:   atomic.NewInt32(0),
-		txnSem:   atomic.NewInt32(0),
 	}
 }
 
@@ -44,8 +58,6 @@ func newSegmentAllocManager(pchannel types.PChannelInfo, msg message.ImmutableCr
 	return &segmentAllocManager{
 		pchannel: pchannel,
 		inner:    meta,
-		ackSem:   atomic.NewInt32(0),
-		txnSem:   atomic.NewInt32(0),
 	}
 }
 
@@ -79,8 +91,8 @@ func newSegmentAssignmentMetaFromCreateSegmentMessage(msg message.ImmutableCreat
 type segmentAllocManager struct {
 	pchannel types.PChannelInfo
 	inner    *streamingpb.SegmentAssignmentMeta
-	ackSem   *atomic.Int32 // the ackSem is increased when segment allocRows, decreased when the segment is acked.
-	txnSem   *atomic.Int32 // the running txn count of the segment, !!! it's lost after wal recovery.
+	ackSem   atomic.Int32 // the ackSem is increased when segment allocRows, decreased when the segment is acked.
+	txnSem   atomic.Int32 // the running txn count of the segment, !!! it's lost after wal recovery.
 
 	// only can be seen after the segment is flushed.
 	flushedStats *stats.SegmentStats
@@ -190,6 +202,6 @@ func (s *segmentAllocManager) AllocRows(req *AssignSegmentRequest) (*AssignSegme
 	// persist stats if too dirty.
 	return &AssignSegmentResult{
 		SegmentID:   s.GetSegmentID(),
-		Acknowledge: s.ackSem,
+		Acknowledge: &s.ackSem,
 	}, nil
 }

--- a/internal/streamingnode/server/wal/interceptors/shard/shards/shard_manager.go
+++ b/internal/streamingnode/server/wal/interceptors/shard/shards/shard_manager.go
@@ -16,6 +16,7 @@ import (
 	"github.com/milvus-io/milvus/internal/streamingnode/server/wal/interceptors/shard/stats"
 	"github.com/milvus-io/milvus/internal/streamingnode/server/wal/interceptors/shard/utils"
 	"github.com/milvus-io/milvus/internal/streamingnode/server/wal/metricsutil"
+	"github.com/milvus-io/milvus/internal/streamingnode/server/wal/moduleapi"
 	"github.com/milvus-io/milvus/internal/streamingnode/server/wal/recovery"
 	"github.com/milvus-io/milvus/pkg/v3/common"
 	"github.com/milvus-io/milvus/pkg/v3/mlog"
@@ -52,38 +53,49 @@ var (
 
 // ShardManagerRecoverParam is the parameter for recovering the segment assignment manager.
 type ShardManagerRecoverParam struct {
-	ChannelInfo            types.PChannelInfo
-	WAL                    *syncutil.Future[wal.WAL]
-	Scheduler              nodescheduler.Scheduler
+	ChannelInfo        types.PChannelInfo
+	WAL                *syncutil.Future[wal.WAL]
+	Scheduler          nodescheduler.Scheduler
+	WritePathRecovery  *moduleapi.WritePathRecoveryModuleSnapshot
+	CheckpointTimeTick uint64
+	// InitialRecoverSnapshot is kept for compatibility with existing callers.
+	// Production recovery passes WritePathRecovery instead.
 	InitialRecoverSnapshot *recovery.RecoverySnapshot
 	TxnManager             TxnManager
 }
 
 // RecoverShardManager recovers the segment assignment manager from the recovery snapshot.
 func RecoverShardManager(param *ShardManagerRecoverParam) ShardManager {
+	writePathRecovery := param.WritePathRecovery
+	checkpointTimeTick := param.CheckpointTimeTick
+	if writePathRecovery == nil {
+		writePathRecovery = writePathRecoveryFromLegacySnapshot(param.InitialRecoverSnapshot)
+		if param.InitialRecoverSnapshot != nil && param.InitialRecoverSnapshot.Checkpoint != nil {
+			checkpointTimeTick = param.InitialRecoverSnapshot.Checkpoint.TimeTick
+		}
+	}
 	// recover the collection infos
-	collections := newCollectionInfos(param.InitialRecoverSnapshot)
+	collections := newCollectionInfos(writePathRecovery)
 	// recover the segment assignment infos
-	partitionToSegmentManagers, segmentBelongs := newSegmentAllocManagersFromRecovery(param.ChannelInfo, param.InitialRecoverSnapshot, collections)
+	partitionToSegmentManagers, segmentBelongs := newSegmentAllocManagersFromRecovery(param.ChannelInfo, writePathRecovery, collections)
 
 	ctx, cancel := context.WithCancel(context.Background())
 	logger := resource.Resource().Logger().With(mlog.FieldComponent("shard-manager")).With(mlog.Stringer("pchannel", param.ChannelInfo))
-	// create managers list.
-	managers := make(map[PartitionUniqueKey]*partitionManager)
 	segmentTotal := 0
 	metrics := metricsutil.NewSegmentAssignMetrics(param.ChannelInfo.Name)
 	for collectionID, collectionInfo := range collections {
-		for partitionID := range collectionInfo.PartitionIDs {
-			segmentManagers := make(map[int64]*segmentAllocManager, 0)
+		collectionInfo.FencedAssignTimeTick = checkpointTimeTick
+		for partitionID := range collectionInfo.Partitions {
+			var segmentManagers map[int64]*segmentAllocManager
 			// recovery meta is recovered , use it.
 			uniqueKey := PartitionUniqueKey{CollectionID: collectionID, PartitionID: partitionID}
-			if managers, ok := partitionToSegmentManagers[uniqueKey]; ok {
-				segmentManagers = managers
+			if recovered, ok := partitionToSegmentManagers[uniqueKey]; ok {
+				segmentManagers = recovered
 			}
-			if _, ok := managers[uniqueKey]; ok {
-				panic("partition manager already exists when buildNewPartitionManagers in segment assignment service, there's a bug in system")
+			if partitionID == common.AllPartitionsID && len(segmentManagers) == 0 {
+				continue
 			}
-			managers[uniqueKey] = newPartitionSegmentManager(
+			collectionInfo.Partitions[partitionID] = newPartitionSegmentManager(
 				ctx,
 				logger,
 				param.WAL,
@@ -94,23 +106,22 @@ func RecoverShardManager(param *ShardManagerRecoverParam) ShardManager {
 				partitionID,
 				segmentManagers,
 				param.TxnManager,
-				param.InitialRecoverSnapshot.Checkpoint.TimeTick, // use the checkpoint time tick to fence directly.
+				checkpointTimeTick, // use the checkpoint time tick to fence directly.
 				metrics,
 			)
 			segmentTotal += len(segmentManagers)
 		}
 	}
 	m := &shardManagerImpl{
-		mu:                sync.Mutex{},
-		ctx:               ctx,
-		cancel:            cancel,
-		wal:               param.WAL,
-		scheduler:         param.Scheduler,
-		pchannel:          param.ChannelInfo,
-		partitionManagers: managers,
-		collections:       collections,
-		txnManager:        param.TxnManager,
-		metrics:           metrics,
+		mu:          sync.Mutex{},
+		ctx:         ctx,
+		cancel:      cancel,
+		wal:         param.WAL,
+		scheduler:   param.Scheduler,
+		pchannel:    param.ChannelInfo,
+		collections: collections,
+		txnManager:  param.TxnManager,
+		metrics:     metrics,
 	}
 	m.SetLogger(logger)
 	m.updateMetrics()
@@ -118,7 +129,7 @@ func RecoverShardManager(param *ShardManagerRecoverParam) ShardManager {
 	belongs := lo.Values(segmentBelongs)
 	stats := make([]*stats.SegmentStats, 0, len(belongs))
 	for _, belong := range belongs {
-		stat := m.partitionManagers[belong.PartitionUniqueKey()].segments[belong.SegmentID].GetStatFromRecovery()
+		stat := m.collections[belong.CollectionID].Partitions[belong.PartitionID].segments[belong.SegmentID].GetStatFromRecovery()
 		if info := m.collections[belong.CollectionID]; info != nil {
 			stat.RuntimeFlushSize = info.RuntimeFlushSize(stat.Modified)
 		}
@@ -128,74 +139,110 @@ func RecoverShardManager(param *ShardManagerRecoverParam) ShardManager {
 	return m
 }
 
+func writePathRecoveryFromLegacySnapshot(snapshot *recovery.RecoverySnapshot) *moduleapi.WritePathRecoveryModuleSnapshot {
+	if snapshot == nil {
+		return &moduleapi.WritePathRecoveryModuleSnapshot{}
+	}
+	if snapshot.WritePathRecovery != nil {
+		return snapshot.WritePathRecovery
+	}
+	write := &moduleapi.WritePathRecoveryModuleSnapshot{
+		VChannels:       make(map[string]moduleapi.VChannelWritePathRecoveryState),
+		GrowingSegments: make(map[int64]moduleapi.SegmentWritePathRecoveryState),
+	}
+	for vchannel, meta := range snapshot.VChannels {
+		if meta.GetState() != streamingpb.VChannelState_VCHANNEL_STATE_NORMAL || meta.GetCollectionInfo() == nil {
+			continue
+		}
+		collection := meta.GetCollectionInfo()
+		state := moduleapi.VChannelWritePathRecoveryState{
+			VChannel:     vchannel,
+			CollectionID: collection.GetCollectionId(),
+			PartitionIDs: make([]int64, 0, len(collection.GetPartitions())),
+		}
+		for _, partition := range collection.GetPartitions() {
+			state.PartitionIDs = append(state.PartitionIDs, partition.GetPartitionId())
+		}
+		if schemas := collection.GetSchemas(); len(schemas) > 0 {
+			state.Schema = schemas[len(schemas)-1].GetSchema()
+		}
+		write.VChannels[vchannel] = state
+	}
+	for segmentID, meta := range snapshot.SegmentAssignments {
+		if meta.GetState() != streamingpb.SegmentAssignmentState_SEGMENT_ASSIGNMENT_STATE_GROWING {
+			continue
+		}
+		write.GrowingSegments[segmentID] = moduleapi.SegmentWritePathRecoveryState{
+			VChannel:     meta.GetVchannel(),
+			CollectionID: meta.GetCollectionId(),
+			PartitionID:  meta.GetPartitionId(),
+			SegmentID:    meta.GetSegmentId(),
+			Stat:         meta.GetStat(),
+		}
+	}
+	return write
+}
+
 // newSegmentAllocManagersFromRecovery creates new segment alloc managers from the recovery snapshot.
-func newSegmentAllocManagersFromRecovery(pchannel types.PChannelInfo, recoverInfos *recovery.RecoverySnapshot, collections map[int64]*CollectionInfo) (
+func newSegmentAllocManagersFromRecovery(pchannel types.PChannelInfo, recoverInfos *moduleapi.WritePathRecoveryModuleSnapshot, collections map[int64]*CollectionInfo) (
 	map[PartitionUniqueKey]map[int64]*segmentAllocManager,
 	map[int64]stats.SegmentBelongs,
 ) {
 	// recover the segment infos from the streaming node segment assignment meta storage
 	partitionToSegmentManagers := make(map[PartitionUniqueKey]map[int64]*segmentAllocManager)
 	growingBelongs := make(map[int64]stats.SegmentBelongs)
-	seenSegments := make(map[int64]struct{}, len(recoverInfos.SegmentAssignments))
-	for _, rawMeta := range recoverInfos.SegmentAssignments {
-		coll, ok := collections[rawMeta.GetCollectionId()]
+	seenSegments := make(map[int64]struct{}, len(recoverInfos.GrowingSegments))
+	for _, state := range recoverInfos.GrowingSegments {
+		coll, ok := collections[state.CollectionID]
 		if !ok {
-			panic(fmt.Sprintf("segment assignment meta is dirty, collection not found, %d", rawMeta.GetCollectionId()))
+			panic(fmt.Sprintf("segment assignment meta is dirty, collection not found, %d", state.CollectionID))
 		}
-		if _, ok := coll.PartitionIDs[rawMeta.GetPartitionId()]; !ok {
-			panic(fmt.Sprintf("segment assignment meta is dirty, partition not found, partition not found, %d", rawMeta.GetPartitionId()))
+		if _, ok := coll.Partitions[state.PartitionID]; !ok {
+			panic(fmt.Sprintf("segment assignment meta is dirty, partition not found, partition not found, %d", state.PartitionID))
 		}
-		if _, ok := seenSegments[rawMeta.GetSegmentId()]; ok {
-			panic(fmt.Sprintf("segment assignment meta is dirty, segment repeated, %d", rawMeta.GetSegmentId()))
+		if _, ok := seenSegments[state.SegmentID]; ok {
+			panic(fmt.Sprintf("segment assignment meta is dirty, segment repeated, %d", state.SegmentID))
 		}
-		seenSegments[rawMeta.GetSegmentId()] = struct{}{}
+		seenSegments[state.SegmentID] = struct{}{}
 		uniqueKey := PartitionUniqueKey{
-			CollectionID: rawMeta.GetCollectionId(),
-			PartitionID:  rawMeta.GetPartitionId(),
+			CollectionID: state.CollectionID,
+			PartitionID:  state.PartitionID,
 		}
-		switch rawMeta.GetState() {
-		case streamingpb.SegmentAssignmentState_SEGMENT_ASSIGNMENT_STATE_GROWING:
-			m := newSegmentAllocManagerFromProto(pchannel, rawMeta)
-			growingBelongs[m.GetSegmentID()] = stats.SegmentBelongs{
-				PChannel:     pchannel.Name,
-				VChannel:     m.GetVChannel(),
-				CollectionID: rawMeta.GetCollectionId(),
-				PartitionID:  rawMeta.GetPartitionId(),
-				SegmentID:    m.GetSegmentID(),
-			}
-			if _, ok := partitionToSegmentManagers[uniqueKey]; !ok {
-				partitionToSegmentManagers[uniqueKey] = make(map[int64]*segmentAllocManager, 2)
-			}
-			partitionToSegmentManagers[uniqueKey][rawMeta.GetSegmentId()] = m
-		case streamingpb.SegmentAssignmentState_SEGMENT_ASSIGNMENT_STATE_FLUSHED:
-			continue
-		default:
-			panic(fmt.Sprintf("segment assignment meta has unknown state, segment %d state %s", rawMeta.GetSegmentId(), rawMeta.GetState()))
+		m := newSegmentAllocManagerFromRecovery(pchannel, state)
+		growingBelongs[m.GetSegmentID()] = stats.SegmentBelongs{
+			PChannel:     pchannel.Name,
+			VChannel:     m.GetVChannel(),
+			CollectionID: state.CollectionID,
+			PartitionID:  state.PartitionID,
+			SegmentID:    m.GetSegmentID(),
 		}
+		if _, ok := partitionToSegmentManagers[uniqueKey]; !ok {
+			partitionToSegmentManagers[uniqueKey] = make(map[int64]*segmentAllocManager, 2)
+		}
+		partitionToSegmentManagers[uniqueKey][state.SegmentID] = m
 	}
 	return partitionToSegmentManagers, growingBelongs
 }
 
 // newCollectionInfos creates a new collection info map from the recovery snapshot.
-func newCollectionInfos(recoverInfos *recovery.RecoverySnapshot) map[int64]*CollectionInfo {
+func newCollectionInfos(recoverInfos *moduleapi.WritePathRecoveryModuleSnapshot) map[int64]*CollectionInfo {
 	// collectionMap is a map from collectionID to collectionInfo.
 	collectionInfoMap := make(map[int64]*CollectionInfo, len(recoverInfos.VChannels))
-	for _, vchannelInfo := range recoverInfos.VChannels {
-		currentPartition := make(map[int64]struct{}, len(vchannelInfo.CollectionInfo.Partitions))
-		for _, partition := range vchannelInfo.CollectionInfo.Partitions {
-			currentPartition[partition.PartitionId] = struct{}{}
+	for _, state := range recoverInfos.VChannels {
+		partitions := make(map[int64]*partitionManager, len(state.PartitionIDs)+1)
+		for _, partitionID := range state.PartitionIDs {
+			partitions[partitionID] = nil
 		}
 		// add all partitions id into the collection info.
-		currentPartition[common.AllPartitionsID] = struct{}{}
-		// Only keep the latest schema, as shard_interceptor only needs the current write view
+		partitions[common.AllPartitionsID] = nil
 		var latestSchema *streamingpb.CollectionSchemaOfVChannel
-		if len(vchannelInfo.CollectionInfo.Schemas) > 0 {
-			latestSchema = vchannelInfo.CollectionInfo.Schemas[len(vchannelInfo.CollectionInfo.Schemas)-1]
+		if state.Schema != nil {
+			latestSchema = &streamingpb.CollectionSchemaOfVChannel{Schema: state.Schema}
 		}
-		collectionInfoMap[vchannelInfo.CollectionInfo.CollectionId] = &CollectionInfo{
-			VChannel:     vchannelInfo.Vchannel,
-			PartitionIDs: currentPartition,
-			Schema:       latestSchema,
+		collectionInfoMap[state.CollectionID] = &CollectionInfo{
+			VChannel:   state.VChannel,
+			Partitions: partitions,
+			Schema:     latestSchema,
 		}
 	}
 	return collectionInfoMap
@@ -207,22 +254,59 @@ func newCollectionInfos(recoverInfos *recovery.RecoverySnapshot) map[int64]*Coll
 type shardManagerImpl struct {
 	mlog.Binder
 
-	mu                sync.Mutex
-	ctx               context.Context
-	cancel            context.CancelFunc
-	wal               *syncutil.Future[wal.WAL]
-	scheduler         nodescheduler.Scheduler
-	pchannel          types.PChannelInfo
-	partitionManagers map[PartitionUniqueKey]*partitionManager // map partitionID to partition manager
-	collections       map[int64]*CollectionInfo                // map collectionID to collectionInfo
-	metrics           *metricsutil.SegmentAssignMetrics
-	txnManager        TxnManager
+	mu          sync.Mutex
+	ctx         context.Context
+	cancel      context.CancelFunc
+	wal         *syncutil.Future[wal.WAL]
+	scheduler   nodescheduler.Scheduler
+	pchannel    types.PChannelInfo
+	collections map[int64]*CollectionInfo // map collectionID to collectionInfo
+	metrics     *metricsutil.SegmentAssignMetrics
+	txnManager  TxnManager
 }
 
 type CollectionInfo struct {
-	VChannel     string
-	PartitionIDs map[int64]struct{}
-	Schema       *streamingpb.CollectionSchemaOfVChannel
+	VChannel             string
+	Partitions           map[int64]*partitionManager
+	Schema               *streamingpb.CollectionSchemaOfVChannel
+	FencedAssignTimeTick uint64
+}
+
+func (m *shardManagerImpl) partitionManager(key PartitionUniqueKey) *partitionManager {
+	collection := m.collections[key.CollectionID]
+	if collection == nil {
+		return nil
+	}
+	return collection.Partitions[key.PartitionID]
+}
+
+func (m *shardManagerImpl) ensurePartitionManager(key PartitionUniqueKey) *partitionManager {
+	collection := m.collections[key.CollectionID]
+	if collection == nil {
+		return nil
+	}
+	manager, ok := collection.Partitions[key.PartitionID]
+	if !ok {
+		return nil
+	}
+	if manager == nil {
+		manager = newPartitionSegmentManager(
+			m.ctx,
+			m.Logger(),
+			m.wal,
+			m.scheduler,
+			m.pchannel,
+			collection.VChannel,
+			key.CollectionID,
+			key.PartitionID,
+			nil,
+			m.txnManager,
+			collection.FencedAssignTimeTick,
+			m.metrics,
+		)
+		collection.Partitions[key.PartitionID] = manager
+	}
+	return manager
 }
 
 // SchemaVersion returns the current collection schema version for the write path.
@@ -373,22 +457,25 @@ func (m *shardManagerImpl) Close() {
 }
 
 func (m *shardManagerImpl) updateMetrics() {
-	// the partition managers contains the all partitions id, so we need to subtract the collections count.
-	m.metrics.UpdatePartitionCount(len(m.partitionManagers) - len(m.collections))
+	partitionCount := 0
+	for _, collection := range m.collections {
+		partitionCount += len(collection.Partitions) - 1
+	}
+	m.metrics.UpdatePartitionCount(partitionCount)
 	m.metrics.UpdateCollectionCount(len(m.collections))
 }
 
 // newCollectionInfo creates a new collection info.
 func newCollectionInfo(vchannel string, partitionIDs []int64) *CollectionInfo {
 	info := &CollectionInfo{
-		VChannel:     vchannel,
-		PartitionIDs: make(map[int64]struct{}, len(partitionIDs)),
-		Schema:       nil, // Schema will be set when collection is created or altered
+		VChannel:   vchannel,
+		Partitions: make(map[int64]*partitionManager, len(partitionIDs)+1),
+		Schema:     nil, // Schema will be set when collection is created or altered
 	}
 	for _, partitionID := range partitionIDs {
-		info.PartitionIDs[partitionID] = struct{}{}
+		info.Partitions[partitionID] = nil
 	}
 	// add all partitions id into the collection info.
-	info.PartitionIDs[common.AllPartitionsID] = struct{}{}
+	info.Partitions[common.AllPartitionsID] = nil
 	return info
 }

--- a/internal/streamingnode/server/wal/interceptors/shard/shards/shard_manager_collection.go
+++ b/internal/streamingnode/server/wal/interceptors/shard/shards/shard_manager_collection.go
@@ -8,6 +8,7 @@ import (
 	"github.com/milvus-io/milvus-proto/go-api/v3/schemapb"
 	"github.com/milvus-io/milvus/internal/streamingnode/server/wal/interceptors/shard/policy"
 	"github.com/milvus-io/milvus/internal/util/streamingutil/status"
+	"github.com/milvus-io/milvus/pkg/v3/common"
 	"github.com/milvus-io/milvus/pkg/v3/mlog"
 	"github.com/milvus-io/milvus/pkg/v3/proto/streamingpb"
 	"github.com/milvus-io/milvus/pkg/v3/streaming/util/message"
@@ -75,6 +76,7 @@ func (m *shardManagerImpl) CreateCollection(msg message.ImmutableCreateCollectio
 	}
 
 	collectionInfo := newCollectionInfo(vchannel, partitionIDs)
+	collectionInfo.FencedAssignTimeTick = timetick
 	// Set schema when creating collection.
 	if schema != nil {
 		collectionInfo.Schema = &streamingpb.CollectionSchemaOfVChannel{
@@ -85,13 +87,15 @@ func (m *shardManagerImpl) CreateCollection(msg message.ImmutableCreateCollectio
 	}
 	m.collections[collectionID] = collectionInfo
 
-	for partitionID := range collectionInfo.PartitionIDs {
-		uniqueKey := PartitionUniqueKey{CollectionID: collectionID, PartitionID: partitionID}
-		if _, ok := m.partitionManagers[uniqueKey]; ok {
+	for partitionID := range collectionInfo.Partitions {
+		if partitionID == common.AllPartitionsID {
+			continue
+		}
+		if collectionInfo.Partitions[partitionID] != nil {
 			logger.Warn(context.TODO(), "partition already exists", mlog.Int64("partitionID", partitionID))
 			continue
 		}
-		m.partitionManagers[uniqueKey] = newPartitionSegmentManager(
+		collectionInfo.Partitions[partitionID] = newPartitionSegmentManager(
 			m.ctx,
 			m.Logger(),
 			m.wal,
@@ -100,7 +104,7 @@ func (m *shardManagerImpl) CreateCollection(msg message.ImmutableCreateCollectio
 			vchannel,
 			collectionID,
 			partitionID,
-			make(map[int64]*segmentAllocManager),
+			nil,
 			m.txnManager,
 			timetick,
 			m.metrics,
@@ -128,20 +132,16 @@ func (m *shardManagerImpl) DropCollection(msg message.ImmutableDropCollectionMes
 	collectionInfo := m.collections[collectionID]
 	delete(m.collections, collectionID)
 	// remove all partition and segment
-	partitionIDs := make([]int64, 0, len(collectionInfo.PartitionIDs))
-	segmentIDs := make([]int64, 0, len(collectionInfo.PartitionIDs))
-	for partitionID := range collectionInfo.PartitionIDs {
-		uniqueKey := PartitionUniqueKey{CollectionID: collectionID, PartitionID: partitionID}
-		pm, ok := m.partitionManagers[uniqueKey]
-		if !ok {
-			logger.Warn(context.TODO(), "partition not exists", mlog.Int64("partitionID", partitionID))
+	partitionIDs := make([]int64, 0, len(collectionInfo.Partitions))
+	segmentIDs := make([]int64, 0, len(collectionInfo.Partitions))
+	for partitionID, pm := range collectionInfo.Partitions {
+		if pm == nil {
 			continue
 		}
 		// Flush all segments and fence assign to the partition manager.
 		segments := pm.FlushAndDropPartition(policy.PolicyCollectionRemoved())
 		partitionIDs = append(partitionIDs, partitionID)
 		segmentIDs = append(segmentIDs, segments...)
-		delete(m.partitionManagers, uniqueKey)
 	}
 	logger.Info(context.TODO(), "collection removed", mlog.Int64s("partitionIDs", partitionIDs), mlog.Int64s("segmentIDs", segmentIDs))
 	m.updateMetrics()

--- a/internal/streamingnode/server/wal/interceptors/shard/shards/shard_manager_partition.go
+++ b/internal/streamingnode/server/wal/interceptors/shard/shards/shard_manager_partition.go
@@ -20,7 +20,7 @@ func (m *shardManagerImpl) checkIfPartitionCanBeCreated(uniquePartitionKey Parti
 		return ErrCollectionNotFound
 	}
 
-	if _, ok := m.collections[uniquePartitionKey.CollectionID].PartitionIDs[uniquePartitionKey.PartitionID]; ok {
+	if _, ok := m.collections[uniquePartitionKey.CollectionID].Partitions[uniquePartitionKey.PartitionID]; ok {
 		return ErrPartitionExists
 	}
 	return nil
@@ -39,7 +39,7 @@ func (m *shardManagerImpl) checkIfPartitionExists(uniquePartitionKey PartitionUn
 	if _, ok := m.collections[uniquePartitionKey.CollectionID]; !ok {
 		return ErrCollectionNotFound
 	}
-	if _, ok := m.collections[uniquePartitionKey.CollectionID].PartitionIDs[uniquePartitionKey.PartitionID]; !ok {
+	if _, ok := m.collections[uniquePartitionKey.CollectionID].Partitions[uniquePartitionKey.PartitionID]; !ok {
 		return ErrPartitionNotFound
 	}
 	return nil
@@ -62,12 +62,12 @@ func (m *shardManagerImpl) CreatePartition(msg message.ImmutableCreatePartitionM
 		return
 	}
 
-	m.collections[collectionID].PartitionIDs[partitionID] = struct{}{}
-	if _, ok := m.partitionManagers[uniquePartitionKey]; ok {
+	collection := m.collections[collectionID]
+	if collection.Partitions[partitionID] != nil {
 		logger.Warn(m.ctx, "partition manager already exists")
 		return
 	}
-	m.partitionManagers[uniquePartitionKey] = newPartitionSegmentManager(
+	collection.Partitions[partitionID] = newPartitionSegmentManager(
 		m.ctx,
 		m.Logger(),
 		m.wal,
@@ -76,7 +76,7 @@ func (m *shardManagerImpl) CreatePartition(msg message.ImmutableCreatePartitionM
 		m.collections[collectionID].VChannel,
 		collectionID,
 		partitionID,
-		make(map[int64]*segmentAllocManager),
+		nil,
 		m.txnManager,
 		tiemtick,
 		m.metrics,
@@ -100,15 +100,15 @@ func (m *shardManagerImpl) DropPartition(msg message.ImmutableDropPartitionMessa
 		logger.Warn(m.ctx, "partition can not be dropped", mlog.Err(err))
 		return
 	}
-	delete(m.collections[collectionID].PartitionIDs, partitionID)
+	collection := m.collections[collectionID]
+	pm := collection.Partitions[partitionID]
+	delete(collection.Partitions, partitionID)
 
-	pm, ok := m.partitionManagers[uniquePartitionKey]
-	if !ok {
+	if pm == nil {
 		logger.Warn(m.ctx, "partition not exists", mlog.FieldCollectionID(collectionID), mlog.FieldPartitionID(partitionID))
 		return
 	}
 
-	delete(m.partitionManagers, uniquePartitionKey)
 	segmentIDs := pm.FlushAndDropPartition(policy.PolicyPartitionRemoved())
 	m.Logger().Info(m.ctx, "partition removed", mlog.Int64s("segmentIDs", segmentIDs))
 	m.updateMetrics()

--- a/internal/streamingnode/server/wal/interceptors/shard/shards/shard_manager_segment.go
+++ b/internal/streamingnode/server/wal/interceptors/shard/shards/shard_manager_segment.go
@@ -50,7 +50,7 @@ func (m *shardManagerImpl) checkIfSegmentCanBeCreated(uniquePartitionKey Partiti
 		return err
 	}
 
-	if m := m.partitionManagers[uniquePartitionKey].GetSegmentManager(segmentID); m != nil {
+	if manager := m.partitionManager(uniquePartitionKey); manager != nil && manager.GetSegmentManager(segmentID) != nil {
 		return ErrSegmentExists
 	}
 	return nil
@@ -72,7 +72,10 @@ func (m *shardManagerImpl) checkIfSegmentCanBeFlushed(uniquePartitionKey Partiti
 
 	// segment can be flushed only if the segment exists, and its state is flushed.
 	// pm must exists, because we have checked the partition exists.
-	pm := m.partitionManagers[uniquePartitionKey]
+	pm := m.partitionManager(uniquePartitionKey)
+	if pm == nil {
+		return ErrSegmentNotFound
+	}
 	sm := pm.GetSegmentManager(segmentID)
 	if sm == nil {
 		return ErrSegmentNotFound
@@ -96,8 +99,8 @@ func (m *shardManagerImpl) CreateSegment(msg message.ImmutableCreateSegmentMessa
 	}
 
 	s := newSegmentAllocManager(m.pchannel, msg)
-	pm, ok := m.partitionManagers[uniquePartitionKey]
-	if !ok {
+	pm := m.ensurePartitionManager(uniquePartitionKey)
+	if pm == nil {
 		panic("critical error: partition manager not found when a segment is created")
 	}
 	pm.AddSegment(s)
@@ -118,8 +121,8 @@ func (m *shardManagerImpl) FlushSegment(msg message.ImmutableFlushMessageV2) {
 		return
 	}
 
-	pm, ok := m.partitionManagers[uniquePartitionKey]
-	if !ok {
+	pm := m.partitionManager(uniquePartitionKey)
+	if pm == nil {
 		logger.Warn(m.ctx, "partition not found when FlushSegment")
 		return
 	}
@@ -133,8 +136,8 @@ func (m *shardManagerImpl) AssignSegment(req *AssignSegmentRequest) (*AssignSegm
 	defer m.mu.Unlock()
 
 	uniqueKey := PartitionUniqueKey{CollectionID: req.CollectionID, PartitionID: req.PartitionID}
-	pm, ok := m.partitionManagers[uniqueKey]
-	if !ok {
+	pm := m.ensurePartitionManager(uniqueKey)
+	if pm == nil {
 		return nil, ErrPartitionNotFound
 	}
 
@@ -174,7 +177,7 @@ func (m *shardManagerImpl) WaitUntilGrowingSegmentReady(uniquePartitionKey Parti
 	if err := m.checkIfPartitionExists(uniquePartitionKey); err != nil {
 		return nil, err
 	}
-	return m.partitionManagers[uniquePartitionKey].WaitPendingGrowingSegmentReady(), nil
+	return m.ensurePartitionManager(uniquePartitionKey).WaitPendingGrowingSegmentReady(), nil
 }
 
 // FlushAndFenceSegmentAllocUntil flush all segment that contains the message which timetick is less than the incoming timetick.
@@ -216,14 +219,11 @@ func (m *shardManagerImpl) flushAndFenceSegmentAllocUntil(collectionID int64, ti
 	}
 
 	collectionInfo := m.collections[collectionID]
-	segmentIDs := make([]int64, 0, len(collectionInfo.PartitionIDs))
+	segmentIDs := make([]int64, 0, len(collectionInfo.Partitions))
 	// collect all partitions
-	for partitionID := range collectionInfo.PartitionIDs {
+	for _, pm := range collectionInfo.Partitions {
 		// Seal all segments and fence assign to the partition manager.
-		uniqueKey := PartitionUniqueKey{CollectionID: collectionID, PartitionID: partitionID}
-		pm, ok := m.partitionManagers[uniqueKey]
-		if !ok {
-			logger.Warn(m.ctx, "partition not found when FlushAndFenceSegmentAllocUntil", mlog.FieldPartitionID(partitionID))
+		if pm == nil {
 			continue
 		}
 		newSealedSegments := pm.FlushAndFenceSegmentUntil(timetick)
@@ -242,8 +242,8 @@ func (m *shardManagerImpl) AsyncFlushSegment(signal utils.SealSegmentSignal) {
 	m.mu.Lock()
 	defer m.mu.Unlock()
 
-	pm, ok := m.partitionManagers[signal.SegmentBelongs.PartitionUniqueKey()]
-	if !ok {
+	pm := m.partitionManager(signal.SegmentBelongs.PartitionUniqueKey())
+	if pm == nil {
 		logger.Warn(m.ctx, "partition not found when AsyncMustSeal, may be already dropped")
 		return
 	}

--- a/internal/streamingnode/server/wal/interceptors/shard/shards/shard_manager_test.go
+++ b/internal/streamingnode/server/wal/interceptors/shard/shards/shard_manager_test.go
@@ -190,6 +190,12 @@ func TestShardManager(t *testing.T) {
 		IntoImmutableMessage(rmq.NewRmqID(1))
 	m.CreateCollection(message.MustAsImmutableCreateCollectionMessageV1(createCollectionMsg))
 	assert.NoError(t, m.CheckIfCollectionExists(7))
+	require.Contains(t, m.collections[7].Partitions, common.AllPartitionsID)
+	assert.Nil(t, m.collections[7].Partitions[common.AllPartitionsID])
+	assert.Nil(t, m.collections[7].Partitions[8].segments)
+	allPartitions := m.ensurePartitionManager(PartitionUniqueKey{CollectionID: 7, PartitionID: common.AllPartitionsID})
+	require.NotNil(t, allPartitions)
+	assert.Nil(t, allPartitions.segments)
 	assert.NoError(t, m.CheckIfPartitionExists(PartitionUniqueKey{CollectionID: 7, PartitionID: 8}))
 	assert.NoError(t, m.CheckIfPartitionExists(PartitionUniqueKey{CollectionID: 7, PartitionID: 9}))
 	assert.NoError(t, m.CheckIfPartitionExists(PartitionUniqueKey{CollectionID: 7, PartitionID: common.AllPartitionsID}))
@@ -222,7 +228,7 @@ func TestShardManager(t *testing.T) {
 		WithTimeTick(600).
 		WithLastConfirmedUseMessageID().
 		IntoImmutableMessage(rmq.NewRmqID(3))
-	m.partitionManagers[PartitionUniqueKey{CollectionID: 7, PartitionID: 10}].onAllocating = make(chan struct{})
+	m.collections[7].Partitions[10].onAllocating = make(chan struct{})
 	ch, err := m.WaitUntilGrowingSegmentReady(PartitionUniqueKey{CollectionID: 7, PartitionID: 10})
 	assert.NoError(t, err)
 	select {
@@ -650,8 +656,8 @@ func TestShardManagerSchemaVersionCheck(t *testing.T) {
 	m.mu.Lock()
 	m.collections[102] = &CollectionInfo{
 		VChannel: "v_corrupt",
-		PartitionIDs: map[int64]struct{}{
-			common.AllPartitionsID: {},
+		Partitions: map[int64]*partitionManager{
+			common.AllPartitionsID: nil,
 		},
 		Schema: &streamingpb.CollectionSchemaOfVChannel{
 			Schema:             nil,
@@ -739,8 +745,12 @@ func TestAsyncFlushSegmentDoesNotHoldShardManagerLockWhileWaitingForWAL(t *testi
 	readyWAL := m.wal.Get()
 	pendingWAL := syncutil.NewFuture[wal.WAL]()
 	m.wal = pendingWAL
-	for _, pm := range m.partitionManagers {
-		pm.wal = pendingWAL
+	for _, collection := range m.collections {
+		for _, pm := range collection.Partitions {
+			if pm != nil {
+				pm.wal = pendingWAL
+			}
+		}
 	}
 
 	flushDone := make(chan struct{})

--- a/internal/streamingnode/server/wal/metricsutil/append.go
+++ b/internal/streamingnode/server/wal/metricsutil/append.go
@@ -11,8 +11,10 @@ import (
 )
 
 const (
-	maxLogged    = 3
-	logThreshold = 10 * time.Millisecond
+	maxLogged                    = 3
+	logThreshold                 = 10 * time.Millisecond
+	inlineInterceptorGroups      = 16
+	inlineInterceptorOccurrences = 2
 )
 
 type InterceptorMetrics struct {
@@ -38,7 +40,16 @@ type AppendMetrics struct {
 	err                error
 	appendDuration     time.Duration
 	implAppendDuration time.Duration
-	interceptors       map[string][]*InterceptorMetrics
+	interceptorGroups  [inlineInterceptorGroups]interceptorMetricsGroup
+	interceptorCount   int
+	extraInterceptors  map[string][]*InterceptorMetrics
+}
+
+type interceptorMetricsGroup struct {
+	name    string
+	metrics [inlineInterceptorOccurrences]InterceptorMetrics
+	count   int
+	extra   []*InterceptorMetrics
 }
 
 type AppendMetricsGuard struct {
@@ -48,22 +59,48 @@ type AppendMetricsGuard struct {
 }
 
 // StartInterceptorCollector start the interceptor to collect the duration.
-func (m *AppendMetrics) StartInterceptorCollector(name string) *InterceptorCollectGuard {
-	if _, ok := m.interceptors[name]; !ok {
-		m.interceptors[name] = make([]*InterceptorMetrics, 0, 2)
+func (m *AppendMetrics) StartInterceptorCollector(name string) InterceptorCollectGuard {
+	for i := 0; i < m.interceptorCount; i++ {
+		if m.interceptorGroups[i].name == name {
+			return newInterceptorCollectGuard(m.interceptorGroups[i].next())
+		}
 	}
-	im := &InterceptorMetrics{}
-	m.interceptors[name] = append(m.interceptors[name], im)
-	return &InterceptorCollectGuard{
+	if m.interceptorCount < len(m.interceptorGroups) {
+		group := &m.interceptorGroups[m.interceptorCount]
+		m.interceptorCount++
+		group.name = name
+		return newInterceptorCollectGuard(group.next())
+	}
+	if m.extraInterceptors == nil {
+		m.extraInterceptors = make(map[string][]*InterceptorMetrics)
+	}
+	metric := &InterceptorMetrics{}
+	m.extraInterceptors[name] = append(m.extraInterceptors[name], metric)
+	return newInterceptorCollectGuard(metric)
+}
+
+func newInterceptorCollectGuard(metric *InterceptorMetrics) InterceptorCollectGuard {
+	return InterceptorCollectGuard{
 		start:        time.Now(),
 		afterStarted: false,
-		interceptor:  im,
+		interceptor:  metric,
 	}
 }
 
+func (g *interceptorMetricsGroup) next() *InterceptorMetrics {
+	if g.count < len(g.metrics) {
+		metric := &g.metrics[g.count]
+		g.count++
+		return metric
+	}
+	metric := &InterceptorMetrics{}
+	g.extra = append(g.extra, metric)
+	return metric
+}
+
 // StartAppendGuard start the append operation.
-func (m *AppendMetrics) StartAppendGuard() *AppendMetricsGuard {
-	return &AppendMetricsGuard{
+func (m *AppendMetrics) StartAppendGuard() AppendMetricsGuard {
+	return AppendMetricsGuard{
 		inner:       m,
 		startAppend: time.Now(),
 	}
@@ -88,21 +125,16 @@ func (m *AppendMetrics) IntoLogFields() []mlog.Field {
 		}
 	}
 	loggedInterceptorCount := 0
-L:
-	for name, ims := range m.interceptors {
-		for i, im := range ims {
-			if !im.ShouldBeLogged() {
-				continue
-			}
-			if loggedInterceptorCount <= maxLogged {
-				fields = append(fields, mlog.Stringer(fmt.Sprintf("%s_%d", name, i), im))
-				loggedInterceptorCount++
-			}
-			if loggedInterceptorCount >= maxLogged {
-				break L
-			}
+	m.rangeInterceptorMetrics(func(name string, occurrence int, im *InterceptorMetrics) bool {
+		if !im.ShouldBeLogged() {
+			return true
 		}
-	}
+		if loggedInterceptorCount <= maxLogged {
+			fields = append(fields, mlog.Stringer(fmt.Sprintf("%s_%d", name, occurrence), im))
+			loggedInterceptorCount++
+		}
+		return loggedInterceptorCount < maxLogged
+	})
 	return fields
 }
 
@@ -123,8 +155,40 @@ func (m *AppendMetricsGuard) FinishAppend() {
 
 // RangeOverInterceptors range over the interceptors.
 func (m *AppendMetrics) RangeOverInterceptors(f func(name string, ims []*InterceptorMetrics)) {
-	for name, ims := range m.interceptors {
-		f(name, ims)
+	for i := 0; i < m.interceptorCount; i++ {
+		group := &m.interceptorGroups[i]
+		metrics := make([]*InterceptorMetrics, 0, group.count+len(group.extra))
+		for j := 0; j < group.count; j++ {
+			metrics = append(metrics, &group.metrics[j])
+		}
+		metrics = append(metrics, group.extra...)
+		f(group.name, metrics)
+	}
+	for name, metrics := range m.extraInterceptors {
+		f(name, metrics)
+	}
+}
+
+func (m *AppendMetrics) rangeInterceptorMetrics(f func(name string, occurrence int, metric *InterceptorMetrics) bool) {
+	for i := 0; i < m.interceptorCount; i++ {
+		group := &m.interceptorGroups[i]
+		for j := 0; j < group.count; j++ {
+			if !f(group.name, j, &group.metrics[j]) {
+				return
+			}
+		}
+		for j, metric := range group.extra {
+			if !f(group.name, group.count+j, metric) {
+				return
+			}
+		}
+	}
+	for name, metrics := range m.extraInterceptors {
+		for occurrence, metric := range metrics {
+			if !f(name, occurrence, metric) {
+				return
+			}
+		}
 	}
 }
 

--- a/internal/streamingnode/server/wal/metricsutil/wal_write.go
+++ b/internal/streamingnode/server/wal/metricsutil/wal_write.go
@@ -3,6 +3,7 @@ package metricsutil
 import (
 	"context"
 	"strconv"
+	"sync"
 	"time"
 
 	"github.com/prometheus/client_golang/prometheus"
@@ -35,7 +36,7 @@ func NewWriteMetrics(pchannel types.PChannelInfo, walName message.WALName) *Writ
 		// woodpecker wal is always slow, so we need to set a higher threshold by default.
 		slowLogThreshold = 3 * time.Second
 	}
-	return &WriteMetrics{
+	writeMetrics := &WriteMetrics{
 		walName:                      walName.String(),
 		pchannel:                     pchannel,
 		constLabel:                   constLabel,
@@ -46,8 +47,32 @@ func NewWriteMetrics(pchannel types.PChannelInfo, walName message.WALName) *Writ
 		walimplsDuration:             metrics.WALImplsAppendMessageDurationSeconds.MustCurryWith(constLabel),
 		walBeforeInterceptorDuration: metrics.WALAppendMessageBeforeInterceptorDurationSeconds.MustCurryWith(constLabel),
 		walAfterInterceptorDuration:  metrics.WALAppendMessageAfterInterceptorDurationSeconds.MustCurryWith(constLabel),
-		slowLogThreshold:             time.Second,
+		slowLogThreshold:             slowLogThreshold,
 	}
+	for index, status := range []string{metrics.WALStatusOK, metrics.WALStatusCancel, metrics.WALStatusError} {
+		writeMetrics.status[index] = writeStatusMetrics{
+			bytes:        writeMetrics.bytes.WithLabelValues(status),
+			walDuration:  writeMetrics.walDuration.WithLabelValues(status),
+			implDuration: writeMetrics.walimplsDuration.WithLabelValues(status),
+		}
+	}
+	return writeMetrics
+}
+
+type writeStatusMetrics struct {
+	bytes        prometheus.Observer
+	walDuration  prometheus.Observer
+	implDuration prometheus.Observer
+}
+
+type messageStatusKey struct {
+	messageType string
+	status      int
+}
+
+type interceptorObservers struct {
+	before prometheus.Observer
+	after  prometheus.Observer
 }
 
 type WriteMetrics struct {
@@ -64,13 +89,15 @@ type WriteMetrics struct {
 	walBeforeInterceptorDuration prometheus.ObserverVec
 	walAfterInterceptorDuration  prometheus.ObserverVec
 	slowLogThreshold             time.Duration
+	status                       [3]writeStatusMetrics
+	totalByMessageStatus         sync.Map
+	interceptorByName            sync.Map
 }
 
 func (m *WriteMetrics) StartAppend(msg message.MutableMessage) *AppendMetrics {
 	return &AppendMetrics{
-		wm:           m,
-		msg:          msg,
-		interceptors: make(map[string][]*InterceptorMetrics),
+		wm:  m,
+		msg: msg,
 	}
 }
 
@@ -78,23 +105,24 @@ func (m *WriteMetrics) done(ctx context.Context, appendMetrics *AppendMetrics) {
 	if !appendMetrics.msg.IsPersisted() {
 		return
 	}
-	status := parseError(appendMetrics.err)
+	statusIndex, status := errorStatus(appendMetrics.err)
+	statusMetrics := m.status[statusIndex]
 	if appendMetrics.implAppendDuration != 0 {
-		m.walimplsDuration.WithLabelValues(status).Observe(appendMetrics.implAppendDuration.Seconds())
+		statusMetrics.implDuration.Observe(appendMetrics.implAppendDuration.Seconds())
 	}
-	m.bytes.WithLabelValues(status).Observe(float64(appendMetrics.msg.EstimateSize()))
-	m.total.WithLabelValues(appendMetrics.msg.MessageType().String(), status).Inc()
-	m.walDuration.WithLabelValues(status).Observe(appendMetrics.appendDuration.Seconds())
-	for name, ims := range appendMetrics.interceptors {
-		for _, im := range ims {
-			if im.Before != 0 {
-				m.walBeforeInterceptorDuration.WithLabelValues(name).Observe(im.Before.Seconds())
-			}
-			if im.After != 0 {
-				m.walAfterInterceptorDuration.WithLabelValues(name).Observe(im.After.Seconds())
-			}
+	statusMetrics.bytes.Observe(float64(appendMetrics.msg.EstimateSize()))
+	m.totalCounter(appendMetrics.msg.MessageType().String(), statusIndex, status).Inc()
+	statusMetrics.walDuration.Observe(appendMetrics.appendDuration.Seconds())
+	appendMetrics.rangeInterceptorMetrics(func(name string, _ int, im *InterceptorMetrics) bool {
+		observers := m.interceptorObservers(name)
+		if im.Before != 0 {
+			observers.before.Observe(im.Before.Seconds())
 		}
-	}
+		if im.After != 0 {
+			observers.after.Observe(im.After.Seconds())
+		}
+		return true
+	})
 	if appendMetrics.err != nil {
 		m.Logger().Warn(ctx, "append message into wal failed", appendMetrics.IntoLogFields()...)
 		return
@@ -108,6 +136,28 @@ func (m *WriteMetrics) done(ctx context.Context, appendMetrics *AppendMetrics) {
 	if m.Logger().LevelEnabled(logLV) {
 		m.Logger().Log(ctx, logLV, "append message into wal", appendMetrics.IntoLogFields()...)
 	}
+}
+
+func (m *WriteMetrics) totalCounter(messageType string, statusIndex int, status string) prometheus.Counter {
+	key := messageStatusKey{messageType: messageType, status: statusIndex}
+	if cached, ok := m.totalByMessageStatus.Load(key); ok {
+		return cached.(prometheus.Counter)
+	}
+	counter := m.total.WithLabelValues(messageType, status)
+	actual, _ := m.totalByMessageStatus.LoadOrStore(key, counter)
+	return actual.(prometheus.Counter)
+}
+
+func (m *WriteMetrics) interceptorObservers(name string) interceptorObservers {
+	if cached, ok := m.interceptorByName.Load(name); ok {
+		return cached.(interceptorObservers)
+	}
+	observers := interceptorObservers{
+		before: m.walBeforeInterceptorDuration.WithLabelValues(name),
+		after:  m.walAfterInterceptorDuration.WithLabelValues(name),
+	}
+	actual, _ := m.interceptorByName.LoadOrStore(name, observers)
+	return actual.(interceptorObservers)
 }
 
 // ObserveRetry observes the retry of the walimpls.
@@ -133,11 +183,16 @@ func (m *WriteMetrics) Close() {
 
 // parseError parses the error to status.
 func parseError(err error) string {
+	_, status := errorStatus(err)
+	return status
+}
+
+func errorStatus(err error) (int, string) {
 	if err == nil {
-		return metrics.WALStatusOK
+		return 0, metrics.WALStatusOK
 	}
 	if status.IsCanceled(err) {
-		return metrics.WALStatusCancel
+		return 1, metrics.WALStatusCancel
 	}
-	return metrics.WALStatusError
+	return 2, metrics.WALStatusError
 }

--- a/internal/streamingnode/server/wal/metricsutil/wal_write_trace_test.go
+++ b/internal/streamingnode/server/wal/metricsutil/wal_write_trace_test.go
@@ -9,6 +9,7 @@ import (
 	"path/filepath"
 	"strings"
 	"testing"
+	"time"
 
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
@@ -89,4 +90,46 @@ func TestAppendMetricsDoneUsesProvidedTraceContext(t *testing.T) {
 	require.NotNil(t, entry, string(content))
 	assert.Equal(t, "0102030405060708090a0b0c0d0e0f10", entry["traceID"])
 	assert.Equal(t, "0102030405060708", entry["spanID"])
+}
+
+func TestAppendMetricsCollectorUsesCompactInlineStorage(t *testing.T) {
+	paramtable.Init()
+	writeMetrics := NewWriteMetrics(types.PChannelInfo{Name: "pchannel-alloc", Term: 1}, message.WALNameTest)
+	defer writeMetrics.Close()
+	msg := message.NewTimeTickMessageBuilderV1().
+		WithHeader(&message.TimeTickMessageHeader{}).
+		WithBody(&msgpb.TimeTickMsg{}).
+		WithAllVChannel().
+		MustBuildMutable()
+
+	allocs := testing.AllocsPerRun(100, func() {
+		appendMetrics := writeMetrics.StartAppend(msg)
+		collector := appendMetrics.StartInterceptorCollector("timetick")
+		collector.BeforeDone()
+		collector.AfterStart()
+		collector.AfterDone()
+	})
+	assert.LessOrEqual(t, allocs, float64(1))
+}
+
+func TestAppendMetricsLogFieldsKeepPerInterceptorOccurrenceIndexes(t *testing.T) {
+	msg := message.NewTimeTickMessageBuilderV1().
+		WithHeader(&message.TimeTickMessageHeader{}).
+		WithBody(&msgpb.TimeTickMsg{}).
+		WithAllVChannel().
+		MustBuildMutable()
+	appendMetrics := &AppendMetrics{msg: msg, err: assert.AnError}
+	for _, name := range []string{"lock", "lock", "txn"} {
+		collector := appendMetrics.StartInterceptorCollector(name)
+		collector.interceptor.Before = logThreshold + time.Millisecond
+	}
+
+	fields := appendMetrics.IntoLogFields()
+	keys := make([]string, 0, len(fields))
+	for _, field := range fields {
+		keys = append(keys, field.Key)
+	}
+	assert.Contains(t, keys, "lock_0")
+	assert.Contains(t, keys, "lock_1")
+	assert.Contains(t, keys, "txn_0")
 }

--- a/internal/streamingnode/server/wal/moduleapi/module.go
+++ b/internal/streamingnode/server/wal/moduleapi/module.go
@@ -5,6 +5,7 @@ import (
 
 	"google.golang.org/protobuf/proto"
 
+	"github.com/milvus-io/milvus-proto/go-api/v3/schemapb"
 	walcheckpoint "github.com/milvus-io/milvus/internal/streamingnode/server/wal/checkpoint"
 	"github.com/milvus-io/milvus/pkg/v3/proto/streamingpb"
 	"github.com/milvus-io/milvus/pkg/v3/streaming/util/message"
@@ -19,6 +20,15 @@ type Module interface {
 	// snapshots for RecoveryStorage-owned catalog persistence. It does not
 	// return an error because it only snapshots in-memory state.
 	ConsumeDirtySnapshots() []DirtySnapshot
+}
+
+type CleanupContext struct {
+	MetaPhysicalTimeTick uint64
+	DataPhysicalTimeTick uint64
+}
+
+type CleanupModule interface {
+	ConsumeCleanupSnapshots(CleanupContext) []DirtySnapshot
 }
 
 type ModuleName string
@@ -74,6 +84,33 @@ func (*SegmentModuleSnapshot) ModuleName() ModuleName {
 
 type TransformLogModuleSnapshot struct {
 	TransformLogs map[string]*streamingpb.VChannelTransformLogMeta
+}
+
+// WritePathRecoveryModuleSnapshot contains only the state needed to resume the WAL
+// write path. It intentionally excludes persisted binlogs and historical
+// schemas retained by QueryView recovery.
+type WritePathRecoveryModuleSnapshot struct {
+	VChannels       map[string]VChannelWritePathRecoveryState
+	GrowingSegments map[int64]SegmentWritePathRecoveryState
+}
+
+func (*WritePathRecoveryModuleSnapshot) ModuleName() ModuleName {
+	return ModuleNameVChannel
+}
+
+type VChannelWritePathRecoveryState struct {
+	VChannel     string
+	CollectionID int64
+	PartitionIDs []int64
+	Schema       *schemapb.CollectionSchema
+}
+
+type SegmentWritePathRecoveryState struct {
+	VChannel     string
+	CollectionID int64
+	PartitionID  int64
+	SegmentID    int64
+	Stat         *streamingpb.SegmentAssignmentStat
 }
 
 func (*TransformLogModuleSnapshot) ModuleName() ModuleName {

--- a/internal/streamingnode/server/wal/moduleapi/module.go
+++ b/internal/streamingnode/server/wal/moduleapi/module.go
@@ -31,6 +31,13 @@ type CleanupModule interface {
 	ConsumeCleanupSnapshots(CleanupContext) []DirtySnapshot
 }
 
+// PendingCleanupModule exposes whether a cleanup module still has work that
+// RecoveryStorage must drain before closing.
+type PendingCleanupModule interface {
+	CleanupModule
+	HasPendingCleanup() bool
+}
+
 type ModuleName string
 
 const (

--- a/internal/streamingnode/server/wal/recovery/recovery_background_task.go
+++ b/internal/streamingnode/server/wal/recovery/recovery_background_task.go
@@ -232,6 +232,9 @@ func (rs *recoveryStorageImpl) persistCheckpointSnapshot(ctx context.Context, sn
 		return err
 	}
 	if snapshot.CheckpointDirty {
+		rs.mu.Lock()
+		rs.persistedCheckpoint = snapshot.Checkpoint.Clone()
+		rs.mu.Unlock()
 		rs.metrics.ObServePersistedMetrics(snapshot.Checkpoint.TimeTick)
 		rs.simpleTruncateCheckpoint(ctx, snapshot.Checkpoint)
 	}

--- a/internal/streamingnode/server/wal/recovery/recovery_background_task.go
+++ b/internal/streamingnode/server/wal/recovery/recovery_background_task.go
@@ -21,9 +21,19 @@ func (rs *recoveryStorageImpl) isDirty() bool {
 	}
 
 	rs.mu.Lock()
-	defer rs.mu.Unlock()
 	checkpointDirty := rs.checkpointManager != nil && rs.checkpointManager.HasDirty()
-	return rs.dirtyCounter > 0 || rs.moduleDirty || rs.pendingSalvageCheckpoint != nil || checkpointDirty
+	dirty := rs.dirtyCounter > 0 || rs.moduleDirty || rs.pendingSalvageCheckpoint != nil || checkpointDirty
+	rs.mu.Unlock()
+	if dirty {
+		return true
+	}
+
+	for _, module := range rs.modules {
+		if cleanupModule, ok := module.(moduleapi.PendingCleanupModule); ok && cleanupModule.HasPendingCleanup() {
+			return true
+		}
+	}
+	return false
 }
 
 // TODO: !!! all recovery persist operation should be a compare-and-swap operation to

--- a/internal/streamingnode/server/wal/recovery/recovery_storage.go
+++ b/internal/streamingnode/server/wal/recovery/recovery_storage.go
@@ -21,6 +21,7 @@ type RecoverySnapshot struct {
 	VChannels                   map[string]*streamingpb.VChannelMeta
 	SegmentAssignments          map[int64]*streamingpb.SegmentAssignmentMeta
 	SegmentDataVersionSummaries map[string]*streamingpb.SegmentDataVersionSummary
+	WritePathRecovery           *moduleapi.WritePathRecoveryModuleSnapshot
 	Checkpoint                  *WALCheckpoint
 	CheckpointDirty             bool
 	TxnBuffer                   *utility.TxnBuffer

--- a/internal/streamingnode/server/wal/recovery/recovery_storage_impl.go
+++ b/internal/streamingnode/server/wal/recovery/recovery_storage_impl.go
@@ -139,6 +139,7 @@ type recoveryStorageImpl struct {
 	currentClusterID       string
 	channel                types.PChannelInfo
 	checkpoint             *WALCheckpoint
+	persistedCheckpoint    *WALCheckpoint
 	checkpointManager      *walcheckpoint.Manager
 	metaObservedCheckpoint utility.WALConsumeCheckpoint
 	vchannelManager        *vchannel.PChannelRecoveryManager
@@ -165,6 +166,9 @@ type recoveryStorageImpl struct {
 func (r *recoveryStorageImpl) installCheckpointManager(checkpoint *WALCheckpoint) {
 	r.checkpointManager = walcheckpoint.NewManager(checkpoint)
 	r.checkpoint = r.checkpointManager.Checkpoint()
+	if r.persistedCheckpoint == nil && checkpoint != nil {
+		r.persistedCheckpoint = checkpoint.Clone()
+	}
 	r.metaObservedCheckpoint = utility.WALConsumeCheckpoint{
 		MessageID: r.checkpoint.MessageID,
 		TimeTick:  r.checkpoint.TimeTick,
@@ -296,8 +300,24 @@ func (r *recoveryStorageImpl) consumeDirtySnapshot() *dirtyPersistSnapshot {
 	}
 	r.mu.Unlock()
 
+	r.mu.Lock()
+	var persistedCheckpoint *WALCheckpoint
+	if r.persistedCheckpoint != nil {
+		persistedCheckpoint = r.persistedCheckpoint.Clone()
+	}
+	r.mu.Unlock()
+	cleanup := moduleapi.CleanupContext{}
+	if persistedCheckpoint != nil {
+		cleanup.MetaPhysicalTimeTick = persistedCheckpoint.TimeTick
+		if persistedCheckpoint.DataCheckpoint != nil {
+			cleanup.DataPhysicalTimeTick = persistedCheckpoint.DataCheckpoint.TimeTick
+		}
+	}
 	moduleSnapshots := make([]moduleapi.DirtySnapshot, 0)
 	for _, module := range r.modules {
+		if cleanupModule, ok := module.(moduleapi.CleanupModule); ok {
+			moduleSnapshots = append(moduleSnapshots, cleanupModule.ConsumeCleanupSnapshots(cleanup)...)
+		}
 		moduleSnapshots = append(moduleSnapshots, module.ConsumeDirtySnapshots()...)
 	}
 

--- a/internal/streamingnode/server/wal/recovery/recovery_storage_impl_test.go
+++ b/internal/streamingnode/server/wal/recovery/recovery_storage_impl_test.go
@@ -79,6 +79,16 @@ type notifyingDirtyModule struct {
 	notify func()
 }
 
+type recordingCleanupModule struct {
+	testRecoveryModule
+	cleanup moduleapi.CleanupContext
+}
+
+func (m *recordingCleanupModule) ConsumeCleanupSnapshots(cleanup moduleapi.CleanupContext) []moduleapi.DirtySnapshot {
+	m.cleanup = cleanup
+	return nil
+}
+
 func (m *notifyingDirtyModule) ConsumeDirtySnapshots() []moduleapi.DirtySnapshot {
 	if m.notify != nil {
 		m.notify()
@@ -99,6 +109,25 @@ func newTestRecoveryStorage(t *testing.T, checkpoint *utility.WALCheckpoint) *re
 		checkpoint,
 		WithNodeScheduler(nodeScheduler),
 	)
+}
+
+func TestConsumeDirtySnapshotUsesLastPersistedPhysicalCheckpointsForCleanup(t *testing.T) {
+	storage := newTestRecoveryStorage(t, &utility.WALCheckpoint{
+		MessageID: walimplstest.NewTestMessageID(10),
+		TimeTick:  10,
+		DataCheckpoint: &utility.WALConsumeCheckpoint{
+			MessageID: walimplstest.NewTestMessageID(9),
+			TimeTick:  9,
+		},
+	})
+	module := &recordingCleanupModule{}
+	storage.modules = []moduleapi.Module{module}
+	storage.checkpoint.TimeTick = 100
+	storage.checkpoint.DataCheckpoint.TimeTick = 90
+
+	assert.Nil(t, storage.consumeDirtySnapshot())
+	assert.Equal(t, uint64(10), module.cleanup.MetaPhysicalTimeTick)
+	assert.Equal(t, uint64(9), module.cleanup.DataPhysicalTimeTick)
 }
 
 func (b *recordingRecoveryStreamBuilder) WALName() message.WALName {

--- a/internal/streamingnode/server/wal/recovery/recovery_storage_impl_test.go
+++ b/internal/streamingnode/server/wal/recovery/recovery_storage_impl_test.go
@@ -89,6 +89,22 @@ func (m *recordingCleanupModule) ConsumeCleanupSnapshots(cleanup moduleapi.Clean
 	return nil
 }
 
+type pendingCleanupModule struct {
+	testRecoveryModule
+	pending  bool
+	consumed int
+}
+
+func (m *pendingCleanupModule) ConsumeCleanupSnapshots(moduleapi.CleanupContext) []moduleapi.DirtySnapshot {
+	m.consumed++
+	m.pending = false
+	return nil
+}
+
+func (m *pendingCleanupModule) HasPendingCleanup() bool {
+	return m.pending
+}
+
 func (m *notifyingDirtyModule) ConsumeDirtySnapshots() []moduleapi.DirtySnapshot {
 	if m.notify != nil {
 		m.notify()
@@ -128,6 +144,22 @@ func TestConsumeDirtySnapshotUsesLastPersistedPhysicalCheckpointsForCleanup(t *t
 	assert.Nil(t, storage.consumeDirtySnapshot())
 	assert.Equal(t, uint64(10), module.cleanup.MetaPhysicalTimeTick)
 	assert.Equal(t, uint64(9), module.cleanup.DataPhysicalTimeTick)
+}
+
+func TestRecoveryStorageCloseDrainsPendingCleanup(t *testing.T) {
+	storage := newTestRecoveryStorage(t, &utility.WALCheckpoint{
+		MessageID: walimplstest.NewTestMessageID(10),
+		TimeTick:  10,
+		DataCheckpoint: &utility.WALConsumeCheckpoint{
+			MessageID: walimplstest.NewTestMessageID(9),
+			TimeTick:  9,
+		},
+	})
+	module := &pendingCleanupModule{pending: true}
+	storage.modules = []moduleapi.Module{module}
+
+	require.NoError(t, storage.persistDritySnapshotWhenClosing())
+	assert.Equal(t, 1, module.consumed)
 }
 
 func (b *recordingRecoveryStreamBuilder) WALName() message.WALName {

--- a/internal/streamingnode/server/wal/recovery/recovery_stream.go
+++ b/internal/streamingnode/server/wal/recovery/recovery_stream.go
@@ -9,6 +9,7 @@ import (
 	"github.com/milvus-io/milvus/internal/streamingnode/server/resource"
 	"github.com/milvus-io/milvus/internal/streamingnode/server/wal/moduleapi"
 	"github.com/milvus-io/milvus/pkg/v3/mlog"
+	"github.com/milvus-io/milvus/pkg/v3/proto/streamingpb"
 	"github.com/milvus-io/milvus/pkg/v3/streaming/util/message"
 )
 
@@ -60,10 +61,16 @@ L:
 	}
 	snapshot = r.switchModulesIntoMetaAndData()
 	snapshot.TxnBuffer = rs.TxnBuffer()
+	vchannelCount := len(snapshot.VChannels)
+	segmentCount := len(snapshot.SegmentAssignments)
+	if snapshot.WritePathRecovery != nil {
+		vchannelCount = len(snapshot.WritePathRecovery.VChannels)
+		segmentCount = len(snapshot.WritePathRecovery.GrowingSegments)
+	}
 	logFields := []mlog.Field{
 		mlog.String("channel", recoveryStreamBuilder.Channel().String()),
-		mlog.Int("vchannels", len(snapshot.VChannels)),
-		mlog.Int("segments", len(snapshot.SegmentAssignments)),
+		mlog.Int("vchannels", vchannelCount),
+		mlog.Int("segments", segmentCount),
 		mlog.String("checkpoint", snapshot.Checkpoint.MessageID.String()),
 		mlog.Uint64("checkpointTimeTick", snapshot.Checkpoint.TimeTick),
 	}
@@ -85,12 +92,22 @@ func (r *recoveryStorageImpl) switchModulesIntoMetaAndData() *RecoverySnapshot {
 		moduleSnapshot := module.SwitchIntoMetaAndData()
 		for _, s := range moduleapi.FlattenModuleSnapshot(moduleSnapshot) {
 			switch typed := s.(type) {
+			case *moduleapi.WritePathRecoveryModuleSnapshot:
+				if snapshot.WritePathRecovery == nil {
+					snapshot.WritePathRecovery = &moduleapi.WritePathRecoveryModuleSnapshot{
+						VChannels:       make(map[string]moduleapi.VChannelWritePathRecoveryState),
+						GrowingSegments: make(map[int64]moduleapi.SegmentWritePathRecoveryState),
+					}
+				}
+				maps.Copy(snapshot.WritePathRecovery.VChannels, typed.VChannels)
+				maps.Copy(snapshot.WritePathRecovery.GrowingSegments, typed.GrowingSegments)
 			case *moduleapi.VChannelModuleSnapshot:
 				if snapshot.VChannels == nil {
 					snapshot.VChannels = maps.Clone(typed.VChannels)
 				} else {
 					maps.Copy(snapshot.VChannels, typed.VChannels)
 				}
+				snapshot.mergeLegacyVChannelsIntoWritePathRecovery(typed.VChannels)
 			case *moduleapi.SegmentModuleSnapshot:
 				if snapshot.SegmentAssignments == nil {
 					snapshot.SegmentAssignments = maps.Clone(typed.Segments)
@@ -102,6 +119,7 @@ func (r *recoveryStorageImpl) switchModulesIntoMetaAndData() *RecoverySnapshot {
 				} else {
 					maps.Copy(snapshot.SegmentDataVersionSummaries, typed.DataVersionSummaries)
 				}
+				snapshot.mergeLegacySegmentsIntoWritePathRecovery(typed.Segments)
 			}
 		}
 	}
@@ -110,4 +128,52 @@ func (r *recoveryStorageImpl) switchModulesIntoMetaAndData() *RecoverySnapshot {
 		snapshot.AlterWALInfo = &alterWALInfoCopy
 	}
 	return snapshot
+}
+
+func (s *RecoverySnapshot) ensureWritePathRecovery() *moduleapi.WritePathRecoveryModuleSnapshot {
+	if s.WritePathRecovery == nil {
+		s.WritePathRecovery = &moduleapi.WritePathRecoveryModuleSnapshot{
+			VChannels:       make(map[string]moduleapi.VChannelWritePathRecoveryState),
+			GrowingSegments: make(map[int64]moduleapi.SegmentWritePathRecoveryState),
+		}
+	}
+	return s.WritePathRecovery
+}
+
+func (s *RecoverySnapshot) mergeLegacyVChannelsIntoWritePathRecovery(vchannels map[string]*streamingpb.VChannelMeta) {
+	write := s.ensureWritePathRecovery()
+	for vchannel, meta := range vchannels {
+		if meta.GetState() != streamingpb.VChannelState_VCHANNEL_STATE_NORMAL || meta.GetCollectionInfo() == nil {
+			continue
+		}
+		collection := meta.GetCollectionInfo()
+		state := moduleapi.VChannelWritePathRecoveryState{
+			VChannel:     vchannel,
+			CollectionID: collection.GetCollectionId(),
+			PartitionIDs: make([]int64, 0, len(collection.GetPartitions())),
+		}
+		for _, partition := range collection.GetPartitions() {
+			state.PartitionIDs = append(state.PartitionIDs, partition.GetPartitionId())
+		}
+		if schemas := collection.GetSchemas(); len(schemas) > 0 {
+			state.Schema = schemas[len(schemas)-1].GetSchema()
+		}
+		write.VChannels[vchannel] = state
+	}
+}
+
+func (s *RecoverySnapshot) mergeLegacySegmentsIntoWritePathRecovery(segments map[int64]*streamingpb.SegmentAssignmentMeta) {
+	write := s.ensureWritePathRecovery()
+	for segmentID, meta := range segments {
+		if meta.GetState() != streamingpb.SegmentAssignmentState_SEGMENT_ASSIGNMENT_STATE_GROWING {
+			continue
+		}
+		write.GrowingSegments[segmentID] = moduleapi.SegmentWritePathRecoveryState{
+			VChannel:     meta.GetVchannel(),
+			CollectionID: meta.GetCollectionId(),
+			PartitionID:  meta.GetPartitionId(),
+			SegmentID:    meta.GetSegmentId(),
+			Stat:         meta.GetStat(),
+		}
+	}
 }

--- a/internal/streamingnode/server/wal/vchannel/frontier_index.go
+++ b/internal/streamingnode/server/wal/vchannel/frontier_index.go
@@ -9,67 +9,71 @@ import (
 type frontierHeapItem[K comparable] struct {
 	key   K
 	value uint64
-	index int
 }
 
-type frontierHeap[K comparable] []*frontierHeapItem[K]
+type frontierHeap[K comparable] struct {
+	values  []frontierHeapItem[K]
+	indexes map[K]int
+}
 
-func (h frontierHeap[K]) Len() int           { return len(h) }
-func (h frontierHeap[K]) Less(i, j int) bool { return h[i].value < h[j].value }
+func (h frontierHeap[K]) Len() int           { return len(h.values) }
+func (h frontierHeap[K]) Less(i, j int) bool { return h.values[i].value < h.values[j].value }
 func (h frontierHeap[K]) Swap(i, j int) {
-	h[i], h[j] = h[j], h[i]
-	h[i].index = i
-	h[j].index = j
+	h.values[i], h.values[j] = h.values[j], h.values[i]
+	h.indexes[h.values[i].key] = i
+	h.indexes[h.values[j].key] = j
 }
 
 func (h *frontierHeap[K]) Push(value any) {
-	item := value.(*frontierHeapItem[K])
-	item.index = len(*h)
-	*h = append(*h, item)
+	item := value.(frontierHeapItem[K])
+	h.indexes[item.key] = len(h.values)
+	h.values = append(h.values, item)
 }
 
 func (h *frontierHeap[K]) Pop() any {
-	old := *h
+	old := h.values
 	last := old[len(old)-1]
-	old[len(old)-1] = nil
-	last.index = -1
-	*h = old[:len(old)-1]
+	var zero frontierHeapItem[K]
+	old[len(old)-1] = zero
+	h.values = old[:len(old)-1]
+	delete(h.indexes, last.key)
 	return last
 }
 
 type minimumFrontierIndex[K comparable] struct {
 	mu    sync.Mutex
-	items map[K]*frontierHeapItem[K]
+	items map[K]int
 	heap  frontierHeap[K]
 }
 
 func newMinimumFrontierIndex[K comparable]() *minimumFrontierIndex[K] {
-	return &minimumFrontierIndex[K]{items: make(map[K]*frontierHeapItem[K])}
+	items := make(map[K]int)
+	return &minimumFrontierIndex[K]{
+		items: items,
+		heap:  frontierHeap[K]{indexes: items},
+	}
 }
 
 func (i *minimumFrontierIndex[K]) Update(key K, value uint64) bool {
 	i.mu.Lock()
 	defer i.mu.Unlock()
-	item, ok := i.items[key]
-	if ok && item.value == value {
+	index, ok := i.items[key]
+	if ok && i.heap.values[index].value == value {
 		return false
 	}
 	if ok {
-		item.value = value
-		heap.Fix(&i.heap, item.index)
+		i.heap.values[index].value = value
+		heap.Fix(&i.heap, index)
 		return true
 	}
-	item = &frontierHeapItem[K]{key: key, value: value}
-	i.items[key] = item
-	heap.Push(&i.heap, item)
+	heap.Push(&i.heap, frontierHeapItem[K]{key: key, value: value})
 	return true
 }
 
 func (i *minimumFrontierIndex[K]) Remove(key K) {
 	i.mu.Lock()
-	if item, ok := i.items[key]; ok {
-		heap.Remove(&i.heap, item.index)
-		delete(i.items, key)
+	if index, ok := i.items[key]; ok {
+		heap.Remove(&i.heap, index)
 	}
 	i.mu.Unlock()
 }
@@ -78,9 +82,15 @@ func (i *minimumFrontierIndex[K]) Minimum() uint64 {
 	i.mu.Lock()
 	defer i.mu.Unlock()
 	if i.heap.Len() > 0 {
-		return i.heap[0].value
+		return i.heap.values[0].value
 	}
 	return math.MaxUint64
+}
+
+func (i *minimumFrontierIndex[K]) Len() int {
+	i.mu.Lock()
+	defer i.mu.Unlock()
+	return i.heap.Len()
 }
 
 type segmentFrontierScope struct {
@@ -90,14 +100,14 @@ type segmentFrontierScope struct {
 
 type segmentFrontierIndex struct {
 	mu         sync.Mutex
-	all        *minimumFrontierIndex[int64]
+	all        *minimumFrontierIndex[segmentFrontierScope]
 	scopes     map[int64]segmentFrontierScope
 	partitions map[segmentFrontierScope]*minimumFrontierIndex[int64]
 }
 
 func newSegmentFrontierIndex() *segmentFrontierIndex {
 	return &segmentFrontierIndex{
-		all:        newMinimumFrontierIndex[int64](),
+		all:        newMinimumFrontierIndex[segmentFrontierScope](),
 		scopes:     make(map[int64]segmentFrontierScope),
 		partitions: make(map[segmentFrontierScope]*minimumFrontierIndex[int64]),
 	}
@@ -108,7 +118,14 @@ func (i *segmentFrontierIndex) Update(segmentID, collectionID, partitionID int64
 	defer i.mu.Unlock()
 	scope := segmentFrontierScope{collectionID: collectionID, partitionID: partitionID}
 	if previous, ok := i.scopes[segmentID]; ok && previous != scope {
-		i.partitions[previous].Remove(segmentID)
+		previousPartition := i.partitions[previous]
+		previousPartition.Remove(segmentID)
+		if previousPartition.Len() == 0 {
+			delete(i.partitions, previous)
+			i.all.Remove(previous)
+		} else {
+			i.all.Update(previous, previousPartition.Minimum())
+		}
 	}
 	i.scopes[segmentID] = scope
 	partition := i.partitions[scope]
@@ -116,21 +133,43 @@ func (i *segmentFrontierIndex) Update(segmentID, collectionID, partitionID int64
 		partition = newMinimumFrontierIndex[int64]()
 		i.partitions[scope] = partition
 	}
-	allChanged := i.all.Update(segmentID, frontier)
 	partitionChanged := partition.Update(segmentID, frontier)
+	allChanged := i.all.Update(scope, partition.Minimum())
 	return allChanged || partitionChanged
 }
 
 func (i *segmentFrontierIndex) All() uint64 {
+	i.mu.Lock()
+	defer i.mu.Unlock()
 	return i.all.Minimum()
 }
 
 func (i *segmentFrontierIndex) Partition(collectionID, partitionID int64) uint64 {
 	i.mu.Lock()
 	partition := i.partitions[segmentFrontierScope{collectionID: collectionID, partitionID: partitionID}]
-	i.mu.Unlock()
 	if partition == nil {
+		i.mu.Unlock()
 		return math.MaxUint64
 	}
-	return partition.Minimum()
+	minimum := partition.Minimum()
+	i.mu.Unlock()
+	return minimum
+}
+
+func (i *segmentFrontierIndex) Remove(segmentID int64) {
+	i.mu.Lock()
+	defer i.mu.Unlock()
+	scope, ok := i.scopes[segmentID]
+	if !ok {
+		return
+	}
+	delete(i.scopes, segmentID)
+	partition := i.partitions[scope]
+	partition.Remove(segmentID)
+	if partition.Len() == 0 {
+		delete(i.partitions, scope)
+		i.all.Remove(scope)
+		return
+	}
+	i.all.Update(scope, partition.Minimum())
 }

--- a/internal/streamingnode/server/wal/vchannel/frontier_index_test.go
+++ b/internal/streamingnode/server/wal/vchannel/frontier_index_test.go
@@ -35,3 +35,25 @@ func TestMinimumFrontierIndexUpdatesAndRemovesEntries(t *testing.T) {
 	index.Remove("v2")
 	assert.Equal(t, uint64(30), index.Minimum())
 }
+
+func TestSegmentFrontierIndexMovesAndRemovesSegments(t *testing.T) {
+	index := newSegmentFrontierIndex()
+	index.Update(1, 100, 10, 10)
+	index.Update(2, 100, 10, 20)
+	index.Update(3, 100, 20, 30)
+	assert.Len(t, index.all.items, 2)
+
+	index.Update(1, 100, 20, 40)
+	assert.Equal(t, uint64(20), index.All())
+	assert.Equal(t, uint64(20), index.Partition(100, 10))
+	assert.Equal(t, uint64(30), index.Partition(100, 20))
+
+	index.Remove(2)
+	assert.Equal(t, uint64(math.MaxUint64), index.Partition(100, 10))
+	assert.Equal(t, uint64(30), index.All())
+
+	index.Remove(3)
+	assert.Equal(t, uint64(40), index.All())
+	index.Remove(1)
+	assert.Equal(t, uint64(math.MaxUint64), index.All())
+}

--- a/internal/streamingnode/server/wal/vchannel/manager.go
+++ b/internal/streamingnode/server/wal/vchannel/manager.go
@@ -57,6 +57,7 @@ type PChannelRecoveryManager struct {
 	segmentsByVChannel    map[string]map[int64]*streamingpb.SegmentAssignmentMeta
 	dirtyMu               sync.Mutex
 	dirtyModules          map[string]*VChannelRecoveryModule
+	cleanupModules        map[string]*VChannelRecoveryModule
 	durableFrontiers      *minimumFrontierIndex[string]
 	materializedFrontiers *minimumFrontierIndex[string]
 
@@ -191,10 +192,19 @@ func aggregateModuleSnapshots(snapshots []moduleapi.ModuleSnapshot) moduleapi.Mo
 	segments := make(map[int64]*streamingpb.SegmentAssignmentMeta)
 	summaries := make(map[string]*streamingpb.SegmentDataVersionSummary)
 	transformLogs := make(map[string]*streamingpb.VChannelTransformLogMeta)
+	writePathVChannels := make(map[string]moduleapi.VChannelWritePathRecoveryState)
+	writePathSegments := make(map[int64]moduleapi.SegmentWritePathRecoveryState)
 	others := make(moduleapi.CompositeModuleSnapshot, 0)
 
 	for _, snapshot := range snapshots {
 		switch typed := snapshot.(type) {
+		case *moduleapi.WritePathRecoveryModuleSnapshot:
+			for vchannel, state := range typed.VChannels {
+				writePathVChannels[vchannel] = state
+			}
+			for segmentID, state := range typed.GrowingSegments {
+				writePathSegments[segmentID] = state
+			}
 		case *moduleapi.VChannelModuleSnapshot:
 			for vchannel, meta := range typed.VChannels {
 				vchannels[vchannel] = meta
@@ -218,6 +228,12 @@ func aggregateModuleSnapshots(snapshots []moduleapi.ModuleSnapshot) moduleapi.Mo
 	}
 
 	result := make(moduleapi.CompositeModuleSnapshot, 0, 3+len(others))
+	if len(writePathVChannels) > 0 || len(writePathSegments) > 0 {
+		result = append(result, &moduleapi.WritePathRecoveryModuleSnapshot{
+			VChannels:       writePathVChannels,
+			GrowingSegments: writePathSegments,
+		})
+	}
 	if len(vchannels) > 0 {
 		result = append(result, &moduleapi.VChannelModuleSnapshot{VChannels: vchannels})
 	}
@@ -242,11 +258,43 @@ func (m *PChannelRecoveryManager) ConsumeDirtySnapshots() []moduleapi.DirtySnaps
 	for _, module := range m.takeDirtyModules() {
 		dirty := module.ConsumeDirtySnapshots()
 		snapshots = append(snapshots, dirty...)
+		if module.HasCleanupCandidates() {
+			m.markCleanupCandidate(module)
+		}
 		if len(dirty) > 0 {
 			m.markModuleDirty(module)
 		}
 	}
 	return snapshots
+}
+
+func (m *PChannelRecoveryManager) ConsumeCleanupSnapshots(cleanup moduleapi.CleanupContext) []moduleapi.DirtySnapshot {
+	m.dirtyMu.Lock()
+	candidates := m.cleanupModules
+	m.cleanupModules = nil
+	m.dirtyMu.Unlock()
+	var snapshots []moduleapi.DirtySnapshot
+	for vchannel, module := range candidates {
+		snapshots = append(snapshots, module.ConsumeCleanupSnapshots(cleanup)...)
+		if module.HasCleanupCandidates() {
+			m.dirtyMu.Lock()
+			if m.cleanupModules == nil {
+				m.cleanupModules = make(map[string]*VChannelRecoveryModule)
+			}
+			m.cleanupModules[vchannel] = module
+			m.dirtyMu.Unlock()
+		}
+	}
+	return snapshots
+}
+
+func (m *PChannelRecoveryManager) markCleanupCandidate(module *VChannelRecoveryModule) {
+	m.dirtyMu.Lock()
+	if m.cleanupModules == nil {
+		m.cleanupModules = make(map[string]*VChannelRecoveryModule)
+	}
+	m.cleanupModules[module.vchannel] = module
+	m.dirtyMu.Unlock()
 }
 
 func (m *PChannelRecoveryManager) DataFrontier(scope moduleapi.Scope) walcheckpoint.Barrier {
@@ -410,7 +458,7 @@ func (m *PChannelRecoveryManager) newModule(vchannel string) (*VChannelRecoveryM
 			m.markModuleUpdatedByVChannel(vchannel)
 		},
 	}
-	return NewModule(ModuleConfig{
+	return newModuleFromOwnedRecoveryState(ModuleConfig{
 		PChannel:                   m.pchannel,
 		VChannel:                   vchannel,
 		VChannelMeta:               m.config.VChannelMetas[vchannel],

--- a/internal/streamingnode/server/wal/vchannel/manager.go
+++ b/internal/streamingnode/server/wal/vchannel/manager.go
@@ -288,6 +288,12 @@ func (m *PChannelRecoveryManager) ConsumeCleanupSnapshots(cleanup moduleapi.Clea
 	return snapshots
 }
 
+func (m *PChannelRecoveryManager) HasPendingCleanup() bool {
+	m.dirtyMu.Lock()
+	defer m.dirtyMu.Unlock()
+	return len(m.cleanupModules) > 0
+}
+
 func (m *PChannelRecoveryManager) markCleanupCandidate(module *VChannelRecoveryModule) {
 	m.dirtyMu.Lock()
 	if m.cleanupModules == nil {
@@ -458,7 +464,7 @@ func (m *PChannelRecoveryManager) newModule(vchannel string) (*VChannelRecoveryM
 			m.markModuleUpdatedByVChannel(vchannel)
 		},
 	}
-	return newModuleFromOwnedRecoveryState(ModuleConfig{
+	module, err := newModuleFromOwnedRecoveryState(ModuleConfig{
 		PChannel:                   m.pchannel,
 		VChannel:                   vchannel,
 		VChannelMeta:               m.config.VChannelMetas[vchannel],
@@ -483,6 +489,13 @@ func (m *PChannelRecoveryManager) newModule(vchannel string) (*VChannelRecoveryM
 		QueryRuntimeDispatcher:     m.queryDispatcher,
 		OnFrontierUpdated:          func() { m.refreshModuleFrontiersByVChannel(vchannel) },
 	})
+	if err != nil {
+		return nil, err
+	}
+	if module.HasCleanupCandidates() {
+		m.markCleanupCandidate(module)
+	}
+	return module, nil
 }
 
 func (m *PChannelRecoveryManager) markModuleUpdatedByVChannel(vchannel string) {
@@ -548,6 +561,7 @@ func (n *dirtyTrackingNotifier) NotifyBarrierUpdated() {
 
 var (
 	_ moduleapi.Module                    = (*PChannelRecoveryManager)(nil)
+	_ moduleapi.PendingCleanupModule      = (*PChannelRecoveryManager)(nil)
 	_ moduleapi.DataFrontierProvider      = (*PChannelRecoveryManager)(nil)
 	_ wal.TransformLogStreamManager       = (*PChannelRecoveryManager)(nil)
 	_ snview.StreamingNodeResourceManager = (*PChannelRecoveryManager)(nil)

--- a/internal/streamingnode/server/wal/vchannel/manager_test.go
+++ b/internal/streamingnode/server/wal/vchannel/manager_test.go
@@ -149,6 +149,43 @@ func TestPChannelRecoveryManagerReleasesInitialState(t *testing.T) {
 	assert.Equal(t, int64(101), segmentID)
 	assert.Equal(t, "v1", vchannel)
 }
+
+func TestPChannelRecoveryManagerSeedsPersistedTombstoneCleanup(t *testing.T) {
+	scheduler := nodescheduler.New(1)
+	t.Cleanup(scheduler.Close)
+	manager, err := NewPChannelRecoveryManager(PChannelManagerConfig{
+		PChannel:      "p1",
+		VChannelMetas: map[string]*streamingpb.VChannelMeta{"v1": newTestVChannelMeta("v1")},
+		Segments: map[int64]*streamingpb.SegmentAssignmentMeta{
+			101: {
+				SegmentId:              101,
+				CollectionId:           100,
+				PartitionId:            10,
+				Vchannel:               "v1",
+				State:                  streamingpb.SegmentAssignmentState_SEGMENT_ASSIGNMENT_STATE_TOMBSTONED,
+				CheckpointTimeTick:     100,
+				DataCheckpointTimeTick: 100,
+				TombstoneTimeTick:      100,
+				SealedAtDataVersion:    &viewpb.DataVersion{StreamingVersion: 2},
+				Stat:                   &streamingpb.SegmentAssignmentStat{},
+			},
+		},
+		TransformLogMetas: map[string]*streamingpb.VChannelTransformLogMeta{},
+		NodeScheduler:     scheduler,
+	})
+	require.NoError(t, err)
+	t.Cleanup(manager.Close)
+
+	assert.True(t, manager.HasPendingCleanup())
+	snapshots := manager.ConsumeCleanupSnapshots(moduleapi.CleanupContext{
+		MetaPhysicalTimeTick: 101,
+		DataPhysicalTimeTick: 101,
+	})
+	require.Len(t, snapshots, 1)
+	assert.Equal(t, moduleapi.SnapshotOpDelete, snapshots[0].Op())
+	assert.Equal(t, int64(101), snapshots[0].Key().SegmentID)
+}
+
 func TestPChannelRecoveryManagerConsumesDirtySnapshotsFromUpdatedModule(t *testing.T) {
 	ctx := context.Background()
 	manager := newTestManager(t, "p1", "v1")

--- a/internal/streamingnode/server/wal/vchannel/manager_test.go
+++ b/internal/streamingnode/server/wal/vchannel/manager_test.go
@@ -70,19 +70,19 @@ func TestPChannelRecoveryManagerModuleIndexSupportsConcurrentRange(t *testing.T)
 	assert.ElementsMatch(t, []string{"v1", "v2"}, mapKeys(observed))
 }
 
-func TestPChannelRecoveryManagerSwitchAggregatesVChannelMetaSnapshot(t *testing.T) {
+func TestPChannelRecoveryManagerSwitchAggregatesWritePathRecoverySnapshot(t *testing.T) {
 	manager := newTestManager(t, "p1", "v1", "v2")
 
 	snapshots := moduleapi.FlattenModuleSnapshot(manager.SwitchIntoMetaAndData())
 
-	vchannelSnapshots := make([]*moduleapi.VChannelModuleSnapshot, 0)
+	writeSnapshots := make([]*moduleapi.WritePathRecoveryModuleSnapshot, 0)
 	for _, snapshot := range snapshots {
-		if typed, ok := snapshot.(*moduleapi.VChannelModuleSnapshot); ok {
-			vchannelSnapshots = append(vchannelSnapshots, typed)
+		if typed, ok := snapshot.(*moduleapi.WritePathRecoveryModuleSnapshot); ok {
+			writeSnapshots = append(writeSnapshots, typed)
 		}
 	}
-	require.Len(t, vchannelSnapshots, 1)
-	assert.ElementsMatch(t, []string{"v1", "v2"}, mapKeys(vchannelSnapshots[0].VChannels))
+	require.Len(t, writeSnapshots, 1)
+	assert.ElementsMatch(t, []string{"v1", "v2"}, mapKeys(writeSnapshots[0].VChannels))
 }
 
 func TestGroupSegmentsByVChannel(t *testing.T) {
@@ -140,6 +140,7 @@ func TestPChannelRecoveryManagerReleasesInitialState(t *testing.T) {
 
 	module := manager.Module("v1")
 	require.NotNil(t, module)
+	require.Same(t, vchannelMeta, module.vchannelView.meta)
 	require.True(t, proto.Equal(vchannelMeta, module.vchannelView.AssignmentMeta()))
 	require.True(t, proto.Equal(versionSummary, module.segmentDataVersionSummary))
 	require.True(t, proto.Equal(transformLogMeta, module.transformLog.SnapshotMeta()))

--- a/internal/streamingnode/server/wal/vchannel/module.go
+++ b/internal/streamingnode/server/wal/vchannel/module.go
@@ -72,6 +72,8 @@ type VChannelRecoveryModule struct {
 	segments         map[int64]*segment.SegmentView
 	dirtyMu          sync.Mutex
 	dirtySegments    map[int64]*segment.SegmentView
+	cleanupSegments  map[int64]*segment.SegmentView
+	pendingCleanup   map[int64]*segment.SegmentView
 	segmentFrontiers *segmentFrontierIndex
 
 	segmentDataVersionSummary *streamingpb.SegmentDataVersionSummary
@@ -79,10 +81,10 @@ type VChannelRecoveryModule struct {
 
 	transformLog *transformlog.TransformLog
 
-	segmentLifecycle  segment.Lifecycle
-	segmentPackWriter segment.PackWriter
-	onSegmentSealed   func(walview.SegmentSealedEvent)
-	onFrontierUpdated func()
+	segmentLifecycle        segment.Lifecycle
+	segmentPackWriter       segment.PackWriter
+	externalOnSegmentSealed func(walview.SegmentSealedEvent)
+	onFrontierUpdated       func()
 
 	metaAndData bool
 
@@ -92,6 +94,14 @@ type VChannelRecoveryModule struct {
 
 // NewModule creates a single-vchannel recovery module.
 func NewModule(config ModuleConfig) (*VChannelRecoveryModule, error) {
+	return newModule(config, false)
+}
+
+func newModuleFromOwnedRecoveryState(config ModuleConfig) (*VChannelRecoveryModule, error) {
+	return newModule(config, true)
+}
+
+func newModule(config ModuleConfig, adoptVChannelMeta bool) (*VChannelRecoveryModule, error) {
 	if config.PChannel == "" {
 		return nil, merr.WrapErrServiceInternalMsg("vchannel recovery module pchannel is empty")
 	}
@@ -104,11 +114,11 @@ func NewModule(config ModuleConfig) (*VChannelRecoveryModule, error) {
 		runtime:                   config.Runtime,
 		logger:                    config.Logger,
 		segments:                  make(map[int64]*segment.SegmentView),
-		dirtySegments:             make(map[int64]*segment.SegmentView),
 		segmentFrontiers:          newSegmentFrontierIndex(),
 		segmentDataVersionSummary: cloneSegmentDataVersionSummary(config.SegmentDataVersionSummary),
 		segmentLifecycle:          config.SegmentLifecycle,
 		segmentPackWriter:         config.SegmentPackWriter,
+		externalOnSegmentSealed:   config.OnSegmentSealed,
 		queryTransformLogStream:   config.TransformLogStream,
 		onFrontierUpdated:         config.OnFrontierUpdated,
 	}
@@ -118,14 +128,12 @@ func NewModule(config ModuleConfig) (*VChannelRecoveryModule, error) {
 		Dispatcher:       config.QueryRuntimeDispatcher,
 		LoadInfoProvider: config.QueryViewLoadInfoProvider,
 	})
-	module.onSegmentSealed = func(event walview.SegmentSealedEvent) {
-		module.observeQueryResourceEvent(context.Background(), walview.VChannelResourceEvent{SegmentSealed: &event})
-		if config.OnSegmentSealed != nil {
-			config.OnSegmentSealed(event)
-		}
-	}
 	if config.VChannelMeta != nil {
-		module.vchannelView = NewVChannelViewFromMeta(config.VChannelMeta)
+		if adoptVChannelMeta {
+			module.vchannelView = newVChannelViewFromOwnedMeta(config.VChannelMeta)
+		} else {
+			module.vchannelView = NewVChannelViewFromMeta(config.VChannelMeta)
+		}
 	}
 	for id, meta := range config.Segments {
 		if meta.GetVchannel() != config.VChannel {
@@ -136,7 +144,7 @@ func NewModule(config ModuleConfig) (*VChannelRecoveryModule, error) {
 			schema = module.vchannelView.CreateSegmentSchema(meta.GetPartitionId(), meta.GetStat().GetCreateSegmentTimeTick())
 		}
 		var view *segment.SegmentView
-		view = segment.NewSegmentViewFromMetaWithOptions(meta, schema, module.segmentViewOptions(config, id, func() *segment.SegmentView { return view })...)
+		view = segment.NewSegmentViewFromMetaWithConfig(meta, schema, module.segmentViewConfig())
 		module.segments[id] = view
 		module.segmentFrontiers.Update(id, view.CollectionID(), view.PartitionID(), view.DurableFrontierTimeTick())
 	}
@@ -153,22 +161,12 @@ func NewModule(config ModuleConfig) (*VChannelRecoveryModule, error) {
 	return module, nil
 }
 
-func (m *VChannelRecoveryModule) segmentViewOptions(
-	config ModuleConfig,
-	segmentID int64,
-	view func() *segment.SegmentView,
-) []segment.ViewOption {
-	return []segment.ViewOption{
-		segment.WithViewRuntime(config.Runtime),
-		segment.WithViewLifecycle(config.SegmentLifecycle),
-		segment.WithViewPackWriter(config.SegmentPackWriter),
-		segment.WithViewSegmentSealedNotifier(m.onSegmentSealed),
-		segment.WithViewDataUpdatedNotifier(func() {
-			m.markSegmentViewUpdated(segmentID, view())
-			if m.runtime.Notifier != nil {
-				m.runtime.Notifier.NotifyBarrierUpdated()
-			}
-		}),
+func (m *VChannelRecoveryModule) segmentViewConfig() segment.ViewConfig {
+	return segment.ViewConfig{
+		Runtime:    m.runtime,
+		Lifecycle:  m.segmentLifecycle,
+		PackWriter: m.segmentPackWriter,
+		Owner:      m,
 	}
 }
 
@@ -240,36 +238,27 @@ func (m *VChannelRecoveryModule) SwitchIntoMetaAndData() moduleapi.ModuleSnapsho
 	m.mu.Lock()
 	defer m.mu.Unlock()
 	m.metaAndData = true
-	snapshots := make(moduleapi.CompositeModuleSnapshot, 0, 3)
+	snapshot := &moduleapi.WritePathRecoveryModuleSnapshot{}
 	if m.vchannelView != nil {
 		m.vchannelView.SwitchIntoMetaAndData()
-		if m.vchannelView.IsActive() {
-			snapshots = append(snapshots, &moduleapi.VChannelModuleSnapshot{
-				VChannels: map[string]*streamingpb.VChannelMeta{m.vchannel: m.vchannelView.AssignmentMeta()},
-			})
+		if state, ok := m.vchannelView.WritePathRecoveryState(); ok {
+			snapshot.VChannels = map[string]moduleapi.VChannelWritePathRecoveryState{m.vchannel: state}
 		}
 	}
-	segments := make(map[int64]*streamingpb.SegmentAssignmentMeta)
 	for id, view := range m.segments {
 		view.SwitchIntoMetaAndData()
 		m.refreshSegmentFrontierLocked(id, view)
-		if view.IsGrowing() {
-			segments[id] = view.AssignmentMeta()
+		if state, ok := view.WritePathRecoveryState(); ok {
+			if snapshot.GrowingSegments == nil {
+				snapshot.GrowingSegments = make(map[int64]moduleapi.SegmentWritePathRecoveryState)
+			}
+			snapshot.GrowingSegments[id] = state
 		}
-	}
-	if len(segments) > 0 || m.segmentDataVersionSummary != nil {
-		snapshots = append(snapshots, &moduleapi.SegmentModuleSnapshot{
-			Segments:             segments,
-			DataVersionSummaries: m.segmentDataVersionSummaries(),
-		})
 	}
 	if m.transformLog != nil {
 		m.transformLog.SwitchIntoMetaAndData()
-		snapshots = append(snapshots, &moduleapi.TransformLogModuleSnapshot{
-			TransformLogs: map[string]*streamingpb.VChannelTransformLogMeta{m.vchannel: m.transformLog.SnapshotMeta()},
-		})
 	}
-	return snapshots
+	return snapshot
 }
 
 func (m *VChannelRecoveryModule) ConsumeDirtySnapshots() []moduleapi.DirtySnapshot {
@@ -452,7 +441,7 @@ func (m *VChannelRecoveryModule) handleCreateSegmentMessage(ctx context.Context,
 		if schema == nil {
 			return result
 		}
-		view = segment.NewSegmentViewFromCreateSegmentMessageWithOptions(msg, schema, m.segmentOptions(id, func() *segment.SegmentView { return view })...)
+		view = segment.NewSegmentViewFromCreateSegmentMessageWithConfig(msg, schema, m.segmentViewConfig())
 		if m.metaAndData {
 			view.SwitchIntoMetaAndData()
 		}
@@ -554,21 +543,6 @@ func (m *VChannelRecoveryModule) flushPartitionSegmentsCreatedBefore(ctx context
 	return result
 }
 
-func (m *VChannelRecoveryModule) segmentOptions(segmentID int64, view func() *segment.SegmentView) []segment.ViewOption {
-	return []segment.ViewOption{
-		segment.WithViewRuntime(m.runtime),
-		segment.WithViewLifecycle(m.segmentLifecycle),
-		segment.WithViewPackWriter(m.segmentPackWriter),
-		segment.WithViewSegmentSealedNotifier(m.onSegmentSealed),
-		segment.WithViewDataUpdatedNotifier(func() {
-			m.markSegmentViewUpdated(segmentID, view())
-			if m.runtime.Notifier != nil {
-				m.runtime.Notifier.NotifyBarrierUpdated()
-			}
-		}),
-	}
-}
-
 func (m *VChannelRecoveryModule) shouldObserve(msg message.ImmutableMessage) bool {
 	return msg.VChannel() == m.vchannel || msg.VChannel() == "" || msg.IsPChannelLevel()
 }
@@ -652,6 +626,20 @@ func (m *VChannelRecoveryModule) markSegmentUpdatedLocked(segmentID int64) {
 	m.markSegmentViewUpdatedLocked(segmentID, view)
 }
 
+func (m *VChannelRecoveryModule) SegmentDataUpdated(segmentID int64, view *segment.SegmentView) {
+	m.markSegmentViewUpdated(segmentID, view)
+	if m.runtime.Notifier != nil {
+		m.runtime.Notifier.NotifyBarrierUpdated()
+	}
+}
+
+func (m *VChannelRecoveryModule) SegmentSealed(event walview.SegmentSealedEvent) {
+	m.observeQueryResourceEvent(context.Background(), walview.VChannelResourceEvent{SegmentSealed: &event})
+	if m.externalOnSegmentSealed != nil {
+		m.externalOnSegmentSealed(event)
+	}
+}
+
 func (m *VChannelRecoveryModule) markSegmentViewUpdated(segmentID int64, view *segment.SegmentView) {
 	m.mu.Lock()
 	m.markSegmentViewUpdatedLocked(segmentID, view)
@@ -663,8 +651,29 @@ func (m *VChannelRecoveryModule) markSegmentViewUpdatedLocked(segmentID int64, v
 	if view == nil {
 		return
 	}
+	m.tryFinalizeSegmentLocked(segmentID, view)
 	m.markSegmentDirty(segmentID, view)
 	m.refreshSegmentFrontierLocked(segmentID, view)
+}
+
+func (m *VChannelRecoveryModule) tryFinalizeSegmentLocked(segmentID int64, view *segment.SegmentView) bool {
+	oldest, hasOldest := m.queryResources.OldestDataVersion()
+	if !view.TryFinalizeTombstoneAt(oldest, hasOldest) {
+		return false
+	}
+	m.markSegmentDirty(segmentID, view)
+	return true
+}
+
+func (m *VChannelRecoveryModule) tryFinalizeSegmentsLocked() bool {
+	changed := false
+	for segmentID, view := range m.segments {
+		if m.tryFinalizeSegmentLocked(segmentID, view) {
+			m.refreshSegmentFrontierLocked(segmentID, view)
+			changed = true
+		}
+	}
+	return changed
 }
 
 func (m *VChannelRecoveryModule) markTransformSnapshotPersisted(snapshot *streamingpb.VChannelTransformLogMeta) {
@@ -681,13 +690,74 @@ func (m *VChannelRecoveryModule) markSegmentSnapshotPersisted(
 ) {
 	m.mu.Lock()
 	view.MarkSnapshotPersisted(snapshot)
+	tombstonePersisted := view.TombstonePersisted()
+	if tombstonePersisted {
+		if m.cleanupSegments == nil {
+			m.cleanupSegments = make(map[int64]*segment.SegmentView)
+		}
+		m.cleanupSegments[segmentID] = view
+	}
 	m.refreshSegmentFrontierLocked(segmentID, view)
 	m.mu.Unlock()
+	if tombstonePersisted && m.runtime.Notifier != nil {
+		m.runtime.Notifier.NotifyModuleUpdated(moduleapi.ModuleNameSegment)
+	}
 	m.notifyFrontierUpdated()
+}
+
+func (m *VChannelRecoveryModule) HasCleanupCandidates() bool {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	return len(m.cleanupSegments) > 0 || len(m.pendingCleanup) > 0
+}
+
+func (m *VChannelRecoveryModule) ConsumeCleanupSnapshots(cleanup moduleapi.CleanupContext) []moduleapi.DirtySnapshot {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	var snapshots []moduleapi.DirtySnapshot
+	for segmentID, view := range m.cleanupSegments {
+		if !view.TombstonedCleanupReady(cleanup.MetaPhysicalTimeTick, cleanup.DataPhysicalTimeTick) {
+			continue
+		}
+		meta := view.AssignmentMeta()
+		delete(m.cleanupSegments, segmentID)
+		if m.pendingCleanup == nil {
+			m.pendingCleanup = make(map[int64]*segment.SegmentView)
+		}
+		m.pendingCleanup[segmentID] = view
+		owner := view
+		snapshots = append(snapshots, newDirtySnapshot(
+			moduleapi.ModuleNameSegment,
+			moduleapi.SnapshotKey{PChannel: m.pchannel, SegmentID: segmentID},
+			moduleapi.SnapshotOpDelete,
+			meta,
+			meta.GetTombstoneTimeTick(),
+			meta.GetTombstoneTimeTick(),
+			func() { m.completeSegmentCleanup(segmentID, owner) },
+		))
+	}
+	return snapshots
+}
+
+func (m *VChannelRecoveryModule) completeSegmentCleanup(segmentID int64, view *segment.SegmentView) {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	if m.pendingCleanup[segmentID] != view || m.segments[segmentID] != view {
+		return
+	}
+	delete(m.pendingCleanup, segmentID)
+	delete(m.segments, segmentID)
+	m.segmentFrontiers.Remove(segmentID)
+	m.dirtyMu.Lock()
+	delete(m.dirtySegments, segmentID)
+	m.dirtyMu.Unlock()
 }
 
 func (m *VChannelRecoveryModule) markSegmentDirty(segmentID int64, view *segment.SegmentView) {
 	m.dirtyMu.Lock()
+	if m.dirtySegments == nil {
+		m.dirtySegments = make(map[int64]*segment.SegmentView)
+	}
 	m.dirtySegments[segmentID] = view
 	m.dirtyMu.Unlock()
 }
@@ -695,7 +765,7 @@ func (m *VChannelRecoveryModule) markSegmentDirty(segmentID int64, view *segment
 func (m *VChannelRecoveryModule) takeDirtySegments() map[int64]*segment.SegmentView {
 	m.dirtyMu.Lock()
 	dirty := m.dirtySegments
-	m.dirtySegments = make(map[int64]*segment.SegmentView)
+	m.dirtySegments = nil
 	m.dirtyMu.Unlock()
 	return dirty
 }

--- a/internal/streamingnode/server/wal/vchannel/module.go
+++ b/internal/streamingnode/server/wal/vchannel/module.go
@@ -146,6 +146,12 @@ func newModule(config ModuleConfig, adoptVChannelMeta bool) (*VChannelRecoveryMo
 		var view *segment.SegmentView
 		view = segment.NewSegmentViewFromMetaWithConfig(meta, schema, module.segmentViewConfig())
 		module.segments[id] = view
+		if view.TombstonePersisted() {
+			if module.cleanupSegments == nil {
+				module.cleanupSegments = make(map[int64]*segment.SegmentView)
+			}
+			module.cleanupSegments[id] = view
+		}
 		module.segmentFrontiers.Update(id, view.CollectionID(), view.PartitionID(), view.DurableFrontierTimeTick())
 	}
 	module.transformLog = transformlog.New(transformlog.Config{

--- a/internal/streamingnode/server/wal/vchannel/module_test.go
+++ b/internal/streamingnode/server/wal/vchannel/module_test.go
@@ -38,6 +38,73 @@ func TestVChannelRecoveryModuleObservesOnlyItsVChannel(t *testing.T) {
 	assert.Equal(t, uint64(0), result.Data.TimeTick())
 }
 
+func TestVChannelRecoveryModuleLazilyAllocatesDirtySegments(t *testing.T) {
+	module := newTestModule(t, "p1", "v1")
+	assert.Nil(t, module.dirtySegments)
+
+	view := &segment.SegmentView{}
+	module.markSegmentDirty(1, view)
+	require.Len(t, module.dirtySegments, 1)
+	assert.Same(t, view, module.dirtySegments[1])
+
+	assert.Len(t, module.takeDirtySegments(), 1)
+	assert.Nil(t, module.dirtySegments)
+}
+
+func TestSwitchReturnsLightweightWritePathRecoveryState(t *testing.T) {
+	module := newTestModule(t, "p1", "v1")
+	snapshot := module.SwitchIntoMetaAndData()
+	writeSnapshot, ok := snapshot.(*moduleapi.WritePathRecoveryModuleSnapshot)
+	require.True(t, ok)
+	require.Contains(t, writeSnapshot.VChannels, "v1")
+	assert.Equal(t, int64(100), writeSnapshot.VChannels["v1"].CollectionID)
+}
+
+func TestSegmentCleanupWaitsForPhysicalCheckpointsAndCatalogDelete(t *testing.T) {
+	module, err := NewModule(ModuleConfig{
+		PChannel: "p1",
+		VChannel: "v1",
+		Segments: map[int64]*streamingpb.SegmentAssignmentMeta{
+			10: {
+				SegmentId:              10,
+				Vchannel:               "v1",
+				State:                  streamingpb.SegmentAssignmentState_SEGMENT_ASSIGNMENT_STATE_FLUSHED,
+				CheckpointTimeTick:     20,
+				DataCheckpointTimeTick: 20,
+				SealedAtDataVersion:    &viewpb.DataVersion{StreamingVersion: 2},
+				Stat:                   &streamingpb.SegmentAssignmentStat{},
+			},
+		},
+	})
+	require.NoError(t, err)
+
+	module.mu.Lock()
+	require.True(t, module.tryFinalizeSegmentsLocked())
+	module.mu.Unlock()
+
+	upserts := module.ConsumeDirtySnapshots()
+	require.Len(t, upserts, 1)
+	assert.Equal(t, moduleapi.SnapshotOpUpsert, upserts[0].Op())
+	upserts[0].MarkPersisted()
+	require.True(t, module.HasCleanupCandidates())
+
+	assert.Empty(t, module.ConsumeCleanupSnapshots(moduleapi.CleanupContext{
+		MetaPhysicalTimeTick: 20,
+		DataPhysicalTimeTick: 20,
+	}))
+	deletes := module.ConsumeCleanupSnapshots(moduleapi.CleanupContext{
+		MetaPhysicalTimeTick: 21,
+		DataPhysicalTimeTick: 21,
+	})
+	require.Len(t, deletes, 1)
+	assert.Equal(t, moduleapi.SnapshotOpDelete, deletes[0].Op())
+	assert.Contains(t, module.segments, int64(10))
+
+	deletes[0].MarkPersisted()
+	assert.NotContains(t, module.segments, int64(10))
+	assert.False(t, module.HasCleanupCandidates())
+}
+
 func TestVChannelRecoveryModuleRecoveryBarrierFlushesOwnedTransformLog(t *testing.T) {
 	ctx := context.Background()
 	module := newTestModule(t, "p1", "v1")
@@ -207,11 +274,10 @@ func TestRecoveredDurableSegmentRetriesMissingFinalCommit(t *testing.T) {
 			if state == streamingpb.SegmentAssignmentState_SEGMENT_ASSIGNMENT_STATE_TOMBSTONED {
 				meta.TombstoneTimeTick = 30
 			}
-			var view *segment.SegmentView
-			view = segment.NewSegmentViewFromMetaWithOptions(
+			view := segment.NewSegmentViewFromMetaWithConfig(
 				meta,
 				&schemapb.CollectionSchema{Name: "c100"},
-				module.segmentOptions(10, func() *segment.SegmentView { return view })...,
+				module.segmentViewConfig(),
 			)
 			module.segments = map[int64]*segment.SegmentView{10: view}
 
@@ -241,13 +307,11 @@ func TestManualFlushDeduplicatesPendingSegmentFinalCommit(t *testing.T) {
 	module.runtime.Scheduler = taskScheduler
 	module.segmentLifecycle = lifecycle
 	newSegment := func(segmentID int64, createTimeTick uint64) *segment.SegmentView {
-		var view *segment.SegmentView
-		view = segment.NewSegmentViewFromMetaWithOptions(
+		return segment.NewSegmentViewFromMetaWithConfig(
 			newTestGrowingSegmentMeta(segmentID, createTimeTick),
 			&schemapb.CollectionSchema{Name: "c100"},
-			module.segmentOptions(segmentID, func() *segment.SegmentView { return view })...,
+			module.segmentViewConfig(),
 		)
-		return view
 	}
 	module.segments = map[int64]*segment.SegmentView{
 		10: newSegment(10, 10),

--- a/internal/streamingnode/server/wal/vchannel/query_resource_module.go
+++ b/internal/streamingnode/server/wal/vchannel/query_resource_module.go
@@ -3,6 +3,7 @@ package vchannel
 import (
 	"context"
 
+	"github.com/milvus-io/milvus/internal/streamingnode/server/wal/moduleapi"
 	"github.com/milvus-io/milvus/internal/streamingnode/server/wal/snview"
 	"github.com/milvus-io/milvus/internal/streamingnode/server/wal/vchannel/queryresource"
 	"github.com/milvus-io/milvus/internal/streamingnode/server/wal/walview"
@@ -24,6 +25,13 @@ func (m *VChannelRecoveryModule) ReleaseQueryResource(req snview.ReleaseResource
 		return
 	}
 	m.queryResources.Release(req)
+	m.mu.Lock()
+	changed := m.tryFinalizeSegmentsLocked()
+	m.mu.Unlock()
+	if changed && m.runtime.Notifier != nil {
+		m.runtime.Notifier.NotifyModuleUpdated(moduleapi.ModuleNameSegment)
+		m.runtime.Notifier.NotifyBarrierUpdated()
+	}
 }
 
 func (m *VChannelRecoveryModule) QueryRuntime(key qviews.QueryViewKey) (*queryresource.QueryRuntime, bool) {

--- a/internal/streamingnode/server/wal/vchannel/queryresource/helpers.go
+++ b/internal/streamingnode/server/wal/vchannel/queryresource/helpers.go
@@ -5,9 +5,11 @@ import (
 	"github.com/milvus-io/milvus/internal/views/qviews"
 )
 
+var defaultQueryRuntimeBuilders = []QueryRuntimeModuleBuilder{NewGrowingRuntimeModuleBuilder(nil)}
+
 func defaultQueryRuntimeModuleBuilders(builders []QueryRuntimeModuleBuilder) []QueryRuntimeModuleBuilder {
 	if len(builders) == 0 {
-		return []QueryRuntimeModuleBuilder{NewGrowingRuntimeModuleBuilder(nil)}
+		return defaultQueryRuntimeBuilders
 	}
 	return append([]QueryRuntimeModuleBuilder(nil), builders...)
 }

--- a/internal/streamingnode/server/wal/vchannel/queryresource/manager.go
+++ b/internal/streamingnode/server/wal/vchannel/queryresource/manager.go
@@ -47,7 +47,6 @@ func NewManager(config Config) *Manager {
 		scheduler:        config.Scheduler,
 		dispatcher:       config.Dispatcher,
 		loadInfoProvider: config.LoadInfoProvider,
-		refs:             make(map[qviews.QueryViewKey]queryViewRef),
 	}
 }
 
@@ -66,6 +65,9 @@ func (m *Manager) AcquireLocked(req snview.AcquireResource, build ViewBuilder) {
 	}
 	if _, ok := m.refs[req.Key]; !ok {
 		m.assertAcquireMonotonic(req.Key.QueryViewVersion.DataVersion)
+		if m.refs == nil {
+			m.refs = make(map[qviews.QueryViewKey]queryViewRef)
+		}
 		m.refs[req.Key] = queryViewRef{onReady: req.OnReady}
 		if m.runtime == nil && m.task == nil {
 			m.startBuildLocked(req.Meta, build)
@@ -125,6 +127,15 @@ func (m *Manager) QueryRuntime(key qviews.QueryViewKey) (*QueryRuntime, bool) {
 	return m.runtime, true
 }
 
+func (m *Manager) OldestDataVersion() (qviews.DataVersion, bool) {
+	if m == nil {
+		return qviews.DataVersion{}, false
+	}
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	return minQueryViewDataVersion(m.refs)
+}
+
 func (m *Manager) Close() {
 	if m == nil {
 		return
@@ -132,7 +143,7 @@ func (m *Manager) Close() {
 	m.mu.Lock()
 	m.closed = true
 	runtime, task := m.takeRuntimeLocked()
-	m.refs = make(map[qviews.QueryViewKey]queryViewRef)
+	m.refs = nil
 	m.mu.Unlock()
 
 	cancelTask(task)

--- a/internal/streamingnode/server/wal/vchannel/queryresource/manager_test.go
+++ b/internal/streamingnode/server/wal/vchannel/queryresource/manager_test.go
@@ -7,6 +7,7 @@ import (
 	"time"
 
 	"github.com/cockroachdb/errors"
+	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	"google.golang.org/protobuf/proto"
 
@@ -19,6 +20,17 @@ import (
 	"github.com/milvus-io/milvus/pkg/v3/util/merr"
 	"github.com/milvus-io/milvus/pkg/v3/util/nodescheduler"
 )
+
+func TestManagerSharesDefaultBuildersAndLazilyAllocatesRefs(t *testing.T) {
+	first := NewManager(Config{})
+	second := NewManager(Config{})
+
+	require.Len(t, first.builders, 1)
+	require.Len(t, second.builders, 1)
+	assert.Same(t, &first.builders[0], &second.builders[0])
+	assert.Nil(t, first.refs)
+	assert.Nil(t, second.refs)
+}
 
 func TestManagerBuildNotifiesAllCurrentRefsWithoutWaiterGoroutines(t *testing.T) {
 	scheduler := nodescheduler.New(1)

--- a/internal/streamingnode/server/wal/vchannel/segment/flush_policy.go
+++ b/internal/streamingnode/server/wal/vchannel/segment/flush_policy.go
@@ -7,6 +7,8 @@ import (
 	"github.com/milvus-io/milvus/pkg/v3/util/tsoutil"
 )
 
+var defaultWriteOnlyFlushPolicy flushPolicy = &dynamicWriteOnlyFlushPolicy{}
+
 type flushPolicy interface {
 	ShouldFlush(buffer writeOnlyInsertBuffer, now uint64) bool
 }
@@ -18,15 +20,21 @@ type writeOnlyFlushPolicy struct {
 }
 
 func newDefaultWriteOnlyFlushPolicy() flushPolicy {
-	return newWriteOnlyFlushPolicy(
-		0,
-		uint64(paramtable.Get().DataNodeCfg.FlushInsertBufferSize.GetAsInt64()),
-		paramtable.Get().DataNodeCfg.SyncPeriod.GetAsDuration(time.Second),
-	)
+	return defaultWriteOnlyFlushPolicy
+}
+
+type dynamicWriteOnlyFlushPolicy struct{}
+
+func (dynamicWriteOnlyFlushPolicy) ShouldFlush(buffer writeOnlyInsertBuffer, now uint64) bool {
+	params := paramtable.Get()
+	return writeOnlyFlushPolicy{
+		maxBytes: uint64(params.DataNodeCfg.FlushInsertBufferSize.GetAsInt64()),
+		maxAge:   params.DataNodeCfg.SyncPeriod.GetAsDuration(time.Second),
+	}.ShouldFlush(buffer, now)
 }
 
 func newWriteOnlyFlushPolicy(maxRows, maxBytes uint64, maxAge time.Duration) flushPolicy {
-	return writeOnlyFlushPolicy{
+	return &writeOnlyFlushPolicy{
 		maxRows:  maxRows,
 		maxBytes: maxBytes,
 		maxAge:   maxAge,

--- a/internal/streamingnode/server/wal/vchannel/segment/runtime_config.go
+++ b/internal/streamingnode/server/wal/vchannel/segment/runtime_config.go
@@ -5,6 +5,22 @@ import (
 	"github.com/milvus-io/milvus/internal/streamingnode/server/wal/walview"
 )
 
+// ViewOwner receives segment-owned asynchronous state changes. One owner is
+// shared by all segment views in a vchannel, avoiding per-segment callbacks.
+type ViewOwner interface {
+	SegmentDataUpdated(segmentID int64, view *SegmentView)
+	SegmentSealed(event walview.SegmentSealedEvent)
+}
+
+// ViewConfig contains dependencies shared by segment views owned by one
+// vchannel module.
+type ViewConfig struct {
+	Lifecycle  Lifecycle
+	PackWriter PackWriter
+	Runtime    moduleapi.Runtime
+	Owner      ViewOwner
+}
+
 type runtimeConfig struct {
 	lifecycle       Lifecycle
 	packWriter      PackWriter
@@ -14,6 +30,16 @@ type runtimeConfig struct {
 	flushPolicy     flushPolicy
 	metaAndData     bool
 	commitL1Limiter *commitL1Limiter
+	owner           ViewOwner
+}
+
+func runtimeConfigFromViewConfig(config ViewConfig) runtimeConfig {
+	return runtimeConfig{
+		lifecycle:  config.Lifecycle,
+		packWriter: config.PackWriter,
+		runtime:    config.Runtime,
+		owner:      config.Owner,
+	}
 }
 
 func firstRuntimeConfig(configs []runtimeConfig) runtimeConfig {

--- a/internal/streamingnode/server/wal/vchannel/segment/view.go
+++ b/internal/streamingnode/server/wal/vchannel/segment/view.go
@@ -34,6 +34,10 @@ func NewSegmentViewFromMeta(meta *streamingpb.SegmentAssignmentMeta, schema *sch
 	)
 }
 
+func NewSegmentViewFromMetaWithConfig(meta *streamingpb.SegmentAssignmentMeta, schema *schemapb.CollectionSchema, config ViewConfig) *SegmentView {
+	return NewSegmentViewFromMeta(meta, schema, runtimeConfigFromViewConfig(config))
+}
+
 func NewSegmentView(
 	meta *streamingpb.SegmentAssignmentMeta,
 	persistedMetaTimeTick uint64,
@@ -63,6 +67,7 @@ func NewSegmentView(
 		finalCommitDone:       finalCommitDoneFromMeta(meta),
 		metaAndData:           config.metaAndData,
 		commitL1Limiter:       config.commitL1Limiter,
+		owner:                 config.owner,
 	}
 }
 
@@ -94,6 +99,10 @@ func NewSegmentViewFromCreateSegmentMessage(msg message.ImmutableCreateSegmentMe
 		schema,
 		firstRuntimeConfig(configs),
 	)
+}
+
+func NewSegmentViewFromCreateSegmentMessageWithConfig(msg message.ImmutableCreateSegmentMessageV2, schema *schemapb.CollectionSchema, config ViewConfig) *SegmentView {
+	return NewSegmentViewFromCreateSegmentMessage(msg, schema, runtimeConfigFromViewConfig(config))
 }
 
 func newSegmentAssignmentMetaFromCreateSegmentMessage(msg message.ImmutableCreateSegmentMessageV2) *streamingpb.SegmentAssignmentMeta {
@@ -165,6 +174,7 @@ type SegmentView struct {
 	schema             *schemapb.CollectionSchema // schema used to encode pending insert data.
 	metaAndData        bool                       // false during meta-only replay; true when data tasks may run.
 	commitL1Limiter    *commitL1Limiter
+	owner              ViewOwner
 }
 
 // ViewOption configures a segment-level recovery view.
@@ -405,6 +415,24 @@ func (info *SegmentView) AssignmentMeta() *streamingpb.SegmentAssignmentMeta {
 	return proto.Clone(info.meta).(*streamingpb.SegmentAssignmentMeta)
 }
 
+func (info *SegmentView) WritePathRecoveryState() (moduleapi.SegmentWritePathRecoveryState, bool) {
+	info.mu.Lock()
+	defer info.mu.Unlock()
+	if info.meta.GetState() != streamingpb.SegmentAssignmentState_SEGMENT_ASSIGNMENT_STATE_GROWING {
+		return moduleapi.SegmentWritePathRecoveryState{}, false
+	}
+	state := moduleapi.SegmentWritePathRecoveryState{
+		VChannel:     info.meta.GetVchannel(),
+		CollectionID: info.meta.GetCollectionId(),
+		PartitionID:  info.meta.GetPartitionId(),
+		SegmentID:    info.meta.GetSegmentId(),
+	}
+	if info.meta.GetStat() != nil {
+		state.Stat = proto.Clone(info.meta.GetStat()).(*streamingpb.SegmentAssignmentStat)
+	}
+	return state, true
+}
+
 func (info *SegmentView) IDAndVChannel() (int64, string) {
 	info.mu.Lock()
 	defer info.mu.Unlock()
@@ -642,12 +670,20 @@ func (info *SegmentView) MarkSnapshotPersisted(snapshot *streamingpb.SegmentAssi
 }
 
 func (info *SegmentView) NotifyDataUpdated() {
+	if info.owner != nil {
+		info.owner.SegmentDataUpdated(info.ID(), info)
+		return
+	}
 	if info.onDataUpdated != nil {
 		info.onDataUpdated()
 	}
 }
 
 func (info *SegmentView) NotifySegmentSealed(event walview.SegmentSealedEvent) {
+	if info.owner != nil {
+		info.owner.SegmentSealed(event)
+		return
+	}
 	if info.onSegmentSealed != nil {
 		info.onSegmentSealed(event)
 	}
@@ -665,6 +701,18 @@ func (info *SegmentView) markDataCheckpointLocked(timetick uint64) {
 func (info *SegmentView) TryFinalizeTombstone() bool {
 	info.mu.Lock()
 	defer info.mu.Unlock()
+	return info.maybeMarkTombstonedLocked()
+}
+
+func (info *SegmentView) TryFinalizeTombstoneAt(oldest qviews.DataVersion, hasOldest bool) bool {
+	info.mu.Lock()
+	defer info.mu.Unlock()
+	if !info.tombstoneFinalizeReadyLocked() {
+		return false
+	}
+	if sealedAt := info.meta.GetSealedAtDataVersion(); sealedAt != nil && hasOldest && !oldest.GTE(qviews.FromProtoDataVersion(sealedAt)) {
+		return false
+	}
 	return info.maybeMarkTombstonedLocked()
 }
 
@@ -828,6 +876,8 @@ func (s *SegmentView) tombstoneFinalizeReadyLocked() bool {
 	tombstoneTimeTick := s.meta.GetCheckpointTimeTick()
 	return s.meta.GetState() == streamingpb.SegmentAssignmentState_SEGMENT_ASSIGNMENT_STATE_FLUSHED &&
 		tombstoneTimeTick > 0 &&
+		s.finalCommitDone &&
+		s.meta.GetSealedAtDataVersion() != nil &&
 		s.meta.GetDataCheckpointTimeTick() >= tombstoneTimeTick
 }
 

--- a/internal/streamingnode/server/wal/vchannel/segment/view_test.go
+++ b/internal/streamingnode/server/wal/vchannel/segment/view_test.go
@@ -6,10 +6,12 @@ import (
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 
+	"github.com/milvus-io/milvus/internal/streamingnode/server/wal/walview"
 	"github.com/milvus-io/milvus/internal/views/qviews"
 	"github.com/milvus-io/milvus/pkg/v3/proto/streamingpb"
 	"github.com/milvus-io/milvus/pkg/v3/proto/viewpb"
 	"github.com/milvus-io/milvus/pkg/v3/streaming/util/message"
+	"github.com/milvus-io/milvus/pkg/v3/util/paramtable"
 )
 
 func TestConsumeDirtySnapshotKeepsStableInFlightView(t *testing.T) {
@@ -59,6 +61,84 @@ func TestConsumeDirtySnapshotKeepsStableInFlightView(t *testing.T) {
 
 	view.MarkSnapshotPersisted(next)
 	assert.Nil(t, view.ConsumeDirtyAndGetSnapshot())
+}
+
+func TestSegmentViewsShareDefaultFlushPolicy(t *testing.T) {
+	first := NewSegmentViewFromMeta(&streamingpb.SegmentAssignmentMeta{}, nil)
+	second := NewSegmentViewFromMeta(&streamingpb.SegmentAssignmentMeta{}, nil)
+
+	assert.Same(t, first.flushPolicy, second.flushPolicy)
+}
+
+func TestSharedDefaultFlushPolicyObservesDynamicConfig(t *testing.T) {
+	policy := newDefaultWriteOnlyFlushPolicy()
+	params := paramtable.Get()
+	require.NoError(t, params.Save(params.DataNodeCfg.FlushInsertBufferSize.Key, "1"))
+	defer params.Reset(params.DataNodeCfg.FlushInsertBufferSize.Key)
+
+	assert.True(t, policy.ShouldFlush(writeOnlyInsertBuffer{
+		entries:    []message.ImmutableMessage{nil},
+		binarySize: 2,
+	}, 0))
+}
+
+func TestSegmentViewNotifiesSharedOwnerWithoutPerViewCallbacks(t *testing.T) {
+	owner := &recordingSegmentViewOwner{}
+	view := NewSegmentViewFromMetaWithConfig(
+		&streamingpb.SegmentAssignmentMeta{SegmentId: 10},
+		nil,
+		ViewConfig{Owner: owner},
+	)
+
+	view.NotifyDataUpdated()
+	assert.Equal(t, int64(10), owner.segmentID)
+	assert.Same(t, view, owner.view)
+
+	event := walview.SegmentSealedEvent{SegmentID: 10}
+	view.NotifySegmentSealed(event)
+	assert.Equal(t, event, owner.sealed)
+}
+
+func TestSegmentTombstoneWaitsForOldestQueryViewDataVersion(t *testing.T) {
+	view := NewSegmentViewFromMeta(&streamingpb.SegmentAssignmentMeta{
+		SegmentId:              10,
+		State:                  streamingpb.SegmentAssignmentState_SEGMENT_ASSIGNMENT_STATE_FLUSHED,
+		CheckpointTimeTick:     20,
+		DataCheckpointTimeTick: 20,
+		SealedAtDataVersion:    &viewpb.DataVersion{StreamingVersion: 2},
+	}, nil)
+
+	assert.False(t, view.TryFinalizeTombstoneAt(qviews.DataVersion{StreamingVersion: 1}, true))
+	assert.Equal(t, streamingpb.SegmentAssignmentState_SEGMENT_ASSIGNMENT_STATE_FLUSHED, view.AssignmentMeta().GetState())
+	assert.True(t, view.TryFinalizeTombstoneAt(qviews.DataVersion{StreamingVersion: 2}, true))
+	assert.Equal(t, streamingpb.SegmentAssignmentState_SEGMENT_ASSIGNMENT_STATE_TOMBSTONED, view.AssignmentMeta().GetState())
+}
+
+func TestSegmentTombstoneWaitsForFinalCommitDataVersion(t *testing.T) {
+	view := NewSegmentViewFromMeta(&streamingpb.SegmentAssignmentMeta{
+		SegmentId:              10,
+		State:                  streamingpb.SegmentAssignmentState_SEGMENT_ASSIGNMENT_STATE_FLUSHED,
+		CheckpointTimeTick:     20,
+		DataCheckpointTimeTick: 20,
+	}, nil)
+
+	assert.False(t, view.TryFinalizeTombstoneAt(qviews.DataVersion{}, false))
+	assert.Equal(t, streamingpb.SegmentAssignmentState_SEGMENT_ASSIGNMENT_STATE_FLUSHED, view.AssignmentMeta().GetState())
+}
+
+type recordingSegmentViewOwner struct {
+	segmentID int64
+	view      *SegmentView
+	sealed    walview.SegmentSealedEvent
+}
+
+func (o *recordingSegmentViewOwner) SegmentDataUpdated(segmentID int64, view *SegmentView) {
+	o.segmentID = segmentID
+	o.view = view
+}
+
+func (o *recordingSegmentViewOwner) SegmentSealed(event walview.SegmentSealedEvent) {
+	o.sealed = event
 }
 
 func TestFlushedSegmentSnapshotReturnsFilteredSealedSegment(t *testing.T) {

--- a/internal/streamingnode/server/wal/vchannel/transformlog/stream.go
+++ b/internal/streamingnode/server/wal/vchannel/transformlog/stream.go
@@ -49,9 +49,7 @@ func (m *StreamManager) Register(vchannel string, log *TransformLog) {
 	if vchannel == "" || log == nil {
 		return
 	}
-	log.setStreamNotifier(func() {
-		m.notify(vchannel)
-	})
+	log.setStreamNotifier(m)
 	m.streamMu.Lock()
 	defer m.streamMu.Unlock()
 	m.logs[vchannel] = log

--- a/internal/streamingnode/server/wal/vchannel/transformlog/transform_log.go
+++ b/internal/streamingnode/server/wal/vchannel/transformlog/transform_log.go
@@ -73,11 +73,14 @@ type truncateResult struct {
 	Changed bool
 }
 
+type streamNotifier interface {
+	notify(vchannel string)
+}
+
 type TransformLog struct {
 	flushMu               sync.Mutex
 	materializeMu         sync.Mutex
 	mu                    sync.Mutex
-	notifyCh              chan struct{}
 	vchannel              string
 	meta                  *streamingpb.VChannelTransformLogMeta
 	persistedDataTimeTick uint64
@@ -94,7 +97,7 @@ type TransformLog struct {
 	metaAndData           bool
 	flushTasks            []*transformFlushTask
 	materializeTasks      []*transformMaterializeTask
-	streamNotifier        func()
+	streamNotifier        streamNotifier
 
 	chunks []*chunkDescriptor
 }
@@ -107,7 +110,6 @@ func New(config Config) *TransformLog {
 		persistedDataTimeTick: meta.GetCheckpointTimeTick(),
 		persistedMaterialized: meta.GetMaterializedTimeTick(),
 		syncUpTimeTick:        meta.GetCheckpointTimeTick(),
-		notifyCh:              make(chan struct{}),
 		buffer:                newBuffer(config.MaxRows),
 		store:                 config.Store,
 		materializer:          config.Materializer,
@@ -168,7 +170,6 @@ func (t *TransformLog) append(msg message.ImmutableMessage, opt appendOption) ap
 	if !t.buffer.append(msg, opt) {
 		return appendResult{DataTimeTick: t.buffer.DataTimeTick()}
 	}
-	t.notifyScannersLocked()
 	t.notifyStreamLocked()
 	return appendResult{
 		Appended:     true,
@@ -184,7 +185,6 @@ func (t *TransformLog) syncUp(timeTick uint64) appendResult {
 		return appendResult{DataTimeTick: t.buffer.DataTimeTick()}
 	}
 	t.syncUpTimeTick = timeTick
-	t.notifyScannersLocked()
 	t.notifyStreamLocked()
 	return appendResult{
 		Appended:     true,
@@ -686,18 +686,7 @@ func (t *TransformLog) validateLoadedChunkOrderLocked(chunk *chunkDescriptor) er
 	return nil
 }
 
-func (t *TransformLog) notifyChannel() <-chan struct{} {
-	t.mu.Lock()
-	defer t.mu.Unlock()
-	return t.notifyCh
-}
-
-func (t *TransformLog) notifyScannersLocked() {
-	close(t.notifyCh)
-	t.notifyCh = make(chan struct{})
-}
-
-func (t *TransformLog) setStreamNotifier(notifier func()) {
+func (t *TransformLog) setStreamNotifier(notifier streamNotifier) {
 	t.mu.Lock()
 	defer t.mu.Unlock()
 	t.streamNotifier = notifier
@@ -705,7 +694,7 @@ func (t *TransformLog) setStreamNotifier(notifier func()) {
 
 func (t *TransformLog) notifyStreamLocked() {
 	if t.streamNotifier != nil {
-		t.streamNotifier()
+		t.streamNotifier.notify(t.vchannel)
 	}
 }
 

--- a/internal/streamingnode/server/wal/vchannel/transformlog/transform_log_test.go
+++ b/internal/streamingnode/server/wal/vchannel/transformlog/transform_log_test.go
@@ -79,6 +79,35 @@ func TestEmptyBarrierAdvancesInMemoryFrontierWithoutDirtySnapshot(t *testing.T) 
 	assert.Nil(t, transformLog.ConsumeDirtyAndGetSnapshot())
 }
 
+func TestSyncUpWithoutStreamNotifierDoesNotAllocate(t *testing.T) {
+	transformLog := New(Config{VChannel: "v1"})
+	timeTick := uint64(1)
+	allocs := testing.AllocsPerRun(100, func() {
+		if !transformLog.syncUp(timeTick).Appended {
+			panic("sync up did not advance")
+		}
+		timeTick++
+	})
+	assert.Zero(t, allocs)
+}
+
+func TestStreamNotifierReceivesVChannelWithoutPerLogCallback(t *testing.T) {
+	notifier := &recordingTransformLogNotifier{}
+	transformLog := New(Config{VChannel: "v1"})
+	transformLog.setStreamNotifier(notifier)
+
+	require.True(t, transformLog.syncUp(1).Appended)
+	assert.Equal(t, []string{"v1"}, notifier.vchannels)
+}
+
+type recordingTransformLogNotifier struct {
+	vchannels []string
+}
+
+func (n *recordingTransformLogNotifier) notify(vchannel string) {
+	n.vchannels = append(n.vchannels, vchannel)
+}
+
 func TestReadStopsAtEndTimeTick(t *testing.T) {
 	transformLog := New(Config{VChannel: "v1"})
 	manager := NewStreamManager("p1")

--- a/internal/streamingnode/server/wal/vchannel/view.go
+++ b/internal/streamingnode/server/wal/vchannel/view.go
@@ -25,13 +25,25 @@ func NewVChannelViewFromMeta(meta *streamingpb.VChannelMeta, configs ...runtimeC
 	)
 }
 
+func newVChannelViewFromOwnedMeta(meta *streamingpb.VChannelMeta) *VChannelView {
+	return newVChannelView(meta, meta.GetCheckpointTimeTick(), false, runtimeConfig{})
+}
+
 func NewVChannelView(
 	meta *streamingpb.VChannelMeta,
 	persistedMetaTimeTick uint64,
 	dirty bool,
 	config runtimeConfig,
 ) *VChannelView {
-	meta = proto.Clone(meta).(*streamingpb.VChannelMeta)
+	return newVChannelView(proto.Clone(meta).(*streamingpb.VChannelMeta), persistedMetaTimeTick, dirty, config)
+}
+
+func newVChannelView(
+	meta *streamingpb.VChannelMeta,
+	persistedMetaTimeTick uint64,
+	dirty bool,
+	config runtimeConfig,
+) *VChannelView {
 	return &VChannelView{
 		meta:                  meta,
 		persistedMetaTimeTick: persistedMetaTimeTick,
@@ -111,6 +123,27 @@ func (info *VChannelView) AssignmentMeta() *streamingpb.VChannelMeta {
 	info.mu.Lock()
 	defer info.mu.Unlock()
 	return proto.Clone(info.meta).(*streamingpb.VChannelMeta)
+}
+
+func (info *VChannelView) WritePathRecoveryState() (moduleapi.VChannelWritePathRecoveryState, bool) {
+	info.mu.Lock()
+	defer info.mu.Unlock()
+	if info.meta.GetState() != streamingpb.VChannelState_VCHANNEL_STATE_NORMAL || info.meta.GetCollectionInfo() == nil {
+		return moduleapi.VChannelWritePathRecoveryState{}, false
+	}
+	collection := info.meta.GetCollectionInfo()
+	state := moduleapi.VChannelWritePathRecoveryState{
+		VChannel:     info.meta.GetVchannel(),
+		CollectionID: collection.GetCollectionId(),
+		PartitionIDs: make([]int64, 0, len(collection.GetPartitions())),
+	}
+	for _, partition := range collection.GetPartitions() {
+		state.PartitionIDs = append(state.PartitionIDs, partition.GetPartitionId())
+	}
+	if schemas := collection.GetSchemas(); len(schemas) > 0 && schemas[len(schemas)-1].GetSchema() != nil {
+		state.Schema = proto.Clone(schemas[len(schemas)-1].GetSchema()).(*schemapb.CollectionSchema)
+	}
+	return state, true
 }
 
 func (info *VChannelView) Name() string {

--- a/internal/streamingnode/server/wal/vchannel/view_test.go
+++ b/internal/streamingnode/server/wal/vchannel/view_test.go
@@ -47,3 +47,13 @@ func TestConsumeDirtySnapshotKeepsStableInFlightView(t *testing.T) {
 	view.MarkSnapshotPersisted(next)
 	assert.Nil(t, view.ConsumeDirtyAndGetSnapshot())
 }
+
+func TestRecoveredVChannelViewAdoptsOwnedMetaButSnapshotsClone(t *testing.T) {
+	meta := &streamingpb.VChannelMeta{Vchannel: "v1", CheckpointTimeTick: 10}
+	view := newVChannelViewFromOwnedMeta(meta)
+
+	assert.Same(t, meta, view.meta)
+	snapshot := view.AssignmentMeta()
+	assert.NotSame(t, meta, snapshot)
+	assert.Equal(t, meta, snapshot)
+}


### PR DESCRIPTION
issue: milvus-io/milvus#40451

- recovery snapshots: introduce a compact write-path snapshot and transfer recovered metadata ownership to avoid cloning full QueryView state
- hot-path allocations: reuse typed Arrow builders, batch primary-key min/max updates, and cache WAL metric handles
- recovery indexes: maintain collection, partition, segment, dirty-module, and frontier indexes so message handling and recovery avoid full-state scans
- tombstone cleanup: delete persisted segment assignments after durable checkpoints and preserve pending cleanup across graceful shutdown and restart