### PR TITLE
enhance: build QueryView balancer snapshots incrementally

### DIFF
--- a/docs/design-docs/design_docs/qviews/balancer_design.md
+++ b/docs/design-docs/design_docs/qviews/balancer_design.md
@@ -28,11 +28,11 @@ DDL Callbacks (WAL message acknowledgment)
         ▼
 ┌──────────────────────────────────────────────────────────────┐
 │                        Balancer                              │
-│  • Work queue (deduplicated shard IDs)                       │
+│  • Work queue (deduplicated trigger scopes)                  │
 │  • Single goroutine loop:                                    │
 │      1. Detach the pending trigger batch                     │
-│      2. Build BalancerSnapshot (global world view)           │
-│      3. Expand trigger scopes into dirty shards              │
+│      2. Resolve the collection and shard planning scope      │
+│      3. Build a scoped snapshot and refresh the row ledger   │
 │      4. policy.Plan(snapshot, dirty) → BalancePlan           │
 │      5. Apply plan (AddPreparing + ReleaseShardViews)        │
 │  • Periodic ticker as fallback (full scan)                   │
@@ -65,9 +65,9 @@ DDL Callbacks (WAL message acknowledgment)
 
 ### Design Principles
 
-- **Level-triggered reconciliation (Kubernetes controller pattern)**: Event sources with a notifier enqueue affected shard IDs via `Trigger(scope)`; the Balancer compares desired vs. current state and converges. The periodic full scan covers sources without a direct notifier and any missed event. Multiple enqueues for the same shard are deduplicated.
+- **Level-triggered reconciliation (Kubernetes controller pattern)**: Event sources enqueue affected collection, shard, or node scopes via `Trigger(scope)`; the Balancer compares desired vs. current state and converges. The periodic full scan covers sources without a direct notifier and any missed event. Repeated scopes are deduplicated in the pending batch.
 - **Unified allocation algorithm**: A single BalancePolicy handles all scenarios. Scenario differences are encoded in input variations (available nodes, current view, data view), not separate algorithms. This prevents thrashing.
-- **Batch planning**: Each reconcile cycle detaches the pending trigger batch, builds a global snapshot, expands the batch into dirty shards, and asks the Policy for a complete plan. The Policy handles all dirty shards in one call, enabling cross-shard coordination (e.g., avoiding multiple shards targeting the same node).
+- **Scoped batch planning**: Each reconcile cycle detaches the pending trigger batch, resolves its collection and shard scope, builds one immutable snapshot for that scope, and asks the Policy for a complete plan. The Policy handles all target shards in one call while using cluster-wide node row totals for cross-shard coordination.
 - **External inputs as interfaces**: Node Manager, Replica Manager, and DataView Manager are external dependencies consumed via interfaces.
 - **Separated desired and actual state ownership**: `loadmgr` owns load-config lifecycle and desired-state snapshots; `coordview` owns actual QueryView state, shard-view aggregation, and actual-state snapshots. The Balancer composes both snapshots during reconciliation.
 
@@ -95,7 +95,7 @@ type TriggerScope struct {
 ```
 
 - `Trigger()` with no scopes triggers a full scan.
-- `Trigger(scope)` records only the affected scope; the reconcile cycle expands it into shard IDs from its load-config and shard-view snapshots.
+- `Trigger(scope)` records only the affected scope; `SnapshotBuilder` resolves it before reading scoped DataView and ShardView details.
 - A periodic ticker (e.g., 10s) calls `Trigger()` as a safety net for missed events and steady-state balance checks.
 
 #### Main Loop
@@ -115,8 +115,7 @@ for {
         continue
     }
 
-    snap  := b.buildSnapshot()
-    dirty := pending.Expand(snap)
+    snap, dirty := b.snapshotBuilder.build(ctx, pending)
     if len(dirty) == 0 {
         continue
     }
@@ -126,12 +125,51 @@ for {
 }
 ```
 
-`TakePending` establishes the reconcile-cycle boundary before snapshot
-construction. Triggers arriving during snapshot construction remain queued for
-the next cycle, so a trigger batch is expanded only against a snapshot built
-after that batch was detached from the queue.
+`TakePending` establishes the reconcile-cycle boundary before scope resolution
+and snapshot construction. Triggers arriving during construction remain queued
+for the next cycle. The detached batch is resolved before DataView and
+ShardView details are read, so scoped providers only fetch the collections and
+shards needed by that cycle.
 
 The loop is purely infrastructural: the Policy is where all business decisions happen.
+
+#### Scope Resolution
+
+`triggerBatch.resolveScope` produces three sets before provider details are
+read:
+
+```go
+type reconcileScope struct {
+    collectionIDs     map[int64]struct{}
+    collectionWideIDs map[int64]struct{}
+    targetShards      map[qviews.ShardID]struct{}
+}
+```
+
+- `collectionIDs` selects the DataViews fetched for the cycle.
+- `collectionWideIDs` identifies collection triggers whose DataView shards are
+  expanded across every configured replica.
+- `targetShards` is the exact ShardView scope and Policy input.
+
+Dirty collections combine configured replica-by-vchannel shards with resident
+shards from the Registry collection index. Dirty shards are exact targets.
+Dirty nodes expand through the Registry node index. A full planning scope
+combines every configured collection with every resident Registry shard. When
+a scoped trigger cannot be narrowed safely, it uses the same full planning
+scope; only an explicit or periodic full trigger also rebuilds the row-count
+ledger.
+
+The DataView provider exposes both full and collection-scoped reads:
+
+```go
+DataViewSnapshot(ctx context.Context) *DataViewSnapshot
+DataViewSnapshotForCollections(ctx context.Context, collectionIDs map[int64]struct{}) *DataViewSnapshot
+SegmentSnapshot(ctx context.Context, segmentIDs []int64) SegmentSnapshot
+```
+
+A nil collection set selects all collections; a non-nil empty set selects none.
+`SegmentSnapshot` supplies metadata for placement segments that need not belong
+to the latest visible DataViews in the planning scope.
 
 #### External System Integration
 
@@ -145,13 +183,13 @@ The loop is purely infrastructural: the Policy is where all business decisions h
 
 ### 2.2 BalancePolicy
 
-Processes a batch of dirty shards against a global snapshot and produces an execution plan. Stateless pure function.
+Processes a batch of target shards against one immutable snapshot and produces an execution plan. Stateless pure function.
 
 ```go
 type BalancePolicy interface {
     // Plan classifies each dirty shard and computes assignments for those that
-    // need action. Sees the entire snapshot so it can coordinate across shards
-    // (e.g., avoid two shards contending for the same target node).
+    // need action. The snapshot contains scoped shard details and cluster-wide
+    // node row totals so decisions remain coordinated across the batch.
     Plan(snap *BalancerSnapshot, dirty []qviews.ShardID) *BalancePlan
 }
 
@@ -165,7 +203,9 @@ type BalancePlan struct {
 }
 ```
 
-`BalancerSnapshot` is the global world view for this batch (see Section 4). It is built once at the start of each reconcile cycle and reused for all dirty shards in the batch.
+`BalancerSnapshot` combines scoped DataView and ShardView details with the
+global node topology and row-count projection for this batch (see Section 4).
+It is built once and reused for all target shards in the cycle.
 
 #### Why a Unified Algorithm Works
 
@@ -268,13 +308,33 @@ Owns **actual view state**: ShardViewManager lifecycle and view-derived indexes.
 ```go
 type ShardViewRegistry struct { /* ... */ }
 
-func RecoverShardViewRegistry(ctx context.Context, catalog queryview.QueryViewCatalog, syncer syncer.ReliableSyncer) (*ShardViewRegistry, error)
+func RecoverShardViewRegistry(
+    ctx context.Context,
+    catalog queryview.QueryViewCatalog,
+    syncer syncer.ReliableSyncer,
+    dataViewReferences ...qviews.DataViewReferenceManager,
+) (*ShardViewRegistry, error)
 func (r *ShardViewRegistry) Ensure(shardID qviews.ShardID) *ShardViewManager
 func (r *ShardViewRegistry) Get(shardID qviews.ShardID) *ShardViewManager
 func (r *ShardViewRegistry) Snapshot() *ShardViewSnapshot
+func (r *ShardViewRegistry) SnapshotForShards(shardIDs []qviews.ShardID) *ShardViewSnapshot
+func (r *ShardViewRegistry) CollectionShards(collectionID int64) []qviews.ShardID
+func (r *ShardViewRegistry) NodeShards(nodeID int64) []qviews.ShardID
+func (r *ShardViewRegistry) ShardIDs() []qviews.ShardID
+func (r *ShardViewRegistry) RegisterStatsObserver(observer func(qviews.ShardID, *ShardStats))
 ```
 
-Maintains live per-shard stats via ShardViewObserver callbacks from each ShardViewManager. The immutable `ShardViewSnapshot` is refreshed lazily when the live version advances.
+Maintains live per-shard stats via callbacks from each `ShardViewManager`.
+`collectionShards` supports collection-scoped reconciliation, while
+`nodeShards` tracks the shards currently referencing each node. `Snapshot()`
+publishes the resident full snapshot lazily; `SnapshotForShards()` copies only
+the requested `ShardID -> *ShardStats` entries.
+
+Shard managers remain resident for the lifetime of the Registry. A QueryView
+reaching Dropped removes that state machine from its manager, but does not
+remove the manager. Collection index entries are maintained independently of
+view state transitions. Node index entries follow the latest stats and
+disappear when the shard no longer references that node.
 
 #### CollectionLoadManager (Facade)
 
@@ -323,18 +383,18 @@ acquires resources.
 - **Loading**: At least one shard has no Up view.
 - **LoadPercentage**: `count(shards with Up view) / count(total shards) * 100`.
 
-**Recovery**: On startup: LoadConfigStore recovers from ETCD → ShardViewRegistry recovers from persisted views → Balancer triggers full reconcile.
+**Recovery**: On startup: LoadConfigStore recovers from ETCD → ShardViewRegistry recovers persisted managers, stats, and indexes → Balancer triggers a full reconcile that hydrates the row-count ledger before planning.
 
 ## 3. Policy Planning
 
 The Policy internally organizes work into three phases, but processes all dirty shards in one batch so decisions across shards are coordinated.
 
-The existing Balancer / BalancePolicy / BalancerSnapshot / BalancePlan
-boundaries already provide every input required by the normalized design:
-eligible nodes, cross-shard row counts, per-segment `RowNum`, and current
-segment-to-node states. This redesign does not add a provider, RPC, protobuf,
-or QueryView lifecycle state. It changes only Policy-internal configuration,
-steady-state row accounting, node selection, and optional-candidate emission.
+The Balancer / BalancePolicy / BalancerSnapshot / BalancePlan boundaries provide
+every input required by the normalized design: eligible nodes, cluster-wide row
+totals, target-shard row contributions, per-segment `RowNum`, and current
+segment-to-node states. Snapshot construction and row accounting remain
+Coord-local and require no additional RPC, protobuf, or QueryView lifecycle
+state.
 
 ```
 Plan(snap, dirty)
@@ -681,16 +741,18 @@ returned plan itself stores every accepted candidate and segment assignment
 and therefore requires
 `O(L + acceptedCandidates + sum over accepted candidates of S_i)` space.
 
-These bounds exclude snapshot acquisition. After its providers return their
-snapshots, `SnapshotBuilder` additionally spends `O(M + P_all)` time and
-`O(M)` balancer-owned space to build `BalanceNode` entries and aggregate row
-load, where `P_all` is the number of placement-state entries across all shards
-in the snapshot. Provider-specific snapshot construction costs are owned by
-those providers.
+These bounds exclude snapshot acquisition. `SnapshotBuilder` reads only the
+resolved DataView and ShardView scope, refreshes row counts for dirty shards,
+and uses the row-count ledger to populate cluster-wide node loads. Initial and
+periodic full reconciles rebuild the complete ledger.
 
 ## 4. BalancerSnapshot
 
-The snapshot is the global world view built once per reconcile cycle. All dirty shards in the batch are processed against the same snapshot, ensuring consistent decisions.
+The snapshot is the immutable planning view built once per reconcile cycle.
+LoadConfig and node topology remain globally visible. DataView, ShardView, and
+per-shard row details are limited to the resolved planning scope, while each
+node carries its row total across all resident shards. All target shards in the
+batch are processed against the same snapshot.
 
 ### 4.1 Structure
 
@@ -703,10 +765,14 @@ type BalancerSnapshot struct {
     NodeSnapshot       *NodeSnapshot
 
     // Per-node info with cross-shard aggregates embedded.
-    Nodes      map[int64]*BalanceNode
+    Nodes map[int64]*BalanceNode
+
+    // Exact row contributions for target shards. These values are already
+    // included in Nodes and are subtracted before replacement or release.
+    ShardRowStatsSnapshot map[qviews.ShardID]ShardRowStats
 
     // Tunables (production defaults supplied by DefaultBalanceConfig).
-    Config     *BalanceConfig
+    Config *BalanceConfig
 }
 
 // ShardStats is the per-shard placement snapshot returned by ShardViewManager.
@@ -769,6 +835,14 @@ type BalanceNode struct {
     PendingRowCount int64  // Ready / Preparing segments on this node
 }
 
+// ShardRowStats maps each QueryNode to the rows contributed by one shard.
+type ShardRowStats map[int64]NodeRowStats
+
+type NodeRowStats struct {
+    UpRowCount      int64
+    PendingRowCount int64
+}
+
 // BalanceConfig contains only policy inputs. Each score is normalized before
 // its weight is applied.
 type BalanceConfig struct {
@@ -790,7 +864,7 @@ type BalanceConfig struct {
 - The three weights must be non-negative and at least one must be positive. `StickyRowsScale` and `TargetRowsPerShardNode` must be positive.
 - `SegmentCountWeight`, `BaselineSegmentRows`, `BalanceThreshold`, and `CostEfficiencyThreshold` are not part of the normalized design.
 - The production defaults in Section 3.2 are calibrated with deterministic unit and end-to-end scenarios; they are not used as hidden normalization constants.
-- `ShardStats.Segments`, `SegmentInfo.RowNum`, and the existing node aggregates are sufficient to derive per-shard contributions and reusable-copy state. No new snapshot provider field is required.
+- `ShardRowStatsSnapshot` contains the target shards' exact contributions already included in `Nodes`. Policy subtracts these values before replacing or releasing a shard, so the global node totals are not double-counted.
 - Memory and disk capacity are intentionally not admission-control constraints in this policy. Heterogeneous-node capacity normalization can be added later when a reliable capacity signal is available.
 
 ### 4.2 State Source Summary
@@ -798,30 +872,51 @@ type BalanceConfig struct {
 ```
 BalancerSnapshot (built once per reconcile cycle)
 │
-├── LoadConfigSnapshot ← LoadConfigStore
-├── ShardViewSnapshot  ← ShardViewRegistry
-├── DataViewSnapshot   ← DataView Manager + segment lookup
-├── NodeSnapshot       ← Node Manager + Replica Manager
-├── Nodes          ← Node Manager + Replica Manager
-│                     joined with per-node row counts derived from
-│                     ShardViewSnapshot stats × DataViewSnapshot segment RowNum
-└── Config         ← runtime-supplied BalanceConfig
-                     (DefaultBalanceConfig in production wiring)
+├── LoadConfigSnapshot      ← LoadConfigStore (global)
+├── ShardViewSnapshot       ← ShardViewRegistry (target shards)
+├── DataViewSnapshot        ← DataView Manager (selected collections)
+├── NodeSnapshot            ← Node Manager + Replica Manager (global)
+├── Nodes                   ← NodeSnapshot joined with global row-count ledger
+├── ShardRowStatsSnapshot   ← row-count ledger (target shards)
+└── Config                  ← runtime-supplied BalanceConfig
+                              (DefaultBalanceConfig in production wiring)
 ```
+
+`SnapshotBuilder` owns a row-count ledger with three indexes:
+
+```go
+type rowCountLedger struct {
+    segmentRowCounts map[int64]int64
+    shardRowCount    map[qviews.ShardID]ShardRowStats
+    nodeRowCount     map[int64]NodeRowStats
+}
+```
+
+The Registry stats observer marks changed shard contributions dirty without
+performing metadata I/O or starting a reconcile. A scoped build refreshes the
+detached dirty set and keeps stable shard contributions unchanged. An explicit
+or periodic full reconcile clears and rebuilds all three indexes before
+planning. Scope fallback may expand planning to all shards without forcing a
+ledger rebuild.
 
 `RowNum` in segment metadata is the sole balance load metric. A missing or zero
 row count contributes zero load. Zero-row segments are placed using
 stickiness, fanout, and deterministic tie-breaking; no global segment-count
 bonus is added to the node score.
 
-`DeleteApplyStartAfterTimetick` from DataView is passed through to QueryView metadata but is NOT consumed by the allocation algorithm.
+The ledger caches known row counts by SegmentID. Incremental refresh batches
+cache misses through `SegmentSnapshot`; missing metadata contributes zero and
+is not cached, so a later stats update or periodic full reconcile may look it
+up again.
+
+`TransformStartAfterTimetick` from DataView is passed through to QueryView metadata but is NOT consumed by the allocation algorithm.
 
 ### 4.3 Consumption by Phase
 
 | Phase | Snapshot Fields | Purpose |
 |---|---|---|
 | **Phase 1** | `LoadConfigSnapshot`, `ShardViewSnapshot`, `DataViewSnapshot`, `Nodes[*].Alive` | Classify each dirty shard: must / may-optimize / release / none |
-| **Phase 2** | `DataViewSnapshot` shard and segment lookup, `Nodes` filtered by replica, shard segment/node states, normalized-score config | Remove current shard rows, incrementally produce the complete segment → node assignment, update partial rows and opened-node state |
+| **Phase 2** | `DataViewSnapshot` shard and segment lookup, `Nodes` filtered by replica, `ShardRowStatsSnapshot`, shard segment/node states, normalized-score config | Remove current shard rows, incrementally produce the complete segment → node assignment, update partial rows and opened-node state |
 | **Phase 3** | Current assignment and complete candidate assignment | Always emit mandatory work; emit optional work only when assignments differ |
 
 ### 4.4 Within-Batch Coordination
@@ -852,10 +947,10 @@ rebuilding it per shard, or double-counting the replacement view.
 ```
 1. Node Manager detects QN3 crash → Trigger(NodeChanged: true)
 2. Balancer loop wakes and detaches the pending full-scan trigger batch
-3. Balancer builds snapshot; QN3 is unavailable, and shard stats may already
-   reflect Syncer's OnNodeLost transitions
-4. Balancer expands the full-scan batch from the completed snapshot → dirty = [A, B, C]
-5. policy.Plan(snap, dirty):
+3. Scope resolution selects all configured and resident shards
+4. Balancer rebuilds the row-count ledger and snapshot; QN3 is unavailable,
+   and shard stats may already reflect Syncer's OnNodeLost transitions
+5. policy.Plan(snap, [A, B, C]):
    Phase 1: each shard either references unavailable QN3 or is already
             Unrecoverable → all actionMust
    Phase 2: order by size desc; for each shard:
@@ -874,7 +969,8 @@ rebuilding it per shard, or double-counting the replacement view.
 1. Load RPC → broadcast AlterLoadConfigMessage to all collection vchannels → WAL ack
 2. DDL callback: CollectionLoadManager.UpdateLoadConfig(result)
    → persist load config + ensure result vchannel ShardViewManagers + Trigger(DirtyCollections: [C1])
-3. Balancer loop wakes, snapshot includes new LoadConfig but ShardStats is empty
+3. Balancer resolves C1, reads only its DataView and resident ShardStats, and
+   expands its DataView shards across the configured replicas
 4. policy.Plan(snap, [shards of C1]):
    Phase 1: desired present, current absent → actionMust for each
    Phase 2: no stickiness; segments sorted largest-first
@@ -903,18 +999,21 @@ rebuilding it per shard, or double-counting the replacement view.
 | Component | Concurrency Model |
 |---|---|
 | Balancer | Single goroutine reconcile loop. `Trigger()` is thread-safe (enqueue only). |
+| SnapshotBuilder | Row-count ledger is owned by the serialized reconcile loop; a separate mutex protects observer-written dirty shard marks. |
 | BalancePolicy | Stateless pure function; receives immutable snapshot. Thread-safe by definition. |
 | CollectionLoadManager | Delegates desired-state mutation to LoadConfigStore (RWMutex); shard creation is an injected callback. |
+| ShardViewRegistry | RWMutex protects resident managers, stats, reverse indexes, and observer registration. |
 | ShardViewManager | `sync.Mutex` per instance (existing). `Stats()` returns an atomic snapshot. |
 
 ## 7. Component Responsibilities
 
 | Component | Responsibility | Holds State |
 |---|---|---|
-| Balancer | Scheduling framework: work queue + reconcile loop + snapshot builder + plan executor | Work queue only |
+| Balancer | Scheduling framework: work queue + reconcile loop + plan executor | Work queue |
+| SnapshotBuilder | Resolve trigger scope, compose scoped snapshots, and maintain cluster-wide row totals | Row-count ledger + dirty shard set |
 | BalancePolicy | Batch planning: classify dirty shards + compute normalized incremental assignments + emit changed optional candidates | None |
 | CollectionLoadManager | Load-config lifecycle: DDL broadcast-result handling, desired-state persistence, shard ensure callback from result vchannels, dirty collection notify. | None beyond dependencies |
-| ShardViewRegistry | Actual shard view state aggregation and resident ShardViewSnapshot publication. | Registry indexes + snapshot cache |
+| ShardViewRegistry | Actual shard view state aggregation, scoped snapshots, reverse indexes, and stats notifications. | Resident managers + stats + indexes + snapshot cache |
 | ShardViewManager | Per-shard multi-version view management (existing). Exposes `Stats()` for aggregation. | Per-shard state |
 
 ## 8. Package Layout
@@ -924,8 +1023,8 @@ internal/views/
 ├── coord/
 │   ├── balancer/
 │   │   ├── balancer.go        # Balancer + reconcile loop + plan application
-│   │   ├── snapshot_builder.go # SnapshotBuilder composition + row aggregation
-│   │   ├── trigger.go         # TriggerScope definition
+│   │   ├── snapshot_builder.go # Scoped snapshot composition + row-count ledger
+│   │   ├── trigger.go         # TriggerScope queue + reconcile scope resolution
 │   │   ├── snapshot.go        # BalancerSnapshot, BalanceNode, SegmentInfo, BalanceConfig
 │   │   ├── policy.go          # BalancePolicy interface + BalancePlan
 │   │   ├── policy_impl.go     # Default Plan() implementation + shared steady-state row tracker
@@ -949,7 +1048,6 @@ internal/views/
 2. **Global optimization passes**: The current Policy uses deterministic per-shard greedy allocation with a shared steady-state row tracker. For batches where many shards need rebalancing simultaneously (e.g., scale-out), a second optimization pass could detect and resolve cross-shard conflicts (two shards both wanting the same lightly-loaded node).
 3. **Disk-based scoring**: Add `DiskUsage`/`DiskCapacity` back to `BalanceNode` and a disk-balance soft constraint once mmap / disk-index segments are in scope.
 4. **Rate limiting**: Cap concurrent Preparing views across all shards to prevent overwhelming the cluster during large-scale events.
-5. **Snapshot incremental rebuild**: Currently snapshots are built fresh per reconcile cycle. For very large clusters, an incremental snapshot that only re-reads changed collections/shards could reduce overhead.
 
 ## 10. Verification
 
@@ -998,3 +1096,17 @@ internal/views/
 5. QueryNode failure performs mandatory recovery and converges.
 6. A small shard previously spread over many QueryNodes consolidates to a
    smaller node subset.
+
+### 10.4 Snapshot Scope and Row Accounting
+
+1. Dirty collection, shard, and node triggers resolve the expected target
+   shards without reading unrelated ShardStats.
+2. Collection-scoped DataView snapshots exclude unselected collections and
+   preserve segment metadata and delete timeticks for selected collections.
+3. Scoped planning fallback and explicit full reconciliation select the same
+   full planning scope, while only the explicit full path rebuilds the ledger.
+4. Incremental shard contribution replacement produces the same node totals as
+   a full rebuild, including overlapping views and empty stats.
+5. Collection-scoped release uses the Registry collection index, while
+   periodic full reconciliation remains the safety net for residual state
+   outside scoped triggers.

--- a/docs/design-docs/design_docs/qviews/shard_view_management.md
+++ b/docs/design-docs/design_docs/qviews/shard_view_management.md
@@ -83,6 +83,12 @@ Sealed Segment Balancer
 reconstructs every manager, commits all emitted recovery events, and waits for
 the resulting keyed tasks before returning.
 
+The Registry also maintains immutable per-shard stats and reverse indexes for
+Balancer scope resolution. The collection index supports resident-manager
+lookup by collection; the node index follows the latest placement stats.
+Managers remain resident until the Registry closes. Removing a Dropped
+QueryView state machine does not remove its owning manager.
+
 `Close` closes the flush scheduler before the QueryView runtime closes the
 underlying `ReliableSyncer`.
 
@@ -311,9 +317,12 @@ Cleanup continues asynchronously through reliable node callbacks.
 
 During recovery, persisted views are grouped by `ShardID` and reconstructed as
 state machines. Recovered Preparing and Down views create pending sync effects.
-The Registry holds all emitted events inside one Begin/Commit window, commits
-them into keyed tasks, and waits for the Scheduler to become idle before recovery
-completes.
+The Registry holds all emitted events inside one Begin/Commit window. Before
+committing that window, it records each manager's initial stats, builds the
+collection and node indexes, and installs the manager stats observer. It then
+commits the held events and waits for the Scheduler to become idle. This order
+ensures that an immediate recovery sync callback cannot update manager stats
+between the initial snapshot and observer installation.
 
 On shutdown, the QueryView runtime stops the balancer, closes the Registry and
 its flush scheduler, then closes `ReliableSyncer`. This prevents a flush task
@@ -357,6 +366,9 @@ from submitting new sync work after the syncer has closed.
     `ShardID` cannot be flushed by concurrent tasks.
 12. **Cross-Shard Parallelism**: Different `ShardID` lanes may execute in
     different NodeScheduler tasks concurrently.
+13. **Registry Residency**: A manager remains resident after its last QueryView
+    reaches Dropped. QueryView state transitions do not prune collection index
+    entries; node index entries follow the manager's current stats.
 
 ## 8. Package Location
 

--- a/internal/datacoord/dataview_adapter.go
+++ b/internal/datacoord/dataview_adapter.go
@@ -108,6 +108,15 @@ func (s *dataViewSegmentStore) GetSegment(ctx context.Context, segmentID int64) 
 	return newDataViewSegment(s.meta.GetSegment(ctx, segmentID))
 }
 
+func (s *dataViewSegmentStore) GetSegments(_ context.Context, segmentIDs []int64) []*dataview.Segment {
+	segments := s.meta.GetSegmentInfos(segmentIDs)
+	result := make([]*dataview.Segment, 0, len(segments))
+	for _, segment := range segments {
+		result = append(result, newDataViewSegment(segment))
+	}
+	return result
+}
+
 func (s *dataViewSegmentStore) SelectSegments(ctx context.Context, collectionID int64) []*dataview.Segment {
 	segments := s.meta.SelectSegments(ctx, WithCollection(collectionID))
 	result := make([]*dataview.Segment, 0, len(segments))

--- a/internal/datacoord/dataview_adapter_test.go
+++ b/internal/datacoord/dataview_adapter_test.go
@@ -8,10 +8,19 @@ import (
 
 	"github.com/milvus-io/milvus-proto/go-api/v3/commonpb"
 	"github.com/milvus-io/milvus-proto/go-api/v3/msgpb"
+	balancerapi "github.com/milvus-io/milvus/internal/views/coord/balancer/api"
 	"github.com/milvus-io/milvus/pkg/v3/proto/datapb"
 	"github.com/milvus-io/milvus/pkg/v3/proto/viewpb"
 	"github.com/milvus-io/milvus/pkg/v3/util/typeutil"
 )
+
+func (m *fakeGCDataViewManager) DataViewSnapshotForCollections(ctx context.Context, collectionIDs map[int64]struct{}) *balancerapi.DataViewSnapshot {
+	return balancerapi.NewDataViewSnapshot(0, m.snapshotViews, nil)
+}
+
+func (m *fakeGCDataViewManager) SegmentSnapshot(ctx context.Context, segmentIDs []int64) balancerapi.SegmentSnapshot {
+	return nil
+}
 
 func TestServerCreateCollectionDataViewDelegatesToDataViewManager(t *testing.T) {
 	manager := &fakeGCDataViewManager{}
@@ -127,6 +136,45 @@ func TestDataViewSegmentStoreSelectSegmentsSkipsDroppedPartition(t *testing.T) {
 	require.Equal(t, int64(1408), segments[0].GetMemSize())
 	require.Equal(t, uint64(500), segments[0].GetStartPosition().GetTimestamp())
 	require.Equal(t, uint64(500), segments[0].GetTransformStartAfterTimetick())
+}
+
+func TestDataViewSegmentStoreGetSegmentsMapsBatch(t *testing.T) {
+	m := &meta{
+		collections: typeutil.NewConcurrentMap[UniqueID, *collectionInfo](),
+		segments:    NewSegmentsInfo(),
+	}
+	first := NewSegmentInfo(&datapb.SegmentInfo{
+		ID:                            100,
+		CollectionID:                  1,
+		PartitionID:                   10,
+		InsertChannel:                 "ch-1",
+		NumOfRows:                     11,
+		State:                         commonpb.SegmentState_Flushed,
+		Level:                         datapb.SegmentLevel_L1,
+		DeleteApplyStartAfterTimetick: 500,
+	})
+	second := NewSegmentInfo(&datapb.SegmentInfo{
+		ID:            101,
+		CollectionID:  1,
+		PartitionID:   11,
+		InsertChannel: "ch-1",
+		NumOfRows:     22,
+		State:         commonpb.SegmentState_Flushed,
+		Level:         datapb.SegmentLevel_L1,
+	})
+	m.segments.SetSegment(100, first)
+	m.segments.SetSegment(101, second)
+
+	segments := (&dataViewSegmentStore{meta: m}).GetSegments(context.Background(), []int64{101, 404, 100})
+
+	require.Len(t, segments, 2)
+	require.Equal(t, int64(101), segments[0].GetID())
+	require.Equal(t, int64(22), segments[0].GetNumOfRows())
+	require.Equal(t, int64(100), segments[1].GetID())
+	require.Equal(t, int64(10), segments[1].GetPartitionID())
+	require.Equal(t, uint64(500), segments[1].GetTransformStartAfterTimetick())
+	first.NumOfRows = 99
+	require.Equal(t, int64(11), segments[1].GetNumOfRows())
 }
 
 func TestDataViewRecoveryUsesCollectionPartitions(t *testing.T) {

--- a/internal/dataview/manager.go
+++ b/internal/dataview/manager.go
@@ -34,6 +34,7 @@ import (
 
 type SegmentStore interface {
 	GetSegment(ctx context.Context, segID int64) *Segment
+	GetSegments(ctx context.Context, segIDs []int64) []*Segment
 	SelectSegments(ctx context.Context, collectionID int64) []*Segment
 }
 
@@ -67,6 +68,8 @@ type Manager interface {
 	LatestVisibleDataView(ctx context.Context, collectionID int64) (*viewpb.DataViewOfCollection, error)
 	Snapshot(ctx context.Context, collectionIDs []int64) ([]*viewpb.DataViewOfCollection, error)
 	DataViewSnapshot(ctx context.Context) *balancerapi.DataViewSnapshot
+	DataViewSnapshotForCollections(ctx context.Context, collectionIDs map[int64]struct{}) *balancerapi.DataViewSnapshot
+	SegmentSnapshot(ctx context.Context, segmentIDs []int64) balancerapi.SegmentSnapshot
 	ShardTimeTicks(ctx context.Context, collectionIDs []int64) ([]*viewpb.DataViewShardTimeTick, error)
 	IsSegmentReferenced(ctx context.Context, collectionID int64, segmentID int64) (bool, error)
 	GarbageCollect(ctx context.Context, collectionID int64, protected []*viewpb.DataVersion, retainLatest int) error
@@ -663,8 +666,7 @@ func (m *dataViewManager) Snapshot(ctx context.Context, collectionIDs []int64) (
 }
 
 func (m *dataViewManager) DataViewSnapshot(ctx context.Context) *balancerapi.DataViewSnapshot {
-	views, _ := m.Snapshot(ctx, nil)
-	return balancerapi.NewDataViewSnapshot(0, views, m.segmentSnapshot(ctx, views))
+	return m.DataViewSnapshotForCollections(ctx, nil)
 }
 
 type segmentSnapshot map[int64]*balancerapi.SegmentInfo
@@ -674,30 +676,111 @@ func (s segmentSnapshot) Get(segmentID int64) (*balancerapi.SegmentInfo, bool) {
 	return info, ok
 }
 
-func (m *dataViewManager) segmentSnapshot(ctx context.Context, views []*viewpb.DataViewOfCollection) balancerapi.SegmentSnapshot {
-	segments := make(segmentSnapshot)
-	for _, view := range views {
-		for _, shard := range view.GetShards() {
-			for _, partition := range shard.GetPartitions() {
-				for _, segmentID := range partition.GetSegmentIds() {
-					if _, ok := segments[segmentID]; ok {
-						continue
-					}
-					segment := m.segments.GetSegment(ctx, segmentID)
-					if segment == nil {
-						continue
-					}
-					segments[segmentID] = &balancerapi.SegmentInfo{
-						SegmentID:   segment.GetID(),
-						PartitionID: segment.GetPartitionID(),
-						MemSize:     segment.GetMemSize(),
-						RowNum:      segment.GetNumOfRows(),
-					}
-				}
+// DataViewSnapshotForCollections builds an immutable snapshot from the latest
+// visible DataViews in the requested collection scope.
+func (m *dataViewManager) DataViewSnapshotForCollections(ctx context.Context, collectionIDs map[int64]struct{}) *balancerapi.DataViewSnapshot {
+	states := make([]*collectionDataViewState, 0, len(collectionIDs))
+	if collectionIDs == nil {
+		states = m.listStates()
+	} else {
+		for collectionID := range collectionIDs {
+			if state := m.getState(collectionID); state != nil {
+				states = append(states, state)
 			}
 		}
 	}
+
+	views := make([]*viewpb.DataViewOfCollection, 0, len(states))
+	segmentIDs := make([]int64, 0)
+	seenSegments := make(map[int64]struct{})
+	for _, state := range states {
+		state.mu.RLock()
+		if !state.dropped && state.latestVisible != nil {
+			view := canonicalDataViewClone(state.latestVisible)
+			views = append(views, view)
+			for _, partition := range dataViewPartitions(view) {
+				for _, segmentID := range partition.GetSegmentIds() {
+					if _, ok := seenSegments[segmentID]; ok {
+						continue
+					}
+					seenSegments[segmentID] = struct{}{}
+					segmentIDs = append(segmentIDs, segmentID)
+				}
+			}
+		}
+		state.mu.RUnlock()
+	}
+
+	segments := m.getSegments(ctx, segmentIDs)
+	setDataViewDeleteTimeticks(views, segments)
+	return balancerapi.NewDataViewSnapshot(0, views, newSegmentSnapshot(segmentIDs, segments))
+}
+
+// SegmentSnapshot looks up arbitrary segment metadata without requiring the
+// segments to belong to the latest visible DataViews.
+func (m *dataViewManager) SegmentSnapshot(ctx context.Context, segmentIDs []int64) balancerapi.SegmentSnapshot {
+	return newSegmentSnapshot(segmentIDs, m.getSegments(ctx, segmentIDs))
+}
+
+func (m *dataViewManager) getSegments(ctx context.Context, segmentIDs []int64) map[int64]*Segment {
+	segments := make(map[int64]*Segment, len(segmentIDs))
+	if len(segmentIDs) == 0 {
+		return segments
+	}
+	for _, segment := range m.segments.GetSegments(ctx, segmentIDs) {
+		if segment != nil {
+			segments[segment.GetID()] = segment
+		}
+	}
 	return segments
+}
+
+func newSegmentSnapshot(segmentIDs []int64, segmentsByID map[int64]*Segment) balancerapi.SegmentSnapshot {
+	segments := make(segmentSnapshot, len(segmentIDs))
+	for _, segmentID := range segmentIDs {
+		segment := segmentsByID[segmentID]
+		if segment == nil {
+			continue
+		}
+		segments[segmentID] = &balancerapi.SegmentInfo{
+			SegmentID:   segment.GetID(),
+			PartitionID: segment.GetPartitionID(),
+			MemSize:     segment.GetMemSize(),
+			RowNum:      segment.GetNumOfRows(),
+		}
+	}
+	return segments
+}
+
+// setDataViewDeleteTimeticks derives each shard's minimum transform-start
+// timetick from the prefetched segments. Empty shards or any missing member use
+// zero so consumers do not advance beyond unknown metadata.
+func setDataViewDeleteTimeticks(views []*viewpb.DataViewOfCollection, segments map[int64]*Segment) {
+	for _, view := range views {
+		for _, shard := range view.GetShards() {
+			minTs := uint64(math.MaxUint64)
+			hasSegment := false
+			missingSegment := false
+			for _, partition := range shard.GetPartitions() {
+				for _, segmentID := range partition.GetSegmentIds() {
+					hasSegment = true
+					segment := segments[segmentID]
+					if segment == nil {
+						missingSegment = true
+						continue
+					}
+					if ts := segmentTransformStartAfterTimetick(segment); ts < minTs {
+						minTs = ts
+					}
+				}
+			}
+			if !hasSegment || missingSegment {
+				shard.TransformStartAfterTimetick = 0
+			} else {
+				shard.TransformStartAfterTimetick = minTs
+			}
+		}
+	}
 }
 
 func (m *dataViewManager) ShardTimeTicks(ctx context.Context, collectionIDs []int64) ([]*viewpb.DataViewShardTimeTick, error) {

--- a/internal/dataview/manager_test.go
+++ b/internal/dataview/manager_test.go
@@ -140,6 +140,16 @@ func (s *fakeDataViewSegmentStore) GetSegment(ctx context.Context, segID int64) 
 	return s.segments[segID]
 }
 
+func (s *fakeDataViewSegmentStore) GetSegments(ctx context.Context, segIDs []int64) []*Segment {
+	segments := make([]*Segment, 0, len(segIDs))
+	for _, segmentID := range segIDs {
+		if segment := s.segments[segmentID]; segment != nil {
+			segments = append(segments, segment)
+		}
+	}
+	return segments
+}
+
 func (s *fakeDataViewSegmentStore) SelectSegments(ctx context.Context, collectionID int64) []*Segment {
 	segments := make([]*Segment, 0, len(s.segments))
 	for _, segment := range s.segments {
@@ -527,6 +537,100 @@ func TestDataViewManagerDataViewSnapshotForBalancer(t *testing.T) {
 	require.Equal(t, int64(11), segment.RowNum)
 }
 
+func TestDataViewManagerDataViewSnapshotForCollectionsScope(t *testing.T) {
+	ctx := context.Background()
+	manager, _, store := newTestDataViewManager()
+	store.segments[100] = newDataViewTestSegment(1, 10, 100, "ch-1", 1000)
+	store.segments[101] = newDataViewTestSegment(1, 10, 101, "ch-1", 1100)
+	store.segments[101].IsInvisible = true
+	store.segments[200] = newDataViewTestSegment(2, 20, 200, "ch-2", 1200)
+	require.NoError(t, noErrorVersion(manager.OnFlush(ctx, FlushDataViewEvent{CollectionID: 1, SegmentIDs: []int64{100}})))
+	require.NoError(t, noErrorVersion(manager.OnFlush(ctx, FlushDataViewEvent{
+		CollectionID:         1,
+		SegmentIDs:           []int64{101},
+		TemporaryUnavailable: true,
+	})))
+	require.NoError(t, noErrorVersion(manager.OnFlush(ctx, FlushDataViewEvent{CollectionID: 2, SegmentIDs: []int64{200}})))
+
+	tests := []struct {
+		name  string
+		scope map[int64]struct{}
+		has1  bool
+		has2  bool
+	}{
+		{name: "all", scope: nil, has1: true, has2: true},
+		{name: "empty", scope: map[int64]struct{}{}},
+		{name: "selected", scope: map[int64]struct{}{1: {}}, has1: true},
+	}
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			snapshot := manager.DataViewSnapshotForCollections(ctx, test.scope)
+			_, has1 := snapshot.DataVersion(1)
+			_, has2 := snapshot.DataVersion(2)
+			require.Equal(t, test.has1, has1)
+			require.Equal(t, test.has2, has2)
+		})
+	}
+
+	snapshot := manager.DataViewSnapshotForCollections(ctx, map[int64]struct{}{1: {}})
+	shard, ok := snapshot.ShardView(1, "ch-1")
+	require.True(t, ok)
+	require.Equal(t, []int64{100}, shard.GetPartitions()[0].GetSegmentIds())
+	shard.Partitions[0].SegmentIds[0] = 999
+
+	snapshot = manager.DataViewSnapshotForCollections(ctx, map[int64]struct{}{1: {}})
+	shard, ok = snapshot.ShardView(1, "ch-1")
+	require.True(t, ok)
+	require.Equal(t, []int64{100}, shard.GetPartitions()[0].GetSegmentIds())
+}
+
+func TestDataViewManagerDataViewSnapshotForCollectionsTimeticks(t *testing.T) {
+	ctx := context.Background()
+	manager, _, store := newTestDataViewManager()
+	store.segments[100] = newDataViewTestSegment(1, 10, 100, "ch-shared", 900)
+	store.segments[101] = newDataViewTestSegment(1, 11, 101, "ch-shared", 700)
+	store.segments[200] = newDataViewTestSegment(1, 12, 200, "ch-missing", 600)
+
+	sharedShard := newTestDataViewShard("ch-shared", 10, 100)
+	sharedShard.Partitions = append(sharedShard.Partitions,
+		&viewpb.DataViewOfPartition{PartitionId: 11, SegmentIds: []int64{101}})
+	manager.states[1] = &collectionDataViewState{
+		collectionID: 1,
+		latestVisible: newTestDataView(
+			1, 1, 0,
+			sharedShard,
+			newTestDataViewShard("ch-missing", 12, 200, 999),
+			&viewpb.DataViewOfShard{Vchannel: "ch-empty"},
+		),
+	}
+
+	snapshot := manager.DataViewSnapshotForCollections(ctx, map[int64]struct{}{1: {}})
+	shared, ok := snapshot.ShardView(1, "ch-shared")
+	require.True(t, ok)
+	require.Equal(t, uint64(700), shared.GetTransformStartAfterTimetick())
+	missing, ok := snapshot.ShardView(1, "ch-missing")
+	require.True(t, ok)
+	require.Zero(t, missing.GetTransformStartAfterTimetick())
+	empty, ok := snapshot.ShardView(1, "ch-empty")
+	require.True(t, ok)
+	require.Zero(t, empty.GetTransformStartAfterTimetick())
+}
+
+func TestDataViewManagerSegmentSnapshot(t *testing.T) {
+	ctx := context.Background()
+	manager, _, store := newTestDataViewManager()
+	store.segments[100] = newDataViewTestSegment(1, 10, 100, "ch-1", 900)
+	store.segments[100].NumOfRows = 11
+
+	snapshot := manager.SegmentSnapshot(ctx, []int64{100, 999})
+	segment, ok := snapshot.Get(100)
+	require.True(t, ok)
+	require.Equal(t, int64(10), segment.PartitionID)
+	require.Equal(t, int64(11), segment.RowNum)
+	_, ok = snapshot.Get(999)
+	require.False(t, ok)
+}
+
 func TestDataViewManagerCompactPendingOutputIsNoopUntilVisible(t *testing.T) {
 	ctx := context.Background()
 	manager, catalog, store := newTestDataViewManager()
@@ -795,7 +899,8 @@ func TestDataViewManagerRecoverDoesNotReaddHistoricallyRemovedSegments(t *testin
 	manager, catalog, store := newTestDataViewManager()
 	store.segments[100] = newDataViewTestSegment(1, 10, 100, "ch-1", 1000)
 	store.segments[101] = newDataViewTestSegment(1, 11, 101, "ch-1", 1100)
-	catalog.views = append(catalog.views,
+	catalog.views = append(
+		catalog.views,
 		&viewpb.DataViewOfCollection{
 			CollectionId: 1,
 			DataVersion:  &viewpb.DataVersion{StreamingVersion: 1, CompactVersion: 0},
@@ -841,7 +946,8 @@ func TestDataViewManagerRepairCollectionsUsesCatalogDataViews(t *testing.T) {
 	store.segments[101] = newDataViewTestSegment(1, 10, 101, "ch-1", 1100)
 	store.segments[200] = newDataViewTestSegment(2, 20, 200, "ch-2", 2000)
 
-	catalog.views = append(catalog.views,
+	catalog.views = append(
+		catalog.views,
 		newTestDataView(1, 1, 0, newTestDataViewShard("ch-1", 10, 100)),
 		newTestDataView(2, 1, 0, newTestDataViewShard("ch-2", 20, 200)),
 	)
@@ -915,7 +1021,8 @@ func TestDataViewManagerRecoverDoesNotReaddTruncatedSegments(t *testing.T) {
 	manager, catalog, store := newTestDataViewManager()
 	store.segments[100] = newDataViewTestSegment(1, 10, 100, "ch-1", 1000)
 	store.segments[101] = newDataViewTestSegment(1, 10, 101, "ch-1", 1100)
-	catalog.views = append(catalog.views,
+	catalog.views = append(
+		catalog.views,
 		&viewpb.DataViewOfCollection{
 			CollectionId: 1,
 			DataVersion:  &viewpb.DataVersion{StreamingVersion: 1, CompactVersion: 0},
@@ -1086,7 +1193,8 @@ func TestDataViewManagerRecoverKeepsTemporaryFlushResidentUnavailable(t *testing
 	temp := newDataViewTestSegment(1, 10, 101, "ch-1", 1100)
 	temp.IsInvisible = true
 	store.segments[101] = temp
-	catalog.views = append(catalog.views,
+	catalog.views = append(
+		catalog.views,
 		&viewpb.DataViewOfCollection{
 			CollectionId: 1,
 			DataVersion:  &viewpb.DataVersion{StreamingVersion: 1, CompactVersion: 0},
@@ -1201,7 +1309,8 @@ func TestDataViewManagerDropCollectionDropsStateAndCatalog(t *testing.T) {
 func TestDataViewManagerSegmentReferenceUsesRetainedViews(t *testing.T) {
 	ctx := context.Background()
 	manager, catalog, _ := newTestDataViewManager()
-	catalog.views = append(catalog.views,
+	catalog.views = append(
+		catalog.views,
 		&viewpb.DataViewOfCollection{
 			CollectionId: 1,
 			DataVersion:  &viewpb.DataVersion{StreamingVersion: 1, CompactVersion: 0},
@@ -1240,7 +1349,8 @@ func TestDataViewManagerSegmentReferenceUsesRetainedViews(t *testing.T) {
 func TestDataViewManagerGarbageCollectRetainsLatestAndProtectedViews(t *testing.T) {
 	ctx := context.Background()
 	manager, catalog, _ := newTestDataViewManager()
-	catalog.views = append(catalog.views,
+	catalog.views = append(
+		catalog.views,
 		&viewpb.DataViewOfCollection{
 			CollectionId: 1,
 			DataVersion:  &viewpb.DataVersion{StreamingVersion: 1, CompactVersion: 0},
@@ -1311,7 +1421,8 @@ func TestDataViewManagerDoesNotBlockOtherCollections(t *testing.T) {
 func TestDataViewManagerGarbageCollectDoesNotBlockOtherCollections(t *testing.T) {
 	ctx := context.Background()
 	manager, catalog, store := newTestDataViewManager()
-	catalog.views = append(catalog.views,
+	catalog.views = append(
+		catalog.views,
 		&viewpb.DataViewOfCollection{
 			CollectionId: 1,
 			DataVersion:  &viewpb.DataVersion{StreamingVersion: 1, CompactVersion: 0},

--- a/internal/querycoordv2/qviews_runtime.go
+++ b/internal/querycoordv2/qviews_runtime.go
@@ -255,19 +255,47 @@ type mixCoordDataViewProvider struct {
 }
 
 func (p *mixCoordDataViewProvider) DataViewSnapshot(ctx context.Context) *balancer.DataViewSnapshot {
-	source, ok := p.mixCoord.(dataViewProviderSource)
-	if !ok {
-		return balancer.NewDataViewSnapshot(0, nil, nil)
-	}
-	provider := source.DataViewProvider()
+	provider := p.provider()
 	if provider == nil {
 		return balancer.NewDataViewSnapshot(0, nil, nil)
 	}
 	return provider.DataViewSnapshot(ctx)
 }
 
+func (p *mixCoordDataViewProvider) DataViewSnapshotForCollections(ctx context.Context, collectionIDs map[int64]struct{}) *balancer.DataViewSnapshot {
+	provider := p.provider()
+	if provider == nil {
+		return balancer.NewDataViewSnapshot(0, nil, nil)
+	}
+	return provider.DataViewSnapshotForCollections(ctx, collectionIDs)
+}
+
+func (p *mixCoordDataViewProvider) SegmentSnapshot(ctx context.Context, segmentIDs []int64) balancer.SegmentSnapshot {
+	provider := p.provider()
+	if provider == nil {
+		return nil
+	}
+	return provider.SegmentSnapshot(ctx, segmentIDs)
+}
+
+func (p *mixCoordDataViewProvider) provider() balancer.DataViewProvider {
+	source, ok := p.mixCoord.(dataViewProviderSource)
+	if !ok {
+		return nil
+	}
+	return source.DataViewProvider()
+}
+
 type emptyDataViewProvider struct{}
 
 func (emptyDataViewProvider) DataViewSnapshot(context.Context) *balancer.DataViewSnapshot {
 	return balancer.NewDataViewSnapshot(0, nil, nil)
+}
+
+func (emptyDataViewProvider) DataViewSnapshotForCollections(context.Context, map[int64]struct{}) *balancer.DataViewSnapshot {
+	return balancer.NewDataViewSnapshot(0, nil, nil)
+}
+
+func (emptyDataViewProvider) SegmentSnapshot(context.Context, []int64) balancer.SegmentSnapshot {
+	return nil
 }

--- a/internal/querycoordv2/qviews_runtime_test.go
+++ b/internal/querycoordv2/qviews_runtime_test.go
@@ -74,36 +74,6 @@ func TestNewQViewsRuntimeRecoversLoadConfigAndQueryViews(t *testing.T) {
 	assert.Contains(t, runtime.shardViewRegistry.Snapshot().StatsMap(), shardID)
 }
 
-func TestNewQViewsRuntimeUsesDefaultRowBalanceConfig(t *testing.T) {
-	ctx := context.Background()
-	catalog := metastoremocks.NewQueryCoordCatalog(t)
-	catalog.EXPECT().GetCollections(mock.Anything).Return(nil, nil).Once()
-	catalog.EXPECT().GetPartitions(mock.Anything, mock.Anything).
-		Return(map[int64][]*querypb.PartitionLoadInfo{}, nil).Once()
-	catalog.EXPECT().GetReplicas(mock.Anything).Return(nil, nil).Once()
-
-	var config *balancer.BalanceConfig
-	_, err := newQViewsRuntime(ctx, qviewsRuntimeDependencies{
-		queryCoordCatalog:    catalog,
-		queryViewCatalog:     &fakeQueryViewCatalog{},
-		viewSyncClient:       &fakeRuntimeViewSyncClient{},
-		queryNodeClient:      &fakeRuntimeQueryNodeClient{},
-		resourceGroupManager: &fakeRuntimeResourceGroupManager{},
-		dataViewProvider:     &fakeRuntimeDataViewProvider{},
-		balancerFactory: func(builder *balancer.SnapshotBuilder) qviewsBalancer {
-			config = builder.Build(ctx).Config
-			return &fakeRuntimeBalancer{}
-		},
-	})
-	require.NoError(t, err)
-	require.NotNil(t, config)
-	assert.Positive(t, config.StickinessWeight)
-	assert.Positive(t, config.NodeLoadWeight)
-	assert.Positive(t, config.FanoutWeight)
-	assert.Positive(t, config.StickyRowsScale)
-	assert.Positive(t, config.TargetRowsPerShardNode)
-}
-
 type fakeRuntimeDataViewReferences struct {
 	recovered []qviews.DataVersion
 }
@@ -259,6 +229,14 @@ type fakeRuntimeDataViewProvider struct{}
 
 func (p *fakeRuntimeDataViewProvider) DataViewSnapshot(context.Context) *balancer.DataViewSnapshot {
 	return balancer.NewDataViewSnapshot(0, nil, nil)
+}
+
+func (p *fakeRuntimeDataViewProvider) DataViewSnapshotForCollections(context.Context, map[int64]struct{}) *balancer.DataViewSnapshot {
+	return balancer.NewDataViewSnapshot(0, nil, nil)
+}
+
+func (p *fakeRuntimeDataViewProvider) SegmentSnapshot(context.Context, []int64) balancer.SegmentSnapshot {
+	return nil
 }
 
 type fakeRuntimeBalancer struct {

--- a/internal/views/coord/balancer/balancer.go
+++ b/internal/views/coord/balancer/balancer.go
@@ -8,6 +8,7 @@ import (
 	"github.com/cockroachdb/errors"
 
 	"github.com/milvus-io/milvus/internal/views/coord/coordview"
+	"github.com/milvus-io/milvus/internal/views/qviews"
 )
 
 const defaultTickerInterval = 10 * time.Second
@@ -21,7 +22,7 @@ type Balancer interface {
 }
 
 type snapshotSource interface {
-	Build(ctx context.Context) *BalancerSnapshot
+	build(ctx context.Context, pending triggerBatch) (*BalancerSnapshot, []qviews.ShardID)
 }
 
 // DefaultBalancer owns the trigger queue and reconcile loop. Business
@@ -144,8 +145,7 @@ func (b *DefaultBalancer) Reconcile(ctx context.Context) error {
 	if pending.empty() {
 		return nil
 	}
-	snap := b.snapshotBuilder.Build(ctx)
-	dirty := pending.expand(snap)
+	snap, dirty := b.snapshotBuilder.build(ctx, pending)
 	if len(dirty) == 0 {
 		return nil
 	}

--- a/internal/views/coord/balancer/balancer_test.go
+++ b/internal/views/coord/balancer/balancer_test.go
@@ -18,12 +18,16 @@ type testSnapshotSource struct {
 	afterCapture func()
 }
 
-func (s *testSnapshotSource) Build(context.Context) *BalancerSnapshot {
+func (s *testSnapshotSource) build(context.Context, triggerBatch) (*BalancerSnapshot, []qviews.ShardID) {
 	snapshot := s.snapshot
 	if s.afterCapture != nil {
 		s.afterCapture()
 	}
-	return snapshot
+	shards := make([]qviews.ShardID, 0, len(snapshot.ShardStatsMap()))
+	for shardID := range snapshot.ShardStatsMap() {
+		shards = append(shards, shardID)
+	}
+	return snapshot, shards
 }
 
 func TestBalancer_ReconcileDirtyShardAppliesPrepare(t *testing.T) {

--- a/internal/views/coord/balancer/policy_impl.go
+++ b/internal/views/coord/balancer/policy_impl.go
@@ -3,7 +3,6 @@ package balancer
 import (
 	"sort"
 
-	"github.com/milvus-io/milvus/internal/views/coord/coordview"
 	"github.com/milvus-io/milvus/internal/views/qviews"
 	"github.com/milvus-io/milvus/pkg/v3/proto/viewpb"
 )
@@ -118,18 +117,12 @@ func initialProjectedRows(nodes map[int64]*BalanceNode) map[int64]int64 {
 
 func currentShardRows(snap *BalancerSnapshot, shardID qviews.ShardID) map[int64]int64 {
 	rowsByNode := make(map[int64]int64)
-	stats := snap.ShardStatsMap()[shardID]
-	if stats == nil {
+	if snap == nil {
 		return rowsByNode
 	}
-	for segmentID, segment := range stats.Segments {
-		rows := segmentRows(segmentInfoFor(snap, segmentID, segment.PartitionID))
-		for nodeID, state := range segment.Nodes {
-			switch state {
-			case coordview.SegmentStateUp, coordview.SegmentStateReady, coordview.SegmentStatePreparing:
-				rowsByNode[nodeID] += rows
-			}
-		}
+	rowStats := snap.ShardRowStatsSnapshot[shardID]
+	for nodeID, rows := range rowStats {
+		rowsByNode[nodeID] = rows.UpRowCount + rows.PendingRowCount
 	}
 	return rowsByNode
 }

--- a/internal/views/coord/balancer/policy_impl_test.go
+++ b/internal/views/coord/balancer/policy_impl_test.go
@@ -43,6 +43,17 @@ func assignmentsFromBuilder(builder *qviews.QueryViewAtCoordBuilder) map[int64]i
 	return flattenAssignments(builder.Build())
 }
 
+func setTestShardRows(snap *BalancerSnapshot, shardID qviews.ShardID, rowsByNode map[int64]int64) {
+	if snap.ShardRowStatsSnapshot == nil {
+		snap.ShardRowStatsSnapshot = make(map[qviews.ShardID]ShardRowStats)
+	}
+	rowStats := make(ShardRowStats, len(rowsByNode))
+	for nodeID, rows := range rowsByNode {
+		rowStats[nodeID] = NodeRowStats{UpRowCount: rows}
+	}
+	snap.ShardRowStatsSnapshot[shardID] = rowStats
+}
+
 func upStats(version qviews.DataVersion, partitions []int64, fields []int64, placements ...testSegmentPlacement) *coordview.ShardStats {
 	return testShardStats(
 		&qviews.QueryViewVersion{DataVersion: version, QueryVersion: 1},
@@ -213,6 +224,7 @@ func TestDefaultBalancePolicy_ReusedShardRowsAreNotDoubleCounted(t *testing.T) {
 		1: {NodeID: 1, Alive: true, ResourceGroup: "rg1", UpRowCount: 100_000},
 		2: {NodeID: 2, Alive: true, ResourceGroup: "rg1", UpRowCount: 150_000},
 	}
+	setTestShardRows(snap, shardA, map[int64]int64{1: 100_000})
 
 	plan := NewDefaultBalancePolicy().Plan(snap, []qviews.ShardID{shardB, shardA})
 
@@ -231,7 +243,6 @@ func TestDefaultBalancePolicy_ReleasedShardRowsAreRemovedBeforeAllocation(t *tes
 	snap := baseSnap(cfg, loadShard)
 	snap.Config = policyTestConfig()
 	setTestDataSnapshot(snap, collectionID, qviews.DataVersion{StreamingVersion: 1}, newMapSegmentSnapshot(map[int64]*SegmentInfo{
-		101: {SegmentID: 101, PartitionID: 1, RowNum: 100_000},
 		201: {SegmentID: 201, PartitionID: 1, RowNum: 50_000},
 	}), shardDataView("v0", 1, 201))
 	snap.ShardStatsMap()[releaseShard] = upStats(
@@ -244,6 +255,7 @@ func TestDefaultBalancePolicy_ReleasedShardRowsAreRemovedBeforeAllocation(t *tes
 		1: {NodeID: 1, Alive: true, ResourceGroup: "rg1", UpRowCount: 200_000},
 		2: {NodeID: 2, Alive: true, ResourceGroup: "rg1", UpRowCount: 150_000},
 	}
+	setTestShardRows(snap, releaseShard, map[int64]int64{1: 100_000})
 
 	plan := NewDefaultBalancePolicy().Plan(snap, []qviews.ShardID{loadShard, releaseShard})
 
@@ -268,6 +280,7 @@ func TestDefaultBalancePolicy_OptionalOptimizationRequiresMovement(t *testing.T)
 		1: {NodeID: 1, Alive: true, ResourceGroup: "rg1", UpRowCount: 100},
 		2: {NodeID: 2, Alive: true, ResourceGroup: "rg1", UpRowCount: 100},
 	}
+	setTestShardRows(snap, shardID, map[int64]int64{1: 100})
 
 	plan := NewDefaultBalancePolicy().Plan(snap, []qviews.ShardID{shardID})
 
@@ -289,6 +302,7 @@ func TestDefaultBalancePolicy_OptionalOptimizationAcceptedWhenWorthCost(t *testi
 		1: {NodeID: 1, Alive: true, ResourceGroup: "rg1", UpRowCount: 900},
 		2: {NodeID: 2, Alive: true, ResourceGroup: "rg1"},
 	}
+	setTestShardRows(snap, shardID, map[int64]int64{1: 10})
 
 	plan := NewDefaultBalancePolicy().Plan(snap, []qviews.ShardID{shardID})
 
@@ -311,6 +325,7 @@ func TestDefaultBalancePolicy_OptionalChangedAssignmentEmitsWithoutPlanLevelThre
 		1: {NodeID: 1, Alive: true, ResourceGroup: "rg1", UpRowCount: 900},
 		2: {NodeID: 2, Alive: true, ResourceGroup: "rg1"},
 	}
+	setTestShardRows(snap, shardID, map[int64]int64{1: 10})
 
 	plan := NewDefaultBalancePolicy().Plan(snap, []qviews.ShardID{shardID})
 
@@ -331,7 +346,8 @@ func TestDefaultBalancePolicy_LowBenefitScaleOutDoesNotOpenBeyondFanoutBudget(t 
 		103: {SegmentID: 103, PartitionID: 1, RowNum: 20_000},
 		104: {SegmentID: 104, PartitionID: 1, RowNum: 10_000},
 	}), shardDataView("v0", 1, 101, 102, 103, 104))
-	snap.ShardStatsMap()[shardID] = upStats(version, []int64{1}, nil,
+	snap.ShardStatsMap()[shardID] = upStats(
+		version, []int64{1}, nil,
 		placement(101, 1, 1, coordview.SegmentStateUp),
 		placement(102, 1, 2, coordview.SegmentStateUp),
 		placement(103, 1, 2, coordview.SegmentStateUp),
@@ -342,6 +358,7 @@ func TestDefaultBalancePolicy_LowBenefitScaleOutDoesNotOpenBeyondFanoutBudget(t 
 		2: {NodeID: 2, Alive: true, ResourceGroup: "rg1", UpRowCount: 70_000},
 		3: {NodeID: 3, Alive: true, ResourceGroup: "rg1"},
 	}
+	setTestShardRows(snap, shardID, map[int64]int64{1: 80_000, 2: 70_000})
 
 	plan := NewDefaultBalancePolicy().Plan(snap, []qviews.ShardID{shardID})
 
@@ -375,6 +392,7 @@ func TestDefaultBalancePolicy_HighBenefitScaleOutUsesNewNodeWithinFanoutBudget(t
 		2: {NodeID: 2, Alive: true, ResourceGroup: "rg1", UpRowCount: 500_000},
 		3: {NodeID: 3, Alive: true, ResourceGroup: "rg1"},
 	}
+	setTestShardRows(snap, shardID, map[int64]int64{1: 500_000, 2: 500_000})
 
 	plan := NewDefaultBalancePolicy().Plan(snap, []qviews.ShardID{shardID})
 
@@ -403,6 +421,7 @@ func TestDefaultBalancePolicy_SaturatedStickinessIsMaximumOptionalMoveCost(t *te
 		1: {NodeID: 1, Alive: true, ResourceGroup: "rg1", UpRowCount: 101_000_000},
 		2: {NodeID: 2, Alive: true, ResourceGroup: "rg1"},
 	}
+	setTestShardRows(snap, shardID, map[int64]int64{1: 1_000_000})
 
 	plan := NewDefaultBalancePolicy().Plan(snap, []qviews.ShardID{shardID})
 
@@ -433,6 +452,7 @@ func TestDefaultBalancePolicy_DefaultFanoutBudgetRejectsPureLoadOnlyOverflow(t *
 		2: {NodeID: 2, Alive: true, ResourceGroup: "rg1"},
 		3: {NodeID: 3, Alive: true, ResourceGroup: "rg1"},
 	}
+	setTestShardRows(snap, shardID, map[int64]int64{1: 100_000})
 
 	plan := NewDefaultBalancePolicy().Plan(snap, []qviews.ShardID{shardID})
 
@@ -466,6 +486,7 @@ func TestDefaultBalancePolicy_SmallSpreadShardConsolidates(t *testing.T) {
 		2: {NodeID: 2, Alive: true, ResourceGroup: "rg1", UpRowCount: rowsByNode[2]},
 		3: {NodeID: 3, Alive: true, ResourceGroup: "rg1", UpRowCount: rowsByNode[3]},
 	}
+	setTestShardRows(snap, shardID, rowsByNode)
 
 	plan := NewDefaultBalancePolicy().Plan(snap, []qviews.ShardID{shardID})
 
@@ -497,6 +518,7 @@ func TestDefaultBalancePolicy_AppliedOptionalCandidateIsStable(t *testing.T) {
 		2: {NodeID: 2, Alive: true, ResourceGroup: "rg1", UpRowCount: 30_000},
 		3: {NodeID: 3, Alive: true, ResourceGroup: "rg1", UpRowCount: 30_000},
 	}
+	setTestShardRows(snap, shardID, map[int64]int64{1: 40_000, 2: 30_000, 3: 30_000})
 
 	first := NewDefaultBalancePolicy().Plan(snap, []qviews.ShardID{shardID})
 	require.Contains(t, first.Prepares, shardID)
@@ -511,9 +533,12 @@ func TestDefaultBalancePolicy_AppliedOptionalCandidateIsStable(t *testing.T) {
 	for _, node := range snap.Nodes {
 		node.UpRowCount = 0
 	}
+	appliedRows := make(map[int64]int64)
 	for _, nodeID := range assignments {
 		snap.Nodes[nodeID].UpRowCount += 10_000
+		appliedRows[nodeID] += 10_000
 	}
+	setTestShardRows(snap, shardID, appliedRows)
 
 	second := NewDefaultBalancePolicy().Plan(snap, []qviews.ShardID{shardID})
 
@@ -542,6 +567,7 @@ func TestDefaultBalancePolicy_NodeLossPreservesSurvivingReusableSegments(t *test
 		2: {NodeID: 2, Alive: true, ResourceGroup: "rg1", UpRowCount: 100_000},
 		3: {NodeID: 3, Alive: true, ResourceGroup: "rg1"},
 	}
+	setTestShardRows(snap, shardID, map[int64]int64{1: 100_000, 2: 100_000})
 
 	plan := NewDefaultBalancePolicy().Plan(snap, []qviews.ShardID{shardID})
 
@@ -570,6 +596,7 @@ func TestDefaultBalancePolicy_MandatorySameAssignmentStillEmits(t *testing.T) {
 		1: {NodeID: 1, Alive: true, ResourceGroup: "rg1", UpRowCount: 100_000},
 		2: {NodeID: 2, Alive: true, ResourceGroup: "rg1", UpRowCount: 200_000},
 	}
+	setTestShardRows(snap, shardID, map[int64]int64{1: 100_000})
 
 	plan := NewDefaultBalancePolicy().Plan(snap, []qviews.ShardID{shardID})
 

--- a/internal/views/coord/balancer/providers.go
+++ b/internal/views/coord/balancer/providers.go
@@ -66,6 +66,8 @@ func (s *NodeSnapshot) Range(fn func(int64, *NodeInfo) bool) {
 // dataview.Manager.Snapshot(ctx, collectionIDs).
 type DataViewProvider interface {
 	DataViewSnapshot(ctx context.Context) *DataViewSnapshot
+	DataViewSnapshotForCollections(ctx context.Context, collectionIDs map[int64]struct{}) *DataViewSnapshot
+	SegmentSnapshot(ctx context.Context, segmentIDs []int64) SegmentSnapshot
 }
 
 type (

--- a/internal/views/coord/balancer/snapshot.go
+++ b/internal/views/coord/balancer/snapshot.go
@@ -24,6 +24,9 @@ type BalancerSnapshot struct {
 
 	// Per-node info with cross-shard aggregates embedded.
 	Nodes map[int64]*BalanceNode
+	// ShardRowStatsSnapshot contains the target shards' exact row counts already
+	// included in Nodes. Policy subtracts them before replacing or releasing ashard
+	ShardRowStatsSnapshot map[qviews.ShardID]ShardRowStats
 
 	// Tunable parameters for the allocation algorithm.
 	Config *BalanceConfig

--- a/internal/views/coord/balancer/snapshot_builder.go
+++ b/internal/views/coord/balancer/snapshot_builder.go
@@ -2,10 +2,14 @@ package balancer
 
 import (
 	"context"
+	"sync"
+
+	"golang.org/x/exp/maps"
 
 	"github.com/milvus-io/milvus/internal/views/coord/coordview"
 	"github.com/milvus-io/milvus/internal/views/coord/loadmgr"
 	"github.com/milvus-io/milvus/internal/views/qviews"
+	"github.com/milvus-io/milvus/pkg/v3/proto/viewpb"
 )
 
 // SnapshotBuilder assembles a BalancerSnapshot from the various sources:
@@ -13,14 +17,60 @@ import (
 // and external providers (node topology, data views, segment metadata).
 //
 // A builder is typically held by the Balancer and invoked at the start of
-// each reconcile cycle. It is stateless apart from its configured sources;
-// calling Build(ctx) twice produces two independent snapshots.
+// each reconcile cycle. It owns a row-count ledger that is rebuilt by full
+// reconciles and incrementally refreshed from ShardStats changes in between.
 type SnapshotBuilder struct {
 	configStore      *loadmgr.LoadConfigStore
 	viewRegistry     *coordview.ShardViewRegistry
 	nodeProvider     NodeProvider
 	dataViewProvider DataViewProvider
 	config           *BalanceConfig
+
+	// rowCountLedger is owned by the reconcile loop. Reconcile calls must be serialized.
+	rowCountLedger rowCountLedger
+
+	// rowCountDirtyMu protects rowCountDirtyShards.
+	rowCountDirtyMu sync.Mutex
+	// rowCountDirtyShards tracks shards whose row-count contribution needs refresh.
+	rowCountDirtyShards map[qviews.ShardID]struct{}
+}
+
+// rowCountLedger owns the three indexes used by incremental snapshot builds.
+// shardRowCount is the source of nodeRowCount, while segmentRowCounts caches
+// the immutable RowNum metadata needed to construct each shard entry.
+type rowCountLedger struct {
+	segmentRowCounts map[int64]int64
+	shardRowCount    map[qviews.ShardID]ShardRowStats
+	nodeRowCount     map[int64]NodeRowStats
+}
+
+// ShardRowStats maps each QueryNode to the row-count load contributed by one shard.
+type ShardRowStats map[int64]NodeRowStats
+
+// NodeRowStats splits a node's row-count load by placement state.
+type NodeRowStats struct {
+	UpRowCount      int64
+	PendingRowCount int64
+}
+
+func newRowCountLedger() rowCountLedger {
+	return rowCountLedger{
+		segmentRowCounts: make(map[int64]int64),
+		shardRowCount:    make(map[qviews.ShardID]ShardRowStats),
+		nodeRowCount:     make(map[int64]NodeRowStats),
+	}
+}
+
+// shardRowStatsSnapshot returns a stable outer-map snapshot for the shards
+// planned in this cycle. Row-stat entries themselves are immutable.
+func (l *rowCountLedger) shardRowStatsSnapshot(shardIDs []qviews.ShardID) map[qviews.ShardID]ShardRowStats {
+	rowStats := make(map[qviews.ShardID]ShardRowStats, len(shardIDs))
+	for _, shardID := range shardIDs {
+		if stats, ok := l.shardRowCount[shardID]; ok {
+			rowStats[shardID] = stats
+		}
+	}
+	return rowStats
 }
 
 // NewSnapshotBuilder constructs a builder. All arguments must be non-nil.
@@ -31,47 +81,204 @@ func NewSnapshotBuilder(
 	dataViewProvider DataViewProvider,
 	config *BalanceConfig,
 ) *SnapshotBuilder {
-	return &SnapshotBuilder{
-		configStore:      configStore,
-		viewRegistry:     viewRegistry,
-		nodeProvider:     nodeProvider,
-		dataViewProvider: dataViewProvider,
-		config:           config,
+	builder := &SnapshotBuilder{
+		configStore:         configStore,
+		viewRegistry:        viewRegistry,
+		nodeProvider:        nodeProvider,
+		dataViewProvider:    dataViewProvider,
+		config:              config,
+		rowCountLedger:      newRowCountLedger(),
+		rowCountDirtyShards: make(map[qviews.ShardID]struct{}),
 	}
+	if viewRegistry != nil {
+		viewRegistry.RegisterStatsObserver(builder.ObserveShardStats)
+	}
+	return builder
 }
 
-// Build collects a fresh BalancerSnapshot. The flow is:
-//  1. LoadConfigSnapshot ← LoadConfigStore
-//  2. ShardViewSnapshot  ← ShardViewRegistry
-//  3. DataViewSnapshot   ← DataViewProvider
-//  4. NodeSnapshot       ← NodeProvider
-//  5. Nodes              ← NodeSnapshot plus registry node segment overview.
-//
-// The returned snapshot is owned by the caller and not shared with the
-// builder's sources.
-func (b *SnapshotBuilder) Build(ctx context.Context) *BalancerSnapshot {
-	snap := &BalancerSnapshot{
-		Config: b.config,
+// ObserveShardStats marks one shard contribution dirty. It intentionally does
+// not perform metadata I/O or trigger reconciliation; the next scoped or
+// periodic reconcile consumes the mark.
+func (b *SnapshotBuilder) ObserveShardStats(shardID qviews.ShardID, _ *coordview.ShardStats) {
+	b.rowCountDirtyMu.Lock()
+	b.rowCountDirtyShards[shardID] = struct{}{}
+	b.rowCountDirtyMu.Unlock()
+}
+
+// build captures the trigger scope before reading DataView and shard details,
+// refreshes the incremental row-count ledger, and returns the exact shard list
+// that BalancePolicy should plan in this cycle.
+func (b *SnapshotBuilder) build(ctx context.Context, pending triggerBatch) (*BalancerSnapshot, []qviews.ShardID) {
+	// 1. Capture load configs and resolve the preliminary trigger scope.
+	loadSnapshot := b.configStore.Snapshot()
+
+	scope := pending.resolveScope(loadSnapshot, b.viewRegistry)
+
+	// 2. Read scoped DataViews and expand collection triggers into target shards.
+	dataViewSnapshot := b.dataViewProvider.DataViewSnapshotForCollections(ctx, scope.collectionIDs)
+	scope.AddDataViewShards(loadSnapshot, dataViewSnapshot)
+	targetShards := maps.Keys(scope.targetShards)
+
+	// 3. Snapshot shard stats and refresh their contributions to the row-count ledger.
+	rowCountDirtyShards := b.takeRowCountDirtyShards()
+	targetSnapshot := b.viewRegistry.SnapshotForShards(targetShards)
+	if pending.full {
+		b.rebuildRowCountLedger(ctx, targetShards, targetSnapshot.StatsMap(), dataViewSnapshot, scope.collectionIDs)
+	} else if len(rowCountDirtyShards) > 0 {
+		rowCountSnapshot := b.viewRegistry.SnapshotForShards(rowCountDirtyShards)
+		b.refreshRowCountLedger(ctx, rowCountDirtyShards, rowCountSnapshot.StatsMap())
 	}
 
-	// 1. LoadConfigs + replica index.
-	loadSnapshot := b.configStore.Snapshot()
-	snap.LoadConfigSnapshot = loadSnapshot
+	// 4. Assemble the scoped snapshot consumed by BalancePolicy.
+	snap := &BalancerSnapshot{
+		Config:                b.config,
+		LoadConfigSnapshot:    loadSnapshot,
+		ShardViewSnapshot:     targetSnapshot,
+		DataViewSnapshot:      dataViewSnapshot,
+		ShardRowStatsSnapshot: b.rowCountLedger.shardRowStatsSnapshot(targetShards),
+	}
 
-	// 2. ShardStats.
-	viewSnapshot := b.viewRegistry.Snapshot()
-	snap.ShardViewSnapshot = viewSnapshot
-
-	// 3. DataView + segment metadata snapshot.
-	snap.DataViewSnapshot = b.dataViewProvider.DataViewSnapshot(ctx)
-
-	// 5. Nodes: start from provider infos, then aggregate per-node load.
+	// 5. Attach cluster-wide row counts to the current node snapshot.
 	nodeSnapshot := b.nodeProvider.Snapshot()
 	snap.NodeSnapshot = nodeSnapshot
 	snap.Nodes = buildBalanceNodes(nodeSnapshot)
-	aggregateNodeLoad(snap.Nodes, viewSnapshot.StatsMap(), snap)
+	for nodeID, rows := range b.rowCountLedger.nodeRowCount {
+		if node := snap.Nodes[nodeID]; node != nil {
+			node.UpRowCount = rows.UpRowCount
+			node.PendingRowCount = rows.PendingRowCount
+		}
+	}
 
-	return snap
+	return snap, targetShards
+}
+
+// takeRowCountDirtyShards atomically swaps the observer-owned dirty set. Marks
+// arriving after the swap remain in the newly installed set for the next Build.
+func (b *SnapshotBuilder) takeRowCountDirtyShards() []qviews.ShardID {
+	b.rowCountDirtyMu.Lock()
+	dirtySet := b.rowCountDirtyShards
+	b.rowCountDirtyShards = make(map[qviews.ShardID]struct{})
+	b.rowCountDirtyMu.Unlock()
+
+	return maps.Keys(dirtySet)
+}
+
+// cacheSegmentRowCounts preloads RowNum for segments referenced by the scoped
+// DataView before a full ledger rebuild resolves placement-only segments.
+func (b *SnapshotBuilder) cacheSegmentRowCounts(snapshot *DataViewSnapshot, collectionIDs map[int64]struct{}) {
+	for collectionID := range collectionIDs {
+		snapshot.RangeShards(collectionID, func(shard *viewpb.DataViewOfShard) bool {
+			for _, partition := range shard.GetPartitions() {
+				for _, segmentID := range partition.GetSegmentIds() {
+					if info, ok := snapshot.SegmentInfo(segmentID); ok {
+						b.rowCountLedger.segmentRowCounts[segmentID] = segmentRows(info)
+					}
+				}
+			}
+			return true
+		})
+	}
+}
+
+// rebuildRowCountLedger clears all cached ledger state and reconstructs it from
+// the full reconcile scope.
+func (b *SnapshotBuilder) rebuildRowCountLedger(
+	ctx context.Context,
+	shardIDs []qviews.ShardID,
+	statsByShard map[qviews.ShardID]*coordview.ShardStats,
+	dataSnapshot *DataViewSnapshot,
+	collectionIDs map[int64]struct{},
+) {
+	b.rowCountLedger = newRowCountLedger()
+	b.cacheSegmentRowCounts(dataSnapshot, collectionIDs)
+	b.refreshRowCountLedger(ctx, shardIDs, statsByShard)
+}
+
+// refreshRowCountLedger requests uncached placement metadata in one batch,
+// then replaces each shard's contribution in the node aggregates. Missing
+// metadata remains uncached and contributes zero rows.
+func (b *SnapshotBuilder) refreshRowCountLedger(
+	ctx context.Context,
+	shardIDs []qviews.ShardID,
+	statsByShard map[qviews.ShardID]*coordview.ShardStats,
+) {
+	unknownSegments := make([]int64, 0)
+	for _, shardID := range shardIDs {
+		stats := statsByShard[shardID]
+		if stats == nil {
+			continue
+		}
+		for segmentID := range stats.Segments {
+			if _, ok := b.rowCountLedger.segmentRowCounts[segmentID]; ok {
+				continue
+			}
+			unknownSegments = append(unknownSegments, segmentID)
+		}
+	}
+
+	if len(unknownSegments) > 0 {
+		segmentSnapshot := b.dataViewProvider.SegmentSnapshot(ctx, unknownSegments)
+		if segmentSnapshot != nil {
+			for _, segmentID := range unknownSegments {
+				if info, ok := segmentSnapshot.Get(segmentID); ok {
+					b.rowCountLedger.segmentRowCounts[segmentID] = segmentRows(info)
+				}
+			}
+		}
+	}
+
+	for _, shardID := range shardIDs {
+		b.rowCountLedger.replaceShardRowStats(shardID, statsByShard[shardID])
+	}
+}
+
+// replaceShardRowStats removes the previously applied row counts before adding
+// the values derived from the current immutable stats snapshot.
+func (l *rowCountLedger) replaceShardRowStats(shardID qviews.ShardID, stats *coordview.ShardStats) {
+	if old, ok := l.shardRowCount[shardID]; ok {
+		l.applyShardRowStats(old, -1)
+		delete(l.shardRowCount, shardID)
+	}
+	if stats == nil || len(stats.Segments) == 0 {
+		return
+	}
+
+	rowStats := make(ShardRowStats)
+	for segmentID, segment := range stats.Segments {
+		rows := l.segmentRowCounts[segmentID]
+		for nodeID, state := range segment.Nodes {
+			nodeRows := rowStats[nodeID]
+			switch state {
+			case coordview.SegmentStateUp:
+				nodeRows.UpRowCount += rows
+			case coordview.SegmentStateReady, coordview.SegmentStatePreparing:
+				nodeRows.PendingRowCount += rows
+			}
+			rowStats[nodeID] = nodeRows
+		}
+	}
+	l.shardRowCount[shardID] = rowStats
+	l.applyShardRowStats(rowStats, 1)
+}
+
+// applyShardRowStats adds row stats for direction=1 and subtracts them for
+// direction=-1.
+func (l *rowCountLedger) applyShardRowStats(rowStats ShardRowStats, direction int64) {
+	for nodeID, rows := range rowStats {
+		stats := l.nodeRowCount[nodeID]
+		stats.UpRowCount += direction * rows.UpRowCount
+		stats.PendingRowCount += direction * rows.PendingRowCount
+		l.storeNodeRowStats(nodeID, stats)
+	}
+}
+
+// storeNodeRowStats keeps the aggregate ledger sparse by removing zero entries.
+func (l *rowCountLedger) storeNodeRowStats(nodeID int64, stats NodeRowStats) {
+	if stats.UpRowCount == 0 && stats.PendingRowCount == 0 {
+		delete(l.nodeRowCount, nodeID)
+		return
+	}
+	l.nodeRowCount[nodeID] = stats
 }
 
 // buildBalanceNodes converts NodeInfos into BalanceNodes with zero aggregate

--- a/internal/views/coord/balancer/snapshot_builder_test.go
+++ b/internal/views/coord/balancer/snapshot_builder_test.go
@@ -3,6 +3,7 @@ package balancer
 import (
 	"context"
 	"testing"
+	"time"
 
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/mock"
@@ -43,10 +44,55 @@ func (f *fakeNodeProvider) notifyNodeChanged() {
 type fakeDataViewProvider struct {
 	collections []*viewpb.DataViewOfCollection
 	segments    map[int64]*SegmentInfo
+
+	collectionRequests []map[int64]struct{}
+	segmentRequests    [][]int64
+	segmentRequestHook func()
 }
 
 func (f *fakeDataViewProvider) DataViewSnapshot(context.Context) *DataViewSnapshot {
 	return NewDataViewSnapshot(1, f.collections, newMapSegmentSnapshot(f.segments))
+}
+
+func (f *fakeDataViewProvider) DataViewSnapshotForCollections(_ context.Context, collectionIDs map[int64]struct{}) *DataViewSnapshot {
+	f.collectionRequests = append(f.collectionRequests, collectionIDs)
+	selected := f.collections
+	if collectionIDs != nil {
+		selected = nil
+		for _, collection := range f.collections {
+			if _, ok := collectionIDs[collection.GetCollectionId()]; ok {
+				selected = append(selected, collection)
+			}
+		}
+	}
+
+	segmentInfos := make(map[int64]*SegmentInfo)
+	for _, collection := range selected {
+		for _, shard := range collection.GetShards() {
+			for _, partition := range shard.GetPartitions() {
+				for _, segmentID := range partition.GetSegmentIds() {
+					if info := f.segments[segmentID]; info != nil {
+						segmentInfos[segmentID] = info
+					}
+				}
+			}
+		}
+	}
+	return NewDataViewSnapshot(1, selected, newMapSegmentSnapshot(segmentInfos))
+}
+
+func (f *fakeDataViewProvider) SegmentSnapshot(_ context.Context, segmentIDs []int64) SegmentSnapshot {
+	f.segmentRequests = append(f.segmentRequests, append([]int64(nil), segmentIDs...))
+	if f.segmentRequestHook != nil {
+		f.segmentRequestHook()
+	}
+	segments := make(map[int64]*SegmentInfo, len(segmentIDs))
+	for _, segmentID := range segmentIDs {
+		if info := f.segments[segmentID]; info != nil {
+			segments[segmentID] = info
+		}
+	}
+	return newMapSegmentSnapshot(segments)
 }
 
 // --- fake catalog/syncer for the registry and store ---
@@ -111,6 +157,11 @@ func storeWithConfig(t *testing.T, collectionID, replicaID int64, partitions []i
 	return store
 }
 
+func buildFullSnapshot(builder *SnapshotBuilder) *BalancerSnapshot {
+	snapshot, _ := builder.build(context.Background(), triggerBatch{full: true})
+	return snapshot
+}
+
 // addShardWithPreparingView inserts a shard in the registry and gives it a
 // single Preparing view with the specified placements.
 func addShardWithPreparingView(
@@ -145,7 +196,7 @@ func TestSnapshotBuilder_EmptyInputs(t *testing.T) {
 		&BalanceConfig{},
 	)
 
-	snap := builder.Build(context.Background())
+	snap := buildFullSnapshot(builder)
 	require.NotNil(t, snap)
 	assert.Empty(t, snap.ConfigsMap())
 	assert.Empty(t, snap.ShardStatsMap())
@@ -171,7 +222,7 @@ func TestSnapshotBuilder_NodeInfosCopied(t *testing.T) {
 		&BalanceConfig{},
 	)
 
-	snap := builder.Build(context.Background())
+	snap := buildFullSnapshot(builder)
 	require.Len(t, snap.Nodes, 2)
 
 	n1 := snap.Nodes[1]
@@ -220,7 +271,7 @@ func TestSnapshotBuilder_AggregatePerNodeRowLoad(t *testing.T) {
 		&BalanceConfig{},
 	)
 
-	snap := builder.Build(context.Background())
+	snap := buildFullSnapshot(builder)
 	require.Len(t, snap.Nodes, 2)
 
 	n1 := snap.Nodes[1]
@@ -254,8 +305,9 @@ func TestSnapshotBuilder_AggregatePerNodeRowCount(t *testing.T) {
 		&BalanceConfig{},
 	)
 
-	snap := builder.Build(context.Background())
+	snap := buildFullSnapshot(builder)
 	assert.Equal(t, int64(10), snap.Nodes[1].PendingRowCount)
+	assert.Equal(t, NodeRowStats{PendingRowCount: 10}, snap.ShardRowStatsSnapshot[shardID][1])
 }
 
 func TestSnapshotBuilder_CollectsSegmentsFromDataViewsAndPlacements(t *testing.T) {
@@ -296,7 +348,7 @@ func TestSnapshotBuilder_CollectsSegmentsFromDataViewsAndPlacements(t *testing.T
 		&BalanceConfig{},
 	)
 
-	snap := builder.Build(context.Background())
+	snap := buildFullSnapshot(builder)
 
 	// Segment metadata stays behind the DataView snapshot lookup; Build no
 	// longer materializes a segment map.
@@ -333,7 +385,7 @@ func TestSnapshotBuilder_UnknownNodeInPlacementIsSkipped(t *testing.T) {
 		&BalanceConfig{},
 	)
 
-	snap := builder.Build(context.Background())
+	snap := buildFullSnapshot(builder)
 	// Node 99 does not appear in snap.Nodes; Balancer's Phase 1 will flag
 	// current view as referencing an unavailable node.
 	_, ok := snap.Nodes[99]
@@ -357,10 +409,284 @@ func TestSnapshotBuilder_MissingSegmentInfoContributesZero(t *testing.T) {
 		&BalanceConfig{},
 	)
 
-	snap := builder.Build(context.Background())
+	snap := buildFullSnapshot(builder)
 	n1 := snap.Nodes[1]
 	// Only segment 101 contributes its RowNum; segment 102 contributes 0.
 	assert.Equal(t, int64(10), n1.PendingRowCount)
+}
+
+func TestRowCountLedger_ReplaceShardRowStats(t *testing.T) {
+	shardID := qviews.ShardID{ReplicaID: 10, VChannel: "by-dev-rootcoord-dml_0_1v0"}
+	ledger := newRowCountLedger()
+	ledger.segmentRowCounts = map[int64]int64{
+		101: 100,
+		102: 50,
+		103: 30,
+	}
+
+	first := testShardStats(
+		nil,
+		0,
+		placement(101, 10, 1, coordview.SegmentStateUp),
+		placement(101, 10, 2, coordview.SegmentStateReady),
+		placement(102, 10, 1, coordview.SegmentStatePreparing),
+		placement(103, 10, 3, coordview.SegmentStateUnrecoverable),
+	)
+	ledger.replaceShardRowStats(shardID, first)
+
+	assert.Equal(t, NodeRowStats{UpRowCount: 100, PendingRowCount: 50}, ledger.nodeRowCount[1])
+	assert.Equal(t, NodeRowStats{PendingRowCount: 100}, ledger.nodeRowCount[2])
+	assert.NotContains(t, ledger.nodeRowCount, int64(3))
+
+	replacement := testShardStats(
+		nil,
+		0,
+		placement(101, 10, 2, coordview.SegmentStateUp),
+		placement(102, 10, 2, coordview.SegmentStatePreparing),
+	)
+	ledger.replaceShardRowStats(shardID, replacement)
+
+	assert.NotContains(t, ledger.nodeRowCount, int64(1))
+	assert.Equal(t, NodeRowStats{UpRowCount: 100, PendingRowCount: 50}, ledger.nodeRowCount[2])
+
+	ledger.replaceShardRowStats(shardID, &coordview.ShardStats{Segments: map[int64]*coordview.SegmentStats{}})
+	assert.Empty(t, ledger.nodeRowCount)
+	assert.NotContains(t, ledger.shardRowCount, shardID)
+
+	ledger.replaceShardRowStats(shardID, nil)
+	assert.Empty(t, ledger.nodeRowCount)
+}
+
+func TestSnapshotBuilder_RowCountDirtySetSwapPreservesNewMarks(t *testing.T) {
+	firstShard := qviews.ShardID{ReplicaID: 10, VChannel: "by-dev-rootcoord-dml_0_1v0"}
+	secondShard := qviews.ShardID{ReplicaID: 20, VChannel: "by-dev-rootcoord-dml_0_2v0"}
+	store := emptyLoadConfigStore(t)
+	registry := emptyRegistry(t)
+	t.Cleanup(registry.Close)
+	addShardWithPreparingView(t, registry, firstShard, map[int64]map[int64][]int64{
+		1: {10: {101}},
+	})
+	requestStarted := make(chan struct{})
+	continueRequest := make(chan struct{})
+	provider := &fakeDataViewProvider{
+		segments: map[int64]*SegmentInfo{101: {SegmentID: 101, RowNum: 100}},
+		segmentRequestHook: func() {
+			close(requestStarted)
+			<-continueRequest
+		},
+	}
+	builder := NewSnapshotBuilder(
+		store,
+		registry,
+		&fakeNodeProvider{infos: map[int64]*NodeInfo{1: {NodeID: 1, Alive: true}}},
+		provider,
+		&BalanceConfig{},
+	)
+	builder.ObserveShardStats(firstShard, nil)
+
+	buildDone := make(chan struct{})
+	go func() {
+		builder.build(context.Background(), triggerBatch{
+			dirtyShards: map[qviews.ShardID]struct{}{firstShard: {}},
+		})
+		close(buildDone)
+	}()
+	select {
+	case <-requestStarted:
+	case <-time.After(5 * time.Second):
+		t.Fatal("timed out waiting for metadata request")
+	}
+
+	builder.ObserveShardStats(secondShard, nil)
+	close(continueRequest)
+	select {
+	case <-buildDone:
+	case <-time.After(5 * time.Second):
+		t.Fatal("timed out waiting for snapshot build")
+	}
+
+	assert.Equal(t, []qviews.ShardID{secondShard}, builder.takeRowCountDirtyShards())
+	assert.Empty(t, builder.takeRowCountDirtyShards())
+}
+
+func TestSnapshotBuilder_FullRebuildClearsStaleLedgerEntries(t *testing.T) {
+	shardID := qviews.ShardID{ReplicaID: 10, VChannel: "by-dev-rootcoord-dml_0_1v0"}
+	staleShardID := qviews.ShardID{ReplicaID: 20, VChannel: "by-dev-rootcoord-dml_0_2v0"}
+	store := emptyLoadConfigStore(t)
+	registry := emptyRegistry(t)
+	t.Cleanup(registry.Close)
+	addShardWithPreparingView(t, registry, shardID, map[int64]map[int64][]int64{
+		1: {10: {101}},
+	})
+	builder := NewSnapshotBuilder(
+		store,
+		registry,
+		&fakeNodeProvider{infos: map[int64]*NodeInfo{
+			1: {NodeID: 1, Alive: true},
+			2: {NodeID: 2, Alive: true},
+		}},
+		&fakeDataViewProvider{segments: map[int64]*SegmentInfo{
+			101: {SegmentID: 101, RowNum: 100},
+		}},
+		&BalanceConfig{},
+	)
+
+	first := buildFullSnapshot(builder)
+	assert.Equal(t, int64(100), first.Nodes[1].PendingRowCount)
+
+	builder.rowCountLedger.segmentRowCounts[999] = 900
+	builder.rowCountLedger.shardRowCount[staleShardID] = ShardRowStats{
+		2: {PendingRowCount: 900},
+	}
+	builder.rowCountLedger.nodeRowCount[2] = NodeRowStats{PendingRowCount: 900}
+
+	second := buildFullSnapshot(builder)
+
+	assert.Equal(t, int64(100), second.Nodes[1].PendingRowCount)
+	assert.Zero(t, second.Nodes[2].PendingRowCount)
+	assert.NotContains(t, builder.rowCountLedger.segmentRowCounts, int64(999))
+	assert.NotContains(t, builder.rowCountLedger.shardRowCount, staleShardID)
+	assert.NotContains(t, builder.rowCountLedger.nodeRowCount, int64(2))
+}
+
+func TestSnapshotBuilder_ScopedRefreshUsesCachedNonTargetAndMatchesFullPlan(t *testing.T) {
+	const collectionID, replicaID int64 = 1, 10
+	targetShard := qviews.ShardID{ReplicaID: replicaID, VChannel: "by-dev-rootcoord-dml_0_1v0"}
+	nonTargetShard := qviews.ShardID{ReplicaID: 20, VChannel: "by-dev-rootcoord-dml_0_2v0"}
+	store := storeWithConfig(t, collectionID, replicaID, []int64{10}, []int64{1, 2})
+	registry := emptyRegistry(t)
+	t.Cleanup(registry.Close)
+	registry.Ensure(targetShard)
+	addShardWithPreparingView(t, registry, nonTargetShard, map[int64]map[int64][]int64{
+		1: {20: {201}},
+	})
+	provider := &fakeDataViewProvider{
+		collections: []*viewpb.DataViewOfCollection{
+			{
+				CollectionId: collectionID,
+				DataVersion:  (&qviews.DataVersion{StreamingVersion: 1}).IntoProto(),
+				Shards:       []*viewpb.DataViewOfShard{shardDataView(targetShard.VChannel, 10, 101)},
+			},
+			{
+				CollectionId: 2,
+				DataVersion:  (&qviews.DataVersion{StreamingVersion: 1}).IntoProto(),
+				Shards:       []*viewpb.DataViewOfShard{shardDataView(nonTargetShard.VChannel, 20, 201)},
+			},
+		},
+		segments: map[int64]*SegmentInfo{
+			101: {SegmentID: 101, PartitionID: 10, RowNum: 100},
+			201: {SegmentID: 201, PartitionID: 20, RowNum: 900},
+		},
+	}
+	nodeProvider := &fakeNodeProvider{infos: map[int64]*NodeInfo{
+		1: {NodeID: 1, Alive: true},
+		2: {NodeID: 2, Alive: true},
+	}}
+	builder := NewSnapshotBuilder(
+		store,
+		registry,
+		nodeProvider,
+		provider,
+		policyTestConfig(),
+	)
+
+	hydrated := buildFullSnapshot(builder)
+	require.Equal(t, int64(900), hydrated.Nodes[1].PendingRowCount)
+	provider.collectionRequests = nil
+	provider.segmentRequests = nil
+	builder.ObserveShardStats(nonTargetShard, nil)
+
+	scoped, targets := builder.build(context.Background(), triggerBatch{
+		dirtyColls: map[int64]struct{}{collectionID: {}},
+	})
+
+	assert.Equal(t, []qviews.ShardID{targetShard}, targets)
+	assert.Contains(t, scoped.ShardStatsMap(), targetShard)
+	assert.NotContains(t, scoped.ShardStatsMap(), nonTargetShard)
+	assert.Equal(t, int64(900), scoped.Nodes[1].PendingRowCount)
+	assert.Equal(t, []map[int64]struct{}{setOf[int64](collectionID)}, provider.collectionRequests)
+	assert.Empty(t, provider.segmentRequests, "cached non-target rows must not trigger metadata I/O")
+
+	oracle := &BalancerSnapshot{
+		Config:             builder.config,
+		LoadConfigSnapshot: store.Snapshot(),
+		ShardViewSnapshot:  registry.Snapshot(),
+		DataViewSnapshot:   provider.DataViewSnapshot(context.Background()),
+		NodeSnapshot:       nodeProvider.Snapshot(),
+	}
+	oracle.Nodes = buildBalanceNodes(oracle.NodeSnapshot)
+	aggregateNodeLoad(oracle.Nodes, oracle.ShardStatsMap(), oracle)
+	assert.Equal(t, oracle.Nodes, scoped.Nodes)
+
+	policy := NewDefaultBalancePolicy()
+	scopedPlan := policy.Plan(scoped, targets)
+	fullPlan := policy.Plan(oracle, []qviews.ShardID{targetShard})
+	require.Contains(t, scopedPlan.Prepares, targetShard)
+	require.Contains(t, fullPlan.Prepares, targetShard)
+	assert.Equal(
+		t,
+		assignmentsFromBuilder(fullPlan.Prepares[targetShard]),
+		assignmentsFromBuilder(scopedPlan.Prepares[targetShard]),
+	)
+}
+
+func TestSnapshotBuilder_MissingNonTargetMetadataDoesNotScheduleRetry(t *testing.T) {
+	const collectionID, replicaID int64 = 1, 10
+	targetShard := qviews.ShardID{ReplicaID: replicaID, VChannel: "by-dev-rootcoord-dml_0_1v0"}
+	nonTargetShard := qviews.ShardID{ReplicaID: 20, VChannel: "by-dev-rootcoord-dml_0_2v0"}
+	store := storeWithConfig(t, collectionID, replicaID, []int64{10}, []int64{1, 2})
+	registry := emptyRegistry(t)
+	t.Cleanup(registry.Close)
+	registry.Ensure(targetShard)
+	addShardWithPreparingView(t, registry, nonTargetShard, map[int64]map[int64][]int64{
+		1: {20: {201}},
+	})
+	provider := &fakeDataViewProvider{
+		collections: []*viewpb.DataViewOfCollection{
+			{
+				CollectionId: collectionID,
+				DataVersion:  (&qviews.DataVersion{StreamingVersion: 1}).IntoProto(),
+				Shards:       []*viewpb.DataViewOfShard{shardDataView(targetShard.VChannel, 10, 101)},
+			},
+			{
+				CollectionId: 2,
+				DataVersion:  (&qviews.DataVersion{StreamingVersion: 1}).IntoProto(),
+				Shards:       []*viewpb.DataViewOfShard{shardDataView(nonTargetShard.VChannel, 20, 201)},
+			},
+		},
+		segments: map[int64]*SegmentInfo{
+			101: {SegmentID: 101, PartitionID: 10, RowNum: 100},
+		},
+	}
+	builder := NewSnapshotBuilder(
+		store,
+		registry,
+		&fakeNodeProvider{infos: map[int64]*NodeInfo{
+			1: {NodeID: 1, Alive: true},
+			2: {NodeID: 2, Alive: true},
+		}},
+		provider,
+		policyTestConfig(),
+	)
+	pending := triggerBatch{dirtyColls: map[int64]struct{}{collectionID: {}}}
+
+	first := buildFullSnapshot(builder)
+	assert.Zero(t, first.Nodes[1].PendingRowCount)
+	assert.Equal(t, [][]int64{{201}}, provider.segmentRequests)
+
+	provider.segmentRequests = nil
+	second, _ := builder.build(context.Background(), pending)
+	assert.Zero(t, second.Nodes[1].PendingRowCount)
+	assert.Empty(t, provider.segmentRequests)
+
+	provider.segments[201] = &SegmentInfo{SegmentID: 201, PartitionID: 20, RowNum: 900}
+	provider.segmentRequests = nil
+	third, _ := builder.build(context.Background(), pending)
+	assert.Zero(t, third.Nodes[1].PendingRowCount)
+	assert.Empty(t, provider.segmentRequests)
+
+	fourth := buildFullSnapshot(builder)
+	assert.Equal(t, int64(900), fourth.Nodes[1].PendingRowCount)
 }
 
 func TestAggregateNodeLoad_SkipsUnrecoverableLoad(t *testing.T) {

--- a/internal/views/coord/balancer/trigger.go
+++ b/internal/views/coord/balancer/trigger.go
@@ -1,11 +1,13 @@
 package balancer
 
 import (
-	"sort"
 	"sync"
 
+	"github.com/milvus-io/milvus/internal/views/coord/coordview"
+	"github.com/milvus-io/milvus/internal/views/coord/loadmgr"
 	"github.com/milvus-io/milvus/internal/views/qviews"
-	"github.com/milvus-io/milvus/pkg/v3/util/funcutil"
+	"github.com/milvus-io/milvus/pkg/v3/proto/viewpb"
+	"github.com/milvus-io/milvus/pkg/v3/util/metautil"
 )
 
 // TriggerScope describes the external event scope that dirtied the Balancer.
@@ -38,8 +40,146 @@ type triggerBatch struct {
 	dirtyColls  map[int64]struct{}
 }
 
+// reconcileScope is the scoped DataView-read and Policy-planning boundary
+// resolved from one trigger batch.
+type reconcileScope struct {
+	// collectionIDs selects collections whose DataViews are fetched.
+	collectionIDs map[int64]struct{}
+
+	// collectionWideIDs selects collections whose DataView shards are all
+	// expanded into Policy targets.
+	collectionWideIDs map[int64]struct{}
+
+	// targetShards is the exact ShardStats scope and final Policy input.
+	targetShards map[qviews.ShardID]struct{}
+}
+
 func (b triggerBatch) empty() bool {
 	return !b.full && len(b.dirtyNodes) == 0 && len(b.dirtyShards) == 0 && len(b.dirtyColls) == 0
+}
+
+// resolveScope converts queued collection and shard events into scoped reads
+// and Policy targets. Collection events include resident residual shards;
+// malformed shard channels conservatively fall back to a full reconcile.
+func (b triggerBatch) resolveScope(
+	loadSnapshot *loadmgr.LoadConfigSnapshot,
+	registry *coordview.ShardViewRegistry,
+) reconcileScope {
+	if b.full {
+		return fullReconcileScope(loadSnapshot, registry)
+	}
+
+	scope := newReconcileScope()
+	for collectionID := range b.dirtyColls {
+		scope.collectionIDs[collectionID] = struct{}{}
+		scope.collectionWideIDs[collectionID] = struct{}{}
+		if registry != nil {
+			scope.addShards(registry.CollectionShards(collectionID))
+		}
+	}
+
+	for nodeID := range b.dirtyNodes {
+		if registry == nil {
+			return fullReconcileScope(loadSnapshot, registry)
+		}
+		for _, shardID := range registry.NodeShards(nodeID) {
+			collectionID, ok := parseShardCollection(shardID)
+			if !ok {
+				return fullReconcileScope(loadSnapshot, registry)
+			}
+			scope.collectionIDs[collectionID] = struct{}{}
+			scope.targetShards[shardID] = struct{}{}
+		}
+	}
+
+	for shardID := range b.dirtyShards {
+		collectionID, ok := parseShardCollection(shardID)
+		if !ok {
+			return fullReconcileScope(loadSnapshot, registry)
+		}
+		scope.collectionIDs[collectionID] = struct{}{}
+		scope.targetShards[shardID] = struct{}{}
+	}
+
+	return scope
+}
+
+// AddDataViewShards expands collection-triggered scope into replica-by-vchannel
+// targets from the latest DataView. Direct dirty-shard scope is not expanded.
+func (s *reconcileScope) AddDataViewShards(
+	loadSnapshot *loadmgr.LoadConfigSnapshot,
+	dataSnapshot *DataViewSnapshot,
+) {
+	for collectionID := range s.collectionWideIDs {
+		cfg := loadSnapshot.ConfigsMap()[collectionID]
+		if cfg == nil {
+			continue
+		}
+		dataSnapshot.RangeShards(collectionID, func(shard *viewpb.DataViewOfShard) bool {
+			if shard == nil {
+				return true
+			}
+			for _, replica := range cfg.Replicas {
+				if replica == nil {
+					continue
+				}
+				s.targetShards[qviews.ShardID{
+					ReplicaID: replica.ReplicaID,
+					VChannel:  shard.GetVchannel(),
+				}] = struct{}{}
+			}
+			return true
+		})
+	}
+}
+
+func newReconcileScope() reconcileScope {
+	return reconcileScope{
+		collectionIDs:     make(map[int64]struct{}),
+		collectionWideIDs: make(map[int64]struct{}),
+		targetShards:      make(map[qviews.ShardID]struct{}),
+	}
+}
+
+// fullReconcileScope combines configured collections with all resident shards,
+// so residual views remain visible after their load config has been removed.
+func fullReconcileScope(
+	loadSnapshot *loadmgr.LoadConfigSnapshot,
+	registry *coordview.ShardViewRegistry,
+) reconcileScope {
+	scope := newReconcileScope()
+	if loadSnapshot != nil {
+		for collectionID := range loadSnapshot.ConfigsMap() {
+			scope.collectionIDs[collectionID] = struct{}{}
+			scope.collectionWideIDs[collectionID] = struct{}{}
+		}
+	}
+	if registry != nil {
+		shardIDs := registry.ShardIDs()
+		scope.addShards(shardIDs)
+		for _, shardID := range shardIDs {
+			if collectionID, ok := parseShardCollection(shardID); ok {
+				scope.collectionIDs[collectionID] = struct{}{}
+			}
+		}
+	}
+	return scope
+}
+
+func (s *reconcileScope) addShards(shardIDs []qviews.ShardID) {
+	for _, shardID := range shardIDs {
+		s.targetShards[shardID] = struct{}{}
+	}
+}
+
+// parseShardCollection extracts the collection ID encoded in a shard vchannel.
+// resolveScope uses a false result to fall back to a full reconcile.
+func parseShardCollection(shardID qviews.ShardID) (int64, bool) {
+	channel, err := metautil.ParseChannel(shardID.VChannel, metautil.NewDynChannelMapper())
+	if err != nil {
+		return 0, false
+	}
+	return channel.CollectionID(), true
 }
 
 func newTriggerQueue() *triggerQueue {
@@ -89,41 +229,6 @@ func (q *triggerQueue) signalCh() <-chan struct{} {
 	return q.signal
 }
 
-func (b triggerBatch) expand(snap *BalancerSnapshot) []qviews.ShardID {
-	if snap == nil {
-		return nil
-	}
-
-	out := make(map[qviews.ShardID]struct{})
-	if b.full {
-		for _, shardID := range allSnapshotShards(snap) {
-			out[shardID] = struct{}{}
-		}
-	}
-	for shardID := range b.dirtyShards {
-		out[shardID] = struct{}{}
-	}
-	for nodeID := range b.dirtyNodes {
-		for _, shardID := range snapshotShardsByNode(snap, nodeID) {
-			out[shardID] = struct{}{}
-		}
-	}
-	for collectionID := range b.dirtyColls {
-		for _, shardID := range snapshotShardsByCollection(snap, collectionID) {
-			out[shardID] = struct{}{}
-		}
-	}
-
-	shards := make([]qviews.ShardID, 0, len(out))
-	for shardID := range out {
-		shards = append(shards, shardID)
-	}
-	sort.Slice(shards, func(i, j int) bool {
-		return shardLess(shards[i], shards[j])
-	})
-	return shards
-}
-
 func (q *triggerQueue) takePending() triggerBatch {
 	q.mu.Lock()
 	defer q.mu.Unlock()
@@ -140,68 +245,4 @@ func (q *triggerQueue) takePending() triggerBatch {
 	q.dirtyShards = make(map[qviews.ShardID]struct{})
 	q.dirtyColls = make(map[int64]struct{})
 	return pending
-}
-
-func allSnapshotShards(snap *BalancerSnapshot) []qviews.ShardID {
-	seen := make(map[qviews.ShardID]struct{})
-	for shardID := range snap.ShardStatsMap() {
-		seen[shardID] = struct{}{}
-	}
-	for collectionID := range snap.ConfigsMap() {
-		snap.RangeDataShards(collectionID, func(shardID qviews.ShardID) bool {
-			seen[shardID] = struct{}{}
-			return true
-		})
-	}
-	out := make([]qviews.ShardID, 0, len(seen))
-	for shardID := range seen {
-		out = append(out, shardID)
-	}
-	return out
-}
-
-func snapshotShardsByNode(snap *BalancerSnapshot, nodeID int64) []qviews.ShardID {
-	seen := make(map[qviews.ShardID]struct{})
-	for shardID, stats := range snap.ShardStatsMap() {
-		if stats == nil {
-			continue
-		}
-		for _, segment := range stats.Segments {
-			if _, ok := segment.Nodes[nodeID]; ok {
-				seen[shardID] = struct{}{}
-				break
-			}
-		}
-	}
-	out := make([]qviews.ShardID, 0, len(seen))
-	for shardID := range seen {
-		out = append(out, shardID)
-	}
-	return out
-}
-
-func snapshotShardsByCollection(snap *BalancerSnapshot, collectionID int64) []qviews.ShardID {
-	seen := make(map[qviews.ShardID]struct{})
-	for shardID := range snap.ShardStatsMap() {
-		cfg := snap.ConfigForShard(shardID)
-		if cfg != nil && cfg.CollectionID == collectionID {
-			seen[shardID] = struct{}{}
-			continue
-		}
-		// ReleaseCollection removes the load config before triggering the
-		// collection reconcile. Recover the collection from the vchannel so
-		// residual shard views are released without waiting for a full scan.
-		if cfg == nil && funcutil.GetCollectionIDFromVChannel(shardID.VChannel) == collectionID {
-			seen[shardID] = struct{}{}
-		}
-	}
-	snap.RangeDataShards(collectionID, func(shardID qviews.ShardID) bool {
-		seen[shardID] = struct{}{}
-		return true
-	})
-	out := make([]qviews.ShardID, 0, len(seen))
-	for shardID := range seen {
-		out = append(out, shardID)
-	}
-	return out
 }

--- a/internal/views/coord/balancer/trigger_test.go
+++ b/internal/views/coord/balancer/trigger_test.go
@@ -1,61 +1,255 @@
 package balancer
 
 import (
+	"fmt"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
 
 	"github.com/milvus-io/milvus/internal/views/coord/coordview"
+	"github.com/milvus-io/milvus/internal/views/coord/loadmgr"
 	"github.com/milvus-io/milvus/internal/views/qviews"
+	"github.com/milvus-io/milvus/pkg/v3/proto/viewpb"
 )
 
-func TestTriggerQueueDirtyNodeExpandsOnlyAffectedShards(t *testing.T) {
-	shardA := qviews.ShardID{ReplicaID: 1, VChannel: "v0"}
-	shardB := qviews.ShardID{ReplicaID: 1, VChannel: "v1"}
-	shardWithoutStats := qviews.ShardID{ReplicaID: 1, VChannel: "v2"}
-	snap := &BalancerSnapshot{
-		ShardViewSnapshot: coordview.NewShardViewSnapshot(1, map[qviews.ShardID]*coordview.ShardStats{
-			shardA: testShardStats(nil, 0,
-				placement(101, 1, 10, coordview.SegmentStateUp),
-			),
-			shardB: testShardStats(nil, 0,
-				placement(201, 1, 20, coordview.SegmentStatePreparing),
-			),
-			shardWithoutStats: nil,
-		}),
-	}
+func TestTriggerBatchResolveDirtyCollection(t *testing.T) {
+	registry := triggerTestRegistry(t)
+	shardA := triggerShard(2, 1, 0)
+	shardB := triggerShard(1, 1, 1)
+	unrelated := triggerShard(1, 2, 0)
+	registry.Ensure(shardA)
+	registry.Ensure(shardB)
+	registry.Ensure(unrelated)
 
-	queue := newTriggerQueue()
-	queue.add(TriggerScope{DirtyNodes: []int64{10, 10}})
+	scope := (triggerBatch{dirtyColls: setOf[int64](1)}).resolveScope(nil, registry)
 
-	assert.Equal(t, []qviews.ShardID{shardA}, queue.takePending().expand(snap))
-	assert.Empty(t, queue.takePending().expand(snap), "takePending must clear the pending node set")
+	assert.Equal(t, setOf[int64](1), scope.collectionIDs)
+	assert.Equal(t, setOf(shardB, shardA), scope.targetShards)
 }
 
-func TestTriggerQueueNilSnapshotDropsPendingWork(t *testing.T) {
-	queue := newTriggerQueue()
-	queue.add(TriggerScope{
-		DirtyNodes:       []int64{1},
-		DirtyShards:      []qviews.ShardID{{ReplicaID: 1, VChannel: "v0"}},
-		DirtyCollections: []int64{10},
+func TestTriggerBatchResolveDirtyShard(t *testing.T) {
+	shard := triggerShard(10, 2, 0)
+	scope := (triggerBatch{dirtyShards: setOf(shard)}).resolveScope(nil, nil)
+
+	assert.Equal(t, setOf[int64](2), scope.collectionIDs)
+	assert.Equal(t, setOf(shard), scope.targetShards)
+}
+
+func TestTriggerBatchResolveDirtyNode(t *testing.T) {
+	registry := triggerTestRegistry(t)
+	shardA := triggerShard(10, 1, 0)
+	shardB := triggerShard(20, 2, 0)
+	unrelated := triggerShard(30, 3, 0)
+	addShardWithPreparingView(t, registry, shardA, map[int64]map[int64][]int64{
+		100: {10: {101}},
+	})
+	addShardWithPreparingView(t, registry, shardB, map[int64]map[int64][]int64{
+		100: {20: {201}},
+	})
+	addShardWithPreparingView(t, registry, unrelated, map[int64]map[int64][]int64{
+		200: {30: {301}},
 	})
 
-	assert.Nil(t, queue.takePending().expand(nil))
-	assert.Empty(t, queue.takePending().expand(&BalancerSnapshot{}))
+	scope := (triggerBatch{dirtyNodes: setOf[int64](100)}).resolveScope(nil, registry)
+
+	assert.Equal(t, setOf[int64](1, 2), scope.collectionIDs)
+	assert.Empty(t, scope.collectionWideIDs)
+	assert.Equal(t, setOf(shardA, shardB), scope.targetShards)
 }
 
-func TestTriggerBatchExpandReleasedCollectionIncludesResidualShards(t *testing.T) {
-	const collectionID int64 = 1
-	residualShard := qviews.ShardID{ReplicaID: 10, VChannel: "by-dev-rootcoord-dml_0_1v0"}
-	unrelatedShard := qviews.ShardID{ReplicaID: 20, VChannel: "by-dev-rootcoord-dml_0_2v0"}
-	snap := &BalancerSnapshot{
-		ShardViewSnapshot: coordview.NewShardViewSnapshot(1, map[qviews.ShardID]*coordview.ShardStats{
-			residualShard:  testShardStats(nil, 0),
-			unrelatedShard: testShardStats(nil, 0),
-		}),
+func TestTriggerBatchMalformedNodeShardFallsBackToFull(t *testing.T) {
+	loadSnapshot := triggerLoadSnapshot(triggerLoadConfig(1, 10), triggerLoadConfig(2, 20))
+	registry := triggerTestRegistry(t)
+	validShard := triggerShard(20, 2, 0)
+	malformedShard := qviews.ShardID{ReplicaID: 10, VChannel: "malformed"}
+	addShardWithPreparingView(t, registry, validShard, map[int64]map[int64][]int64{
+		100: {20: {201}},
+	})
+	addShardWithPreparingView(t, registry, malformedShard, map[int64]map[int64][]int64{
+		100: {10: {101}},
+	})
+
+	scope := (triggerBatch{dirtyNodes: setOf[int64](100)}).resolveScope(loadSnapshot, registry)
+
+	assert.Equal(t, setOf[int64](1, 2), scope.collectionIDs)
+	assert.Equal(t, setOf(registry.ShardIDs()...), scope.targetShards)
+}
+
+func TestTriggerBatchResolveMergesScopes(t *testing.T) {
+	registry := triggerTestRegistry(t)
+	collectionShard := triggerShard(1, 1, 0)
+	dirtyShard := triggerShard(2, 2, 0)
+	registry.Ensure(collectionShard)
+
+	scope := (triggerBatch{
+		dirtyColls:  setOf[int64](1),
+		dirtyShards: setOf(dirtyShard),
+	}).resolveScope(nil, registry)
+
+	assert.Equal(t, setOf[int64](1, 2), scope.collectionIDs)
+	assert.Equal(t, setOf(collectionShard, dirtyShard), scope.targetShards)
+}
+
+func TestTriggerBatchResolveFull(t *testing.T) {
+	registry := triggerTestRegistry(t)
+	shardA := triggerShard(2, 1, 0)
+	residualShard := triggerShard(3, 3, 0)
+	malformedShard := qviews.ShardID{ReplicaID: 1, VChannel: "malformed"}
+	registry.Ensure(shardA)
+	registry.Ensure(residualShard)
+	registry.Ensure(malformedShard)
+	loadSnapshot := triggerLoadSnapshot(
+		triggerLoadConfig(2, 20),
+		triggerLoadConfig(1, 10),
+	)
+
+	queue := newTriggerQueue()
+	queue.add(TriggerScope{NodeChanged: true})
+	scope := queue.takePending().resolveScope(loadSnapshot, registry)
+
+	assert.Equal(t, setOf[int64](1, 2, 3), scope.collectionIDs)
+	assert.Equal(t, setOf(malformedShard, shardA, residualShard), scope.targetShards)
+	assert.True(t, queue.takePending().empty())
+}
+
+func TestTriggerBatchMalformedDirtyShardFallsBackToFull(t *testing.T) {
+	loadSnapshot := triggerLoadSnapshot(triggerLoadConfig(1, 10), triggerLoadConfig(2, 20))
+	registry := triggerTestRegistry(t)
+	validShard := triggerShard(2, 2, 0)
+	malformedShard := qviews.ShardID{ReplicaID: 1, VChannel: "malformed"}
+	registry.Ensure(validShard)
+	registry.Ensure(malformedShard)
+
+	scope := (triggerBatch{dirtyShards: setOf(malformedShard)}).resolveScope(loadSnapshot, registry)
+
+	assert.Equal(t, setOf[int64](1, 2), scope.collectionIDs)
+	assert.Equal(t, setOf(registry.ShardIDs()...), scope.targetShards)
+}
+
+func TestTriggerBatchReleasedCollectionIncludesResidualShards(t *testing.T) {
+	registry := triggerTestRegistry(t)
+	residualShard := triggerShard(10, 1, 0)
+	unrelatedShard := triggerShard(20, 2, 0)
+	registry.Ensure(residualShard)
+	registry.Ensure(unrelatedShard)
+
+	scope := (triggerBatch{dirtyColls: setOf[int64](1)}).resolveScope(
+		triggerLoadSnapshot(triggerLoadConfig(2, 20)),
+		registry,
+	)
+
+	assert.Equal(t, setOf[int64](1), scope.collectionIDs)
+	assert.Equal(t, setOf(residualShard), scope.targetShards)
+}
+
+func TestTriggerBatchDirtyCollectionUsesCollectionIndexOnly(t *testing.T) {
+	registry := triggerTestRegistry(t)
+	malformedResidual := qviews.ShardID{ReplicaID: 20, VChannel: "malformed"}
+	registry.Ensure(malformedResidual)
+	loadSnapshot := triggerLoadSnapshot(triggerLoadConfig(1, 10))
+
+	scope := (triggerBatch{dirtyColls: setOf[int64](99)}).resolveScope(loadSnapshot, registry)
+
+	assert.Equal(t, setOf[int64](99), scope.collectionIDs)
+	assert.Empty(t, scope.targetShards)
+}
+
+func TestReconcileScopeAddDataViewShards(t *testing.T) {
+	loadSnapshot := triggerLoadSnapshot(&loadmgr.LoadConfig{
+		CollectionID: 1,
+		Replicas: []*loadmgr.ReplicaAssignment{
+			{ReplicaID: 20},
+			{ReplicaID: 10},
+		},
+	})
+	dataSnapshot := NewDataViewSnapshot(1, []*viewpb.DataViewOfCollection{
+		{
+			CollectionId: 1,
+			DataVersion:  &viewpb.DataVersion{},
+			Shards: []*viewpb.DataViewOfShard{
+				{Vchannel: "by-dev-rootcoord-dml_0_1v1"},
+				nil,
+				{Vchannel: "by-dev-rootcoord-dml_0_1v0"},
+			},
+		},
+		{
+			CollectionId: 2,
+			DataVersion:  &viewpb.DataVersion{},
+			Shards:       []*viewpb.DataViewOfShard{{Vchannel: "by-dev-rootcoord-dml_0_2v0"}},
+		},
+	}, nil)
+	scope := (triggerBatch{dirtyColls: setOf[int64](1)}).resolveScope(loadSnapshot, nil)
+
+	scope.AddDataViewShards(loadSnapshot, dataSnapshot)
+
+	assert.Equal(t, setOf(
+		triggerShard(10, 1, 0),
+		triggerShard(10, 1, 1),
+		triggerShard(20, 1, 0),
+		triggerShard(20, 1, 1),
+	), scope.targetShards)
+}
+
+func TestReconcileScopeDoesNotExpandDirtyShard(t *testing.T) {
+	loadSnapshot := triggerLoadSnapshot(&loadmgr.LoadConfig{
+		CollectionID: 1,
+		Replicas: []*loadmgr.ReplicaAssignment{
+			{ReplicaID: 10},
+			{ReplicaID: 20},
+		},
+	})
+	dataSnapshot := NewDataViewSnapshot(1, []*viewpb.DataViewOfCollection{
+		{
+			CollectionId: 1,
+			DataVersion:  &viewpb.DataVersion{},
+			Shards: []*viewpb.DataViewOfShard{
+				{Vchannel: "by-dev-rootcoord-dml_0_1v0"},
+				{Vchannel: "by-dev-rootcoord-dml_0_1v1"},
+			},
+		},
+	}, nil)
+	dirtyShard := triggerShard(10, 1, 0)
+
+	scope := (triggerBatch{dirtyShards: setOf(dirtyShard)}).resolveScope(loadSnapshot, nil)
+
+	scope.AddDataViewShards(loadSnapshot, dataSnapshot)
+
+	assert.Equal(t, setOf(dirtyShard), scope.targetShards)
+}
+
+func triggerTestRegistry(t *testing.T) *coordview.ShardViewRegistry {
+	t.Helper()
+	registry := emptyRegistry(t)
+	t.Cleanup(registry.Close)
+	return registry
+}
+
+func triggerLoadSnapshot(configs ...*loadmgr.LoadConfig) *loadmgr.LoadConfigSnapshot {
+	byCollection := make(map[int64]*loadmgr.LoadConfig, len(configs))
+	for _, cfg := range configs {
+		byCollection[cfg.CollectionID] = cfg
 	}
+	return loadmgr.NewLoadConfigSnapshot(1, byCollection)
+}
 
-	pending := triggerBatch{dirtyColls: map[int64]struct{}{collectionID: {}}}
+func triggerLoadConfig(collectionID, replicaID int64) *loadmgr.LoadConfig {
+	return &loadmgr.LoadConfig{
+		CollectionID: collectionID,
+		Replicas:     []*loadmgr.ReplicaAssignment{{ReplicaID: replicaID}},
+	}
+}
 
-	assert.Equal(t, []qviews.ShardID{residualShard}, pending.expand(snap))
+func triggerShard(replicaID, collectionID, shardIndex int64) qviews.ShardID {
+	return qviews.ShardID{
+		ReplicaID: replicaID,
+		VChannel:  fmt.Sprintf("by-dev-rootcoord-dml_0_%dv%d", collectionID, shardIndex),
+	}
+}
+
+func setOf[T comparable](values ...T) map[T]struct{} {
+	set := make(map[T]struct{}, len(values))
+	for _, value := range values {
+		set[value] = struct{}{}
+	}
+	return set
 }

--- a/internal/views/coord/coordview/shard_view_registry.go
+++ b/internal/views/coord/coordview/shard_view_registry.go
@@ -4,10 +4,13 @@ import (
 	"context"
 	"sync"
 
+	"golang.org/x/exp/maps"
+
 	"github.com/milvus-io/milvus/internal/metastore/kv/queryview"
 	"github.com/milvus-io/milvus/internal/views/coord/coordview/syncer"
 	"github.com/milvus-io/milvus/internal/views/qviews"
 	"github.com/milvus-io/milvus/pkg/v3/proto/viewpb"
+	"github.com/milvus-io/milvus/pkg/v3/util/metautil"
 	"github.com/milvus-io/milvus/pkg/v3/util/nodescheduler"
 	"github.com/milvus-io/milvus/pkg/v3/util/paramtable"
 )
@@ -30,6 +33,11 @@ type ShardViewRegistry struct {
 	shards   map[qviews.ShardID]*ShardViewManager
 	stats    map[qviews.ShardID]*ShardStats
 	snapshot *ShardViewSnapshot
+
+	// Reverse indexes cover resident shards. The collection index changes with
+	// shard lifecycle, while the node index tracks current Stats placements.
+	collectionShards map[int64]map[qviews.ShardID]struct{}
+	nodeShards       map[int64]map[qviews.ShardID]struct{}
 
 	statsObservers []func(qviews.ShardID, *ShardStats)
 }
@@ -80,7 +88,6 @@ func RecoverShardViewRegistry(
 		}
 		shards[sid] = manager
 	}
-	batch.Commit()
 
 	registry := &ShardViewRegistry{
 		ctx:                ctx,
@@ -89,11 +96,20 @@ func RecoverShardViewRegistry(
 		version:            1,
 		shards:             shards,
 		stats:              make(map[qviews.ShardID]*ShardStats, len(shards)),
+		collectionShards:   make(map[int64]map[qviews.ShardID]struct{}),
+		nodeShards:         make(map[int64]map[qviews.ShardID]struct{}),
 	}
 	for sid, mgr := range shards {
+		stats := mgr.Stats()
+		registry.stats[sid] = stats
+		registry.addCollectionShardLocked(sid)
+		registry.addNodeShardsLocked(sid, stats)
 		mgr.SetStatsObserver(registry.onShardStatsChanged)
-		registry.stats[sid] = mgr.Stats()
 	}
+	// Recovery sync callbacks may update manager stats immediately. Install all
+	// observers and indexes before releasing the held recovery events so those
+	// updates cannot be lost between the initial Stats call and observer setup.
+	batch.Commit()
 	if err := flushScheduler.Flush(ctx); err != nil {
 		for _, manager := range shards {
 			manager.unpinAllReferences()
@@ -127,6 +143,7 @@ func (r *ShardViewRegistry) Ensure(shardID qviews.ShardID) *ShardViewManager {
 	}
 	r.shards[shardID] = mgr
 	r.stats[shardID] = stats
+	r.addCollectionShardLocked(shardID)
 	r.version++
 	r.mu.Unlock()
 	return mgr
@@ -170,6 +187,50 @@ func (r *ShardViewRegistry) Snapshot() *ShardViewSnapshot {
 		r.publishSnapshotLocked()
 	}
 	return r.snapshot
+}
+
+// SnapshotForShards returns an immutable snapshot containing only the
+// requested resident shards. It does not refresh the cached full snapshot.
+func (r *ShardViewRegistry) SnapshotForShards(shardIDs []qviews.ShardID) *ShardViewSnapshot {
+	r.mu.RLock()
+	defer r.mu.RUnlock()
+
+	stats := make(map[qviews.ShardID]*ShardStats, len(shardIDs))
+	for _, shardID := range shardIDs {
+		if shardStats, ok := r.stats[shardID]; ok {
+			stats[shardID] = shardStats
+		}
+	}
+	return &ShardViewSnapshot{
+		version: r.version,
+		stats:   stats,
+	}
+}
+
+// CollectionShards returns the resident shards belonging to collectionID.
+func (r *ShardViewRegistry) CollectionShards(collectionID int64) []qviews.ShardID {
+	r.mu.RLock()
+	defer r.mu.RUnlock()
+	return maps.Keys(r.collectionShards[collectionID])
+}
+
+// NodeShards returns the resident shards with placements on nodeID.
+func (r *ShardViewRegistry) NodeShards(nodeID int64) []qviews.ShardID {
+	r.mu.RLock()
+	defer r.mu.RUnlock()
+	return maps.Keys(r.nodeShards[nodeID])
+}
+
+// ShardIDs returns all resident shard IDs.
+func (r *ShardViewRegistry) ShardIDs() []qviews.ShardID {
+	r.mu.RLock()
+	defer r.mu.RUnlock()
+
+	shardIDs := make([]qviews.ShardID, 0, len(r.shards))
+	for shardID := range r.shards {
+		shardIDs = append(shardIDs, shardID)
+	}
+	return shardIDs
 }
 
 // RegisterStatsObserver registers an observer for future per-shard stats
@@ -220,7 +281,9 @@ func (r *ShardViewRegistry) onShardStatsChanged(shardID qviews.ShardID, stats *S
 		r.mu.Unlock()
 		return
 	}
+	r.removeNodeShardsLocked(shardID, r.stats[shardID])
 	r.stats[shardID] = stats
+	r.addNodeShardsLocked(shardID, stats)
 	r.version++
 	observers := append([]func(qviews.ShardID, *ShardStats){}, r.statsObservers...)
 	r.mu.Unlock()
@@ -232,6 +295,56 @@ func (r *ShardViewRegistry) onShardStatsChanged(shardID qviews.ShardID, stats *S
 
 func (r *ShardViewRegistry) publishSnapshotLocked() {
 	r.snapshot = NewShardViewSnapshot(r.version, r.stats)
+}
+
+func (r *ShardViewRegistry) addCollectionShardLocked(shardID qviews.ShardID) {
+	channel, err := metautil.ParseChannel(shardID.VChannel, metautil.NewDynChannelMapper())
+	if err != nil {
+		return
+	}
+	shards := r.collectionShards[channel.CollectionID()]
+	if shards == nil {
+		shards = make(map[qviews.ShardID]struct{})
+		r.collectionShards[channel.CollectionID()] = shards
+	}
+	shards[shardID] = struct{}{}
+}
+
+func (r *ShardViewRegistry) addNodeShardsLocked(shardID qviews.ShardID, stats *ShardStats) {
+	if stats == nil {
+		return
+	}
+	for _, segment := range stats.Segments {
+		if segment == nil {
+			continue
+		}
+		for nodeID := range segment.Nodes {
+			shards := r.nodeShards[nodeID]
+			if shards == nil {
+				shards = make(map[qviews.ShardID]struct{})
+				r.nodeShards[nodeID] = shards
+			}
+			shards[shardID] = struct{}{}
+		}
+	}
+}
+
+func (r *ShardViewRegistry) removeNodeShardsLocked(shardID qviews.ShardID, stats *ShardStats) {
+	if stats == nil {
+		return
+	}
+	for _, segment := range stats.Segments {
+		if segment == nil {
+			continue
+		}
+		for nodeID := range segment.Nodes {
+			shards := r.nodeShards[nodeID]
+			delete(shards, shardID)
+			if len(shards) == 0 {
+				delete(r.nodeShards, nodeID)
+			}
+		}
+	}
 }
 
 func emptyShardStats() *ShardStats {

--- a/internal/views/coord/coordview/shard_view_registry_test.go
+++ b/internal/views/coord/coordview/shard_view_registry_test.go
@@ -2,14 +2,36 @@ package coordview
 
 import (
 	"context"
+	"sync/atomic"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 
+	viewsyncer "github.com/milvus-io/milvus/internal/views/coord/coordview/syncer"
 	"github.com/milvus-io/milvus/internal/views/qviews"
 	"github.com/milvus-io/milvus/pkg/v3/proto/viewpb"
 )
+
+type immediateLostRecoverySyncer struct {
+	lostCallbacks atomic.Int64
+}
+
+func (s *immediateLostRecoverySyncer) SyncViews(_ context.Context, group viewsyncer.SyncGroup) error {
+	for _, views := range group.ViewsByNode {
+		for _, view := range views {
+			node, ok := view.View.WorkNode().(qviews.QueryNode)
+			if !ok || view.OnQueryNodeLost == nil {
+				continue
+			}
+			s.lostCallbacks.Add(1)
+			view.OnQueryNodeLost(node)
+		}
+	}
+	return nil
+}
+
+func (*immediateLostRecoverySyncer) Close() error { return nil }
 
 // newTestRegistry builds a fresh (empty) registry via the recovery path with
 // an empty catalog.
@@ -62,14 +84,16 @@ func TestRegistry_EnsureCreatesOnce(t *testing.T) {
 func TestRegistry_RecoverWithPersistedViews(t *testing.T) {
 	catalog := newMockCatalog()
 
-	shardA := qviews.ShardID{ReplicaID: 1, VChannel: "v0_c0"}
-	shardB := qviews.ShardID{ReplicaID: 2, VChannel: "v0_c1"}
+	shardA := qviews.ShardID{ReplicaID: 1, VChannel: "by-dev-rootcoord-dml_100v0"}
+	shardB := qviews.ShardID{ReplicaID: 2, VChannel: "by-dev-rootcoord-dml_200v1"}
 
 	viewA := buildTestViewWithVersion(1, 1, 1, 1)
+	viewA.Meta.CollectionId = 100
 	viewA.Meta.ReplicaId = shardA.ReplicaID
 	viewA.Meta.Vchannel = shardA.VChannel
 
 	viewB := buildTestViewWithVersion(2, 1, 1, 1)
+	viewB.Meta.CollectionId = 200
 	viewB.Meta.ReplicaId = shardB.ReplicaID
 	viewB.Meta.Vchannel = shardB.VChannel
 
@@ -92,6 +116,130 @@ func TestRegistry_RecoverWithPersistedViews(t *testing.T) {
 
 	mgrB := reg.Get(shardB)
 	require.NotNil(t, mgrB)
+
+	assert.ElementsMatch(t, []qviews.ShardID{shardA}, reg.CollectionShards(100))
+	assert.ElementsMatch(t, []qviews.ShardID{shardB}, reg.CollectionShards(200))
+	assert.ElementsMatch(t, []qviews.ShardID{shardA, shardB}, reg.NodeShards(1))
+	assert.ElementsMatch(t, []qviews.ShardID{shardB}, reg.NodeShards(2))
+}
+
+func TestRegistry_RecoveryPublishesImmediateQueryNodeLoss(t *testing.T) {
+	catalog := newMockCatalog()
+	shardID := qviews.ShardID{ReplicaID: 1, VChannel: "by-dev-rootcoord-dml_100v0"}
+	view := buildTestViewWithVersion(1, 1, 1, 1)
+	view.Meta.CollectionId = 100
+	view.Meta.ReplicaId = shardID.ReplicaID
+	view.Meta.Vchannel = shardID.VChannel
+
+	// Keep Stats() and node-index initialization busy long enough for the
+	// recovery sync callback to contend with observer installation. With the
+	// old Commit-before-observer ordering, the callback can be lost in this
+	// window and the registry remains stuck on Preparing.
+	segmentIDs := make([]int64, 50_000)
+	for i := range segmentIDs {
+		segmentIDs[i] = int64(10_000 + i)
+	}
+	view.QueryNode[0].Partitions[0].SegmentIds = segmentIDs
+	catalog.listed = []*viewpb.QueryViewOfShard{view}
+	s := &immediateLostRecoverySyncer{}
+
+	reg, err := RecoverShardViewRegistry(context.Background(), catalog, s)
+	require.NoError(t, err)
+	t.Cleanup(reg.Close)
+	require.Equal(t, int64(1), s.lostCallbacks.Load())
+
+	managerStats := reg.Get(shardID).Stats()
+	registryStats := reg.SnapshotForShards([]qviews.ShardID{shardID}).StatsMap()[shardID]
+	require.NotNil(t, registryStats)
+	require.Nil(t, managerStats.PreparingVersion)
+	require.Nil(t, registryStats.PreparingVersion)
+	assert.Len(t, registryStats.Segments, len(managerStats.Segments))
+	require.Contains(t, registryStats.Segments, segmentIDs[0])
+	assert.Equal(t, SegmentStateUnrecoverable, registryStats.Segments[segmentIDs[0]].Nodes[1])
+}
+
+func TestRegistry_EnsureIndexesCollection(t *testing.T) {
+	reg := newTestRegistry(t, newMockCatalog(), newMockSyncer())
+	shardA := qviews.ShardID{ReplicaID: 1, VChannel: "by-dev-rootcoord-dml_100v0"}
+	shardB := qviews.ShardID{ReplicaID: 2, VChannel: "by-dev-rootcoord-dml_100v1"}
+	invalid := qviews.ShardID{ReplicaID: 3, VChannel: "invalid-vchannel"}
+
+	reg.Ensure(shardA)
+	reg.Ensure(shardB)
+	reg.Ensure(invalid)
+
+	assert.ElementsMatch(t, []qviews.ShardID{shardA, shardB}, reg.CollectionShards(100))
+	assert.Empty(t, reg.CollectionShards(0))
+	assert.ElementsMatch(t, []qviews.ShardID{shardA, shardB, invalid}, reg.ShardIDs())
+}
+
+func TestRegistry_NodeIndexTracksStatsReplacement(t *testing.T) {
+	reg := newTestRegistry(t, newMockCatalog(), newMockSyncer())
+	shardID := qviews.ShardID{ReplicaID: 1, VChannel: "by-dev-rootcoord-dml_100v0"}
+	reg.Ensure(shardID)
+
+	observed := make(chan struct{}, 1)
+	reg.RegisterStatsObserver(func(_ qviews.ShardID, _ *ShardStats) {
+		reg.NodeShards(1)
+		observed <- struct{}{}
+	})
+
+	reg.onShardStatsChanged(shardID, shardStatsForNodes(map[int64][]int64{
+		101: {1, 2},
+		102: {1},
+	}))
+	assert.ElementsMatch(t, []qviews.ShardID{shardID}, reg.NodeShards(1))
+	assert.ElementsMatch(t, []qviews.ShardID{shardID}, reg.NodeShards(2))
+	assert.Len(t, reg.NodeShards(1), 1, "a shard is indexed once even when multiple segments use the node")
+	<-observed
+
+	reg.onShardStatsChanged(shardID, shardStatsForNodes(map[int64][]int64{
+		103: {3},
+	}))
+	assert.Empty(t, reg.NodeShards(1))
+	assert.Empty(t, reg.NodeShards(2))
+	assert.ElementsMatch(t, []qviews.ShardID{shardID}, reg.NodeShards(3))
+	<-observed
+
+	reg.onShardStatsChanged(shardID, emptyShardStats())
+	assert.Empty(t, reg.NodeShards(3))
+	<-observed
+
+	assert.NotPanics(t, func() {
+		reg.onShardStatsChanged(shardID, nil)
+	})
+	assert.Empty(t, reg.NodeShards(3))
+	<-observed
+}
+
+func TestRegistry_SnapshotForShards(t *testing.T) {
+	reg := newTestRegistry(t, newMockCatalog(), newMockSyncer())
+	shardA := qviews.ShardID{ReplicaID: 1, VChannel: "by-dev-rootcoord-dml_100v0"}
+	shardB := qviews.ShardID{ReplicaID: 2, VChannel: "by-dev-rootcoord-dml_200v0"}
+	missing := qviews.ShardID{ReplicaID: 3, VChannel: "by-dev-rootcoord-dml_300v0"}
+	reg.Ensure(shardA)
+	reg.Ensure(shardB)
+	statsA := shardStatsForNodes(map[int64][]int64{101: {1}})
+	statsB := shardStatsForNodes(map[int64][]int64{201: {2}})
+	reg.onShardStatsChanged(shardA, statsA)
+	reg.onShardStatsChanged(shardB, statsB)
+
+	resident := reg.Snapshot()
+	updatedStatsA := shardStatsForNodes(map[int64][]int64{102: {3}})
+	reg.onShardStatsChanged(shardA, updatedStatsA)
+	require.Same(t, resident, reg.snapshot)
+
+	scoped := reg.SnapshotForShards([]qviews.ShardID{shardA, missing, shardA})
+	require.Same(t, resident, reg.snapshot, "scoped snapshot must not refresh the resident full snapshot")
+	assert.Equal(t, reg.version, scoped.Version())
+	require.Len(t, scoped.StatsMap(), 1)
+	assert.Same(t, updatedStatsA, scoped.StatsMap()[shardA])
+	assert.NotContains(t, scoped.StatsMap(), missing)
+
+	scoped.StatsMap()[shardB] = statsB
+	next := reg.SnapshotForShards([]qviews.ShardID{shardA})
+	assert.NotContains(t, next.StatsMap(), shardB, "each scoped snapshot must own its outer map")
+	assert.Same(t, updatedStatsA, next.StatsMap()[shardA])
 }
 
 func TestRecoverShardViewRegistryRebuildsReferences(t *testing.T) {
@@ -261,4 +409,19 @@ func TestRegistry_SnapshotSegmentNodeStates(t *testing.T) {
 	assert.Equal(t, map[int64]SegmentState{2: SegmentStatePreparing}, stats[shardB].Segments[102].Nodes)
 	assert.Equal(t, map[int64]SegmentState{1: SegmentStatePreparing}, stats[shardC].Segments[103].Nodes)
 	assert.Equal(t, map[int64]SegmentState{2: SegmentStatePreparing}, stats[shardC].Segments[104].Nodes)
+}
+
+func shardStatsForNodes(segmentNodes map[int64][]int64) *ShardStats {
+	stats := emptyShardStats()
+	for segmentID, nodeIDs := range segmentNodes {
+		nodes := make(map[int64]SegmentState, len(nodeIDs))
+		for _, nodeID := range nodeIDs {
+			nodes[nodeID] = SegmentStatePreparing
+		}
+		stats.Segments[segmentID] = &SegmentStats{
+			SegmentID: segmentID,
+			Nodes:     nodes,
+		}
+	}
+	return stats
 }


### PR DESCRIPTION
## What this changes

QueryView reconciliation currently materializes global DataView and ShardView state even when a trigger only affects a small collection, shard, or node scope. This PR resolves each trigger batch into an explicit reconciliation scope before reading state, so scoped reconciles can avoid scanning stable placements.

The implementation:

- fetches DataViews and segment metadata only for the selected collections;
- reads ShardStats only for the exact target shards;
- maintains collection-to-shard and node-to-shard reverse indexes in the ShardView registry for release and node-scoped triggers;
- keeps an incremental per-shard row-count ledger and replaces only contributions from refreshed shards;
- preserves periodic and explicitly requested full reconciliation as the authoritative full ledger rebuild path;
- installs recovery indexes and stats observers before committing held recovery events, so synchronous recovery callbacks are not lost;
- documents snapshot scope, fallback behavior, registry lifetime, recovery ordering, and row-count replacement semantics.

A fallback to full planning scope only broadens the state used for the current policy calculation. It does not implicitly rebuild the row-count ledger; only a periodic or explicit full reconciliation does that. Segment metadata misses are treated as zero-row contributions for that cycle and are not cached.

## Validation

Passed:

```text
go test -v -count=1 -tags dynamic,test -gcflags="all=-N -l" ./internal/views/coord/balancer ./internal/views/coord/coordview ./internal/dataview -timeout 300s
go test -v -count=1 -tags dynamic,test -gcflags="all=-N -l" ./internal/datacoord -run '^TestDataViewSegmentStoreGetSegmentsMapsBatch$' -timeout 300s
go test -v -count=1 -tags dynamic,test -gcflags="all=-N -l" ./internal/querycoordv2 -run '^Test(NewQViewsRuntime|QViewsRuntime)' -timeout 300s
```


Issue: https://github.com/milvus-io/milvus/issues/40451
