### PR TITLE
enhance: evict idle WAL write-ahead buffers

### DIFF
--- a/docs/agent_guides/streaming-system/message/message-semantic-recovery-barrier.md
+++ b/docs/agent_guides/streaming-system/message/message-semantic-recovery-barrier.md
@@ -79,8 +79,8 @@ that VChannel after recovery.
 
 ## Invariants
 
-- `RecoveryBarrier` must be persisted in the WAL. A non-persisted idle tick is
-  not sufficient.
+- `RecoveryBarrier` must be persisted in the WAL. An in-memory idle sync is not
+  sufficient.
 - `RecoveryBarrier` is appended before recovery stream replay starts and is
   consumed as part of that replay.
 - Successful append of the barrier proves the recovering node can write the

--- a/docs/agent_guides/streaming-system/message/message-semantic-time-tick.md
+++ b/docs/agent_guides/streaming-system/message/message-semantic-time-tick.md
@@ -7,9 +7,12 @@ create per-VChannel query MVCC entries. WAL recovery uses a separate
 [RecoveryBarrier](message-semantic-recovery-barrier.md) message when it needs to
 establish a query-resource baseline for every recovered live VChannel.
 
-## IsPersist
+## Persistence
 
-TimeTick messages have an **IsPersist** flag. Persisted when real data messages exist in the batch; non-persisted for idle sync ticks (skips WAL backend write but still flows through interceptors and WriteAheadBuffer).
+TimeTick messages produced by the WAL are persisted. A regular idle sync does
+not create a TimeTick message when there are no real data messages in the batch.
+Callers that require a durable boundary can explicitly force a persisted
+TimeTick.
 
 ## Example
 

--- a/docs/agent_guides/streaming-system/wal/timetick_and_txn.md
+++ b/docs/agent_guides/streaming-system/wal/timetick_and_txn.md
@@ -15,7 +15,7 @@ Every message receives a unique TimeTick from the TSO via `AckManager.Allocate()
 Every TimeTick transitions: **Allocated** → **Confirmed** → **Synced**.
 
 - **Confirmed**: Append completed and `Acker.Ack()` called. The confirmed watermark (`lastConfirmedTimeTick`) advances only when all TimeTicks ≤ it are acknowledged — any in-flight message blocks advancement.
-- **Synced**: A background `TimeTickSyncInspector` periodically drains confirmed entries, constructs a TimeTick message with `Timestamp` = confirmed watermark, and appends it to the WAL. When no real messages exist in the batch, a non-persisted TimeTick is generated (skips WAL backend write).
+- **Synced**: A background `TimeTickSyncInspector` periodically drains confirmed entries. When real messages exist in the batch, it constructs a persisted TimeTick message with `Timestamp` = confirmed watermark and appends it to the WAL. An idle sync without real messages only drains acknowledgements and does not append a TimeTick unless the caller explicitly requests a persisted boundary.
 
 ### Consumer-Side Reordering
 

--- a/internal/streamingnode/server/resource/resource.go
+++ b/internal/streamingnode/server/resource/resource.go
@@ -2,6 +2,7 @@ package resource
 
 import (
 	"reflect"
+	"time"
 
 	clientv3 "go.etcd.io/etcd/client/v3"
 
@@ -11,6 +12,7 @@ import (
 	"github.com/milvus-io/milvus/internal/storage"
 	"github.com/milvus-io/milvus/internal/streamingnode/server/wal/interceptors/shard/stats"
 	tinspector "github.com/milvus-io/milvus/internal/streamingnode/server/wal/interceptors/timetick/inspector"
+	"github.com/milvus-io/milvus/internal/streamingnode/server/wal/interceptors/wab"
 	"github.com/milvus-io/milvus/internal/streamingnode/server/wal/vchantempstore"
 	"github.com/milvus-io/milvus/internal/types"
 	"github.com/milvus-io/milvus/internal/util/idalloc"
@@ -73,6 +75,7 @@ func Init(opts ...optResourceInit) {
 	newR.logger = mlog.With(mlog.FieldModule(typeutil.StreamingNodeRole))
 	newR.segmentStatsManager = stats.NewStatsManager()
 	newR.timeTickInspector = tinspector.NewTimeTickSyncInspector()
+	newR.wabMaintenanceManager = wab.NewMaintenanceManager(time.Second)
 	newR.syncMgr = syncmgr.NewSyncManager(newR.chunkManager)
 	newR.wbMgr = writebuffer.NewManager(newR.syncMgr)
 	newR.wbMgr.Start()
@@ -82,6 +85,7 @@ func Init(opts ...optResourceInit) {
 	assertNotNil(newR.StreamingNodeCatalog())
 	assertNotNil(newR.SegmentStatsManager())
 	assertNotNil(newR.TimeTickInspector())
+	assertNotNil(newR.WABMaintenanceManager())
 	assertNotNil(newR.SyncManager())
 	assertNotNil(newR.WriteBufferManager())
 	r = newR
@@ -91,6 +95,7 @@ func Init(opts ...optResourceInit) {
 func Release() {
 	r.wbMgr.Stop()
 	r.syncMgr.Close()
+	r.wabMaintenanceManager.Close()
 }
 
 // Resource access the underlying singleton of resources.
@@ -101,16 +106,17 @@ func Resource() *resourceImpl {
 // resourceImpl is a basic resource dependency for streamingnode server.
 // All utility on it is concurrent-safe and singleton.
 type resourceImpl struct {
-	logger               *mlog.Logger
-	timestampAllocator   idalloc.Allocator
-	idAllocator          idalloc.Allocator
-	etcdClient           *clientv3.Client
-	chunkManager         storage.ChunkManager
-	mixCoordClient       *syncutil.Future[types.MixCoordClient]
-	streamingNodeCatalog metastore.StreamingNodeCataLog
-	segmentStatsManager  *stats.StatsManager
-	timeTickInspector    tinspector.TimeTickSyncInspector
-	vchannelTempStorage  *vchantempstore.VChannelTempStorage
+	logger                *mlog.Logger
+	timestampAllocator    idalloc.Allocator
+	idAllocator           idalloc.Allocator
+	etcdClient            *clientv3.Client
+	chunkManager          storage.ChunkManager
+	mixCoordClient        *syncutil.Future[types.MixCoordClient]
+	streamingNodeCatalog  metastore.StreamingNodeCataLog
+	segmentStatsManager   *stats.StatsManager
+	timeTickInspector     tinspector.TimeTickSyncInspector
+	wabMaintenanceManager *wab.MaintenanceManager
+	vchannelTempStorage   *vchantempstore.VChannelTempStorage
 
 	// TODO: Global flusher components, should be removed afteer flushering in wal refactoring.
 	syncMgr syncmgr.SyncManager
@@ -163,6 +169,11 @@ func (r *resourceImpl) SegmentStatsManager() *stats.StatsManager {
 
 func (r *resourceImpl) TimeTickInspector() tinspector.TimeTickSyncInspector {
 	return r.timeTickInspector
+}
+
+// WABMaintenanceManager returns the node-level write-ahead buffer maintenance manager.
+func (r *resourceImpl) WABMaintenanceManager() *wab.MaintenanceManager {
+	return r.wabMaintenanceManager
 }
 
 // VChannelTempStorage returns the vchannel temp storage.

--- a/internal/streamingnode/server/resource/test_utility.go
+++ b/internal/streamingnode/server/resource/test_utility.go
@@ -6,6 +6,7 @@ package resource
 import (
 	"context"
 	"testing"
+	"time"
 
 	"google.golang.org/grpc"
 
@@ -14,6 +15,7 @@ import (
 	"github.com/milvus-io/milvus/internal/mocks"
 	"github.com/milvus-io/milvus/internal/streamingnode/server/wal/interceptors/shard/stats"
 	tinspector "github.com/milvus-io/milvus/internal/streamingnode/server/wal/interceptors/timetick/inspector"
+	"github.com/milvus-io/milvus/internal/streamingnode/server/wal/interceptors/wab"
 	"github.com/milvus-io/milvus/internal/types"
 	"github.com/milvus-io/milvus/internal/util/idalloc"
 	"github.com/milvus-io/milvus/pkg/v3/mlog"
@@ -60,4 +62,6 @@ func InitForTest(t *testing.T, opts ...optResourceInit) {
 	}
 	r.segmentStatsManager = stats.NewStatsManager()
 	r.timeTickInspector = tinspector.NewTimeTickSyncInspector()
+	r.wabMaintenanceManager = wab.NewMaintenanceManager(time.Second)
+	t.Cleanup(r.wabMaintenanceManager.Close)
 }

--- a/internal/streamingnode/server/wal/adaptor/initializing.go
+++ b/internal/streamingnode/server/wal/adaptor/initializing.go
@@ -38,6 +38,7 @@ func buildInterceptorParams(ctx context.Context, underlyingWALImpls walimpls.WAL
 	capacity := int(paramtable.Get().StreamingCfg.WALWriteAheadBufferCapacity.GetAsSize())
 	keepalive := paramtable.Get().StreamingCfg.WALWriteAheadBufferKeepalive.GetAsDurationByParse()
 	writeAheadBuffer := wab.NewWriteAheadBuffer(
+		resource.Resource().WABMaintenanceManager(),
 		underlyingWALImpls.Channel().Name,
 		resource.Resource().Logger().With(),
 		capacity,

--- a/internal/streamingnode/server/wal/adaptor/wal_adaptor.go
+++ b/internal/streamingnode/server/wal/adaptor/wal_adaptor.go
@@ -449,10 +449,6 @@ func (w *walAdaptorImpl) Append(ctx context.Context, msg message.MutableMessage)
 	ctx = utility.WithExtraAppendResult(ctx, &extraAppendResult)
 	messageID, err := w.interceptorBuildResult.Interceptor.DoAppend(ctx, msg,
 		func(ctx context.Context, msg message.MutableMessage) (message.MessageID, error) {
-			if notPersistHint := utility.GetNotPersisted(ctx); notPersistHint != nil {
-				// do not persist the message if the hint is set.
-				return notPersistHint.MessageID, nil
-			}
 			metricsGuard.StartWALImplAppend()
 			msgID, err := w.retryAppendWhenRecoverableError(ctx, msg)
 			metricsGuard.FinishWALImplAppend()

--- a/internal/streamingnode/server/wal/interceptors/timetick/inspector/impls.go
+++ b/internal/streamingnode/server/wal/interceptors/timetick/inspector/impls.go
@@ -31,8 +31,8 @@ type timeTickSyncInspectorImpl struct {
 	working      typeutil.ConcurrentSet[string]
 }
 
-func (s *timeTickSyncInspectorImpl) TriggerSync(pChannelInfo types.PChannelInfo, persisted bool) {
-	s.syncNotifier.AddAndNotify(pChannelInfo, persisted)
+func (s *timeTickSyncInspectorImpl) TriggerSync(pChannelInfo types.PChannelInfo, forcePersisted bool) {
+	s.syncNotifier.AddAndNotify(pChannelInfo, forcePersisted)
 }
 
 func (s *timeTickSyncInspectorImpl) GetOperator(pChannelInfo types.PChannelInfo) (TimeTickSyncOperator, bool) {
@@ -84,15 +84,15 @@ func (s *timeTickSyncInspectorImpl) background() {
 			})
 		case <-s.syncNotifier.WaitChan():
 			signals := s.syncNotifier.Get()
-			for pchannel, persisted := range signals {
-				s.asyncSync(pchannel.Name, persisted)
+			for pchannel, forcePersisted := range signals {
+				s.asyncSync(pchannel.Name, forcePersisted)
 			}
 		}
 	}
 }
 
 // asyncSync syncs the pchannel in a goroutine.
-func (s *timeTickSyncInspectorImpl) asyncSync(pchannelName string, persisted bool) {
+func (s *timeTickSyncInspectorImpl) asyncSync(pchannelName string, forcePersisted bool) {
 	if !s.working.Insert(pchannelName) {
 		// Check if the sync operation of pchannel is working, if so, skip it.
 		return
@@ -105,7 +105,7 @@ func (s *timeTickSyncInspectorImpl) asyncSync(pchannelName string, persisted boo
 			s.working.Remove(pchannelName)
 		}()
 		if operator, ok := s.operators.Get(pchannelName); ok {
-			operator.Sync(s.taskNotifier.Context(), persisted)
+			operator.Sync(s.taskNotifier.Context(), forcePersisted)
 		}
 	}()
 }

--- a/internal/streamingnode/server/wal/interceptors/timetick/inspector/notifier.go
+++ b/internal/streamingnode/server/wal/interceptors/timetick/inspector/notifier.go
@@ -22,16 +22,16 @@ type syncNotifier struct {
 }
 
 // AddAndNotify adds a signal and notifies the waiter.
-func (n *syncNotifier) AddAndNotify(pChannelInfo types.PChannelInfo, persisted bool) {
+func (n *syncNotifier) AddAndNotify(pChannelInfo types.PChannelInfo, forcePersisted bool) {
 	n.cond.LockAndBroadcast()
 	defer n.cond.L.Unlock()
 	if _, ok := n.signal[pChannelInfo]; !ok {
-		n.signal[pChannelInfo] = persisted
+		n.signal[pChannelInfo] = forcePersisted
 		return
 	}
-	if persisted {
-		// only persisted signal can overwrite the previous signal
-		n.signal[pChannelInfo] = persisted
+	if forcePersisted {
+		// A force-persisted signal can upgrade a pending regular sync.
+		n.signal[pChannelInfo] = forcePersisted
 	}
 }
 

--- a/internal/streamingnode/server/wal/interceptors/timetick/mvcc/mvcc_manager.go
+++ b/internal/streamingnode/server/wal/interceptors/timetick/mvcc/mvcc_manager.go
@@ -51,8 +51,8 @@ func (cm *MVCCManager) ApplyRecoveryBarrier(vchannel string, timetick uint64) {
 // UpdateMVCC updates the mvcc state by incoming message.
 func (cm *MVCCManager) UpdateMVCC(msg message.MutableMessage) {
 	if !msg.IsPersisted() {
-		// A unpersisted message is always a time tick message that is used to sync up the system time.
-		// No data change should be made by this message so it should be ignored in the mvcc manager.
+		// Compatibility guard for externally constructed non-persisted messages.
+		// The WAL no longer produces non-persisted TimeTick messages.
 		return
 	}
 

--- a/internal/streamingnode/server/wal/interceptors/timetick/timetick_message.go
+++ b/internal/streamingnode/server/wal/interceptors/timetick/timetick_message.go
@@ -7,11 +7,11 @@ import (
 	"github.com/milvus-io/milvus/pkg/v3/util/commonpbutil"
 )
 
-func NewTimeTickMsg(ts uint64, lastConfirmedMessageID message.MessageID, sourceID int64, persist bool) message.MutableMessage {
+func NewTimeTickMsg(ts uint64, lastConfirmedMessageID message.MessageID, sourceID int64) message.MutableMessage {
 	// TODO: time tick should be put on properties, for compatibility, we put it on message body now.
 	// Common message's time tick is set on interceptor.
 	// TimeTickMsg's time tick should be set here.
-	b := message.NewTimeTickMessageBuilderV1().
+	msg := message.NewTimeTickMessageBuilderV1().
 		WithHeader(&message.TimeTickMessageHeader{}).
 		WithBody(&msgpb.TimeTickMsg{
 			Base: commonpbutil.NewMsgBase(
@@ -21,11 +21,8 @@ func NewTimeTickMsg(ts uint64, lastConfirmedMessageID message.MessageID, sourceI
 				commonpbutil.WithSourceID(sourceID),
 			),
 		}).
-		WithAllVChannel()
-	if !persist {
-		b.WithNotPersisted()
-	}
-	msg := b.MustBuildMutable()
+		WithAllVChannel().
+		MustBuildMutable()
 	if lastConfirmedMessageID != nil {
 		return msg.WithTimeTick(ts).WithLastConfirmed(lastConfirmedMessageID)
 	}

--- a/internal/streamingnode/server/wal/interceptors/timetick/timetick_message_test.go
+++ b/internal/streamingnode/server/wal/interceptors/timetick/timetick_message_test.go
@@ -13,30 +13,18 @@ func TestNewTimeTickMsg(t *testing.T) {
 	lastConfirmedMessageID := walimplstest.NewTestMessageID(1)
 	messageID := walimplstest.NewTestMessageID(2)
 	sourceID := int64(42)
-	persist := true
 
-	// Test with persist = true and lastConfirmedMessageID provided
-	msg := NewTimeTickMsg(ts, lastConfirmedMessageID, sourceID, persist)
+	msg := NewTimeTickMsg(ts, lastConfirmedMessageID, sourceID)
 	immutableMsg := msg.IntoImmutableMessage(messageID)
 	assert.NotNil(t, msg)
 	assert.Equal(t, ts, msg.TimeTick())
 	assert.True(t, immutableMsg.IsPersisted())
 	assert.True(t, immutableMsg.LastConfirmedMessageID().EQ(lastConfirmedMessageID))
 
-	// Test with persist = false and lastConfirmedMessageID provided
-	persist = false
-	msg = NewTimeTickMsg(ts, lastConfirmedMessageID, sourceID, persist)
-	immutableMsg = msg.IntoImmutableMessage(messageID)
-	assert.NotNil(t, msg)
-	assert.Equal(t, ts, msg.TimeTick())
-	assert.True(t, immutableMsg.LastConfirmedMessageID().EQ(lastConfirmedMessageID))
-	assert.False(t, msg.IsPersisted())
-
-	// Test with persist = false and lastConfirmedMessageID nil
-	msg = NewTimeTickMsg(ts, nil, sourceID, persist)
+	msg = NewTimeTickMsg(ts, nil, sourceID)
 	immutableMsg = msg.IntoImmutableMessage(messageID)
 	assert.NotNil(t, msg)
 	assert.Equal(t, ts, msg.TimeTick())
 	assert.True(t, immutableMsg.LastConfirmedMessageID().EQ(messageID))
-	assert.False(t, msg.IsPersisted())
+	assert.True(t, immutableMsg.IsPersisted())
 }

--- a/internal/streamingnode/server/wal/interceptors/timetick/timetick_sync_operator.go
+++ b/internal/streamingnode/server/wal/interceptors/timetick/timetick_sync_operator.go
@@ -67,7 +67,7 @@ func (impl *timeTickSyncOperator) MVCCManager() *mvcc.MVCCManager {
 
 // Sync trigger a sync operation.
 // Sync operation is not thread safe, so call it in a single goroutine.
-func (impl *timeTickSyncOperator) Sync(ctx context.Context, persisted bool) {
+func (impl *timeTickSyncOperator) Sync(ctx context.Context, forcePersisted bool) {
 	if impl.walShutdownOrFenced.Load() {
 		// skip append tt msg to a shutdown or fenced wal
 		return
@@ -86,7 +86,7 @@ func (impl *timeTickSyncOperator) Sync(ctx context.Context, persisted bool) {
 			return nil, err
 		}
 		return appendResult.MessageID, nil
-	}, persisted)
+	}, forcePersisted)
 	if err != nil {
 		impl.logger.Warn(ctx, "send time tick sync message failed", mlog.Err(err))
 		if s := status.AsStreamingError(err); s.IsFenced() || s.IsOnShutdown() {
@@ -120,8 +120,7 @@ func (impl *timeTickSyncOperator) sendTsMsg(ctx context.Context, appender func(c
 	// Construct time tick message.
 	ts := impl.ackDetails.LastAllAcknowledgedTimestamp()
 	lastConfirmedMessageID := impl.ackDetails.EarliestLastConfirmedMessageID()
-	persist := (!impl.ackDetails.IsNoPersistedMessage() || forcePersisted)
-	if !persist {
+	if impl.ackDetails.IsNoPersistedMessage() && !forcePersisted {
 		impl.ackDetails.Clear()
 		return nil
 	}
@@ -135,7 +134,7 @@ func (impl *timeTickSyncOperator) sendTsMsgToWAL(ctx context.Context,
 	lastConfirmedMessageID message.MessageID,
 	appender func(ctx context.Context, msg message.MutableMessage) (message.MessageID, error),
 ) error {
-	msg := NewTimeTickMsg(ts, lastConfirmedMessageID, impl.sourceID, true)
+	msg := NewTimeTickMsg(ts, lastConfirmedMessageID, impl.sourceID)
 
 	// Append it to wal.
 	msgID, err := appender(ctx, msg)

--- a/internal/streamingnode/server/wal/interceptors/timetick/timetick_sync_operator_test.go
+++ b/internal/streamingnode/server/wal/interceptors/timetick/timetick_sync_operator_test.go
@@ -32,7 +32,7 @@ func TestTimeTickSyncOperator(t *testing.T) {
 	msgID := walimplstest.NewTestMessageID(1)
 	channel := types.PChannelInfo{Name: "test", Term: 1}
 	ts, _ := resource.Resource().TSOAllocator().Allocate(ctx)
-	lastMsg := NewTimeTickMsg(ts, nil, 0, true)
+	lastMsg := NewTimeTickMsg(ts, nil, 0)
 	immutablelastMsg := lastMsg.IntoImmutableMessage(msgID)
 
 	param := &interceptors.InterceptorBuildParam{
@@ -40,6 +40,7 @@ func TestTimeTickSyncOperator(t *testing.T) {
 		WAL:                 walFuture,
 		LastTimeTickMessage: immutablelastMsg,
 		WriteAheadBuffer: wab.NewWriteAheadBuffer(
+			resource.Resource().WABMaintenanceManager(),
 			channel.Name,
 			resource.Resource().Logger().With(),
 			1024,

--- a/internal/streamingnode/server/wal/interceptors/wab/maintenance_manager.go
+++ b/internal/streamingnode/server/wal/interceptors/wab/maintenance_manager.go
@@ -1,0 +1,90 @@
+package wab
+
+import (
+	"sync"
+	"time"
+)
+
+// MaintenanceManager periodically evicts expired messages from all registered
+// write-ahead buffers with one shared background goroutine.
+type MaintenanceManager struct {
+	mu      sync.Mutex
+	buffers map[*WriteAheadBuffer]struct{}
+	closed  bool
+
+	interval  time.Duration
+	closeCh   chan struct{}
+	closeOnce sync.Once
+	wg        sync.WaitGroup
+}
+
+// NewMaintenanceManager creates a shared write-ahead buffer maintenance manager.
+func NewMaintenanceManager(interval time.Duration) *MaintenanceManager {
+	if interval <= 0 {
+		panic("write-ahead buffer maintenance interval must be positive")
+	}
+
+	manager := &MaintenanceManager{
+		buffers:  make(map[*WriteAheadBuffer]struct{}),
+		interval: interval,
+		closeCh:  make(chan struct{}),
+	}
+	manager.wg.Add(1)
+	go manager.background()
+	return manager
+}
+
+func (m *MaintenanceManager) register(buffer *WriteAheadBuffer) {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	if m.closed {
+		panic("register write-ahead buffer to closed maintenance manager")
+	}
+	m.buffers[buffer] = struct{}{}
+}
+
+func (m *MaintenanceManager) unregister(buffer *WriteAheadBuffer) {
+	m.mu.Lock()
+	delete(m.buffers, buffer)
+	m.mu.Unlock()
+}
+
+func (m *MaintenanceManager) background() {
+	defer m.wg.Done()
+
+	ticker := time.NewTicker(m.interval)
+	defer ticker.Stop()
+	for {
+		select {
+		case <-ticker.C:
+			m.maintain()
+		case <-m.closeCh:
+			return
+		}
+	}
+}
+
+func (m *MaintenanceManager) maintain() {
+	m.mu.Lock()
+	buffers := make([]*WriteAheadBuffer, 0, len(m.buffers))
+	for buffer := range m.buffers {
+		buffers = append(buffers, buffer)
+	}
+	m.mu.Unlock()
+
+	for _, buffer := range buffers {
+		buffer.evictExpiredMessages()
+	}
+}
+
+// Close stops the shared maintenance goroutine.
+func (m *MaintenanceManager) Close() {
+	m.closeOnce.Do(func() {
+		m.mu.Lock()
+		m.closed = true
+		clear(m.buffers)
+		m.mu.Unlock()
+		close(m.closeCh)
+		m.wg.Wait()
+	})
+}

--- a/internal/streamingnode/server/wal/interceptors/wab/pending_queue.go
+++ b/internal/streamingnode/server/wal/interceptors/wab/pending_queue.go
@@ -78,9 +78,10 @@ func (q *pendingQueue) LastTimeTick() uint64 {
 	return q.lastTimeTick
 }
 
-// Evict removes messages that have been in the buffer for longer than the keepAlive duration.
-func (q *pendingQueue) Evict() {
-	q.evict(time.Now())
+// Evict removes messages that have been in the buffer for longer than the
+// keepAlive duration and reports whether any message was removed.
+func (q *pendingQueue) Evict() bool {
+	return q.evict(time.Now())
 }
 
 // CurrentOffset returns the next offset of the buffer.
@@ -154,17 +155,15 @@ func (q *pendingQueue) makeSnapshot(idx int) []messageWithOffset {
 }
 
 // evict removes messages that have been in the buffer for longer than the keepAlive duration.
-func (q *pendingQueue) evict(now time.Time) {
+func (q *pendingQueue) evict(now time.Time) bool {
 	releaseUntilIdx := -1
 	needRelease := 0
 	if q.size > q.capacity {
 		needRelease = q.size - q.capacity
 	}
 
-	// !!! NOTE: the evict operation should never release the last message, so i < len(q.buf)-1 here.
-	// we need to keep the last one wal-persisted message in write ahead buffer
-	// to make the catchup scanner works on underlying wal to catch up the write ahead buffer.
-	// so the catchup scanner can transform into tailing scanner to see the non-persisted timetick from write ahead buffer.
+	// Keep the latest persisted message as the overlap boundary between the
+	// catch-up scanner on the underlying WAL and the tailing WAB reader.
 	for i := 0; i < len(q.buf)-1; i++ {
 		if q.buf[i].Eviction.Before(now) || needRelease > 0 {
 			releaseUntilIdx = i
@@ -183,6 +182,7 @@ func (q *pendingQueue) evict(now time.Time) {
 		}
 		q.buf = q.buf[preservedIdx:]
 	}
+	return preservedIdx > 0
 }
 
 // lowerboundOfMessageList returns the lowerbound of the message list.

--- a/internal/streamingnode/server/wal/interceptors/wab/reader.go
+++ b/internal/streamingnode/server/wal/interceptors/wab/reader.go
@@ -9,7 +9,6 @@ import (
 // WriteAheadBufferReader is used to read messages from WriteAheadBuffer.
 type WriteAheadBufferReader struct {
 	nextOffset    int
-	lastTimeTick  uint64
 	snapshot      []messageWithOffset
 	underlyingBuf *WriteAheadBuffer
 }
@@ -21,7 +20,7 @@ func (r *WriteAheadBufferReader) Next(ctx context.Context) (message.ImmutableMes
 		return msg, nil
 	}
 
-	snapshot, err := r.underlyingBuf.createSnapshotFromOffset(ctx, r.nextOffset, r.lastTimeTick)
+	snapshot, err := r.underlyingBuf.createSnapshotFromOffset(ctx, r.nextOffset)
 	if err != nil {
 		return nil, err
 	}
@@ -40,7 +39,6 @@ func (r *WriteAheadBufferReader) nextFromSnapshot() message.ImmutableMessage {
 		panic("unreachable: next offset should be monotonically increasing")
 	}
 	r.nextOffset = newNextOffset
-	r.lastTimeTick = nextMsg.Message.TimeTick()
 	r.snapshot = r.snapshot[1:]
 	return nextMsg.Message
 }

--- a/internal/streamingnode/server/wal/interceptors/wab/write_ahead_buffer.go
+++ b/internal/streamingnode/server/wal/interceptors/wab/write_ahead_buffer.go
@@ -25,30 +25,32 @@ type ROWriteAheadBuffer interface {
 
 // NewWriteAheadBuffer creates a new WriteAheadBuffer.
 func NewWriteAheadBuffer(
+	maintenanceManager *MaintenanceManager,
 	pchannel string,
 	logger *mlog.Logger,
 	capacity int,
 	keepalive time.Duration,
 	lastConfirmedTimeTickMessage message.ImmutableMessage,
 ) *WriteAheadBuffer {
-	return &WriteAheadBuffer{
-		logger:              logger,
-		cond:                syncutil.NewContextCond(&sync.Mutex{}),
-		pendingMessages:     newPendingQueue(capacity, keepalive, lastConfirmedTimeTickMessage),
-		lastTimeTickMessage: lastConfirmedTimeTickMessage,
-		metrics:             metricsutil.NewWriteAheadBufferMetrics(pchannel, capacity),
+	buffer := &WriteAheadBuffer{
+		logger:             logger,
+		cond:               syncutil.NewContextCond(&sync.Mutex{}),
+		pendingMessages:    newPendingQueue(capacity, keepalive, lastConfirmedTimeTickMessage),
+		metrics:            metricsutil.NewWriteAheadBufferMetrics(pchannel, capacity),
+		maintenanceManager: maintenanceManager,
 	}
+	maintenanceManager.register(buffer)
+	return buffer
 }
 
 // WriteAheadBuffer is a buffer that stores messages in order of time tick.
 type WriteAheadBuffer struct {
-	logger          *mlog.Logger
-	cond            *syncutil.ContextCond
-	closed          bool
-	pendingMessages *pendingQueue // The pending message is always sorted by timetick in monotonic ascending order.
-	// Only keep the persisted messages in the buffer.
-	lastTimeTickMessage message.ImmutableMessage
-	metrics             *metricsutil.WriteAheadBufferMetrics
+	logger             *mlog.Logger
+	cond               *syncutil.ContextCond
+	closed             bool
+	pendingMessages    *pendingQueue // The pending message is always sorted by timetick in monotonic ascending order.
+	metrics            *metricsutil.WriteAheadBufferMetrics
+	maintenanceManager *MaintenanceManager
 }
 
 // Append appends a message to the buffer.
@@ -62,12 +64,12 @@ func (w *WriteAheadBuffer) Append(msgs []message.ImmutableMessage, tsMsg message
 	if tsMsg.MessageType() != message.MessageTypeTimeTick {
 		panic("the message is not a time tick message")
 	}
-	if tsMsg.TimeTick() <= w.lastTimeTickMessage.TimeTick() {
+	if tsMsg.TimeTick() <= w.pendingMessages.LastTimeTick() {
 		panic("the time tick of the message is less or equal than the last time tick message")
 	}
 
 	if len(msgs) > 0 {
-		if msgs[0].TimeTick() <= w.lastTimeTickMessage.TimeTick() {
+		if msgs[0].TimeTick() <= w.pendingMessages.LastTimeTick() {
 			panic("the time tick of the message is less than or equal to the last time tick message")
 		}
 		if msgs[len(msgs)-1].TimeTick() > tsMsg.TimeTick() {
@@ -75,18 +77,27 @@ func (w *WriteAheadBuffer) Append(msgs []message.ImmutableMessage, tsMsg message
 		}
 		w.pendingMessages.Push(msgs)
 	}
-	if tsMsg.IsPersisted() {
-		// The message is persisted, so we need to push it to the pending queue.
-		w.pendingMessages.Push([]message.ImmutableMessage{tsMsg})
-	}
+	w.pendingMessages.Push([]message.ImmutableMessage{tsMsg})
 	w.pendingMessages.Evict()
 
-	w.lastTimeTickMessage = tsMsg
+	w.observeMetricsLocked()
+}
+
+func (w *WriteAheadBuffer) evictExpiredMessages() {
+	w.cond.L.Lock()
+	defer w.cond.L.Unlock()
+	if w.closed || !w.pendingMessages.Evict() {
+		return
+	}
+	w.observeMetricsLocked()
+}
+
+func (w *WriteAheadBuffer) observeMetricsLocked() {
 	w.metrics.Observe(
 		w.pendingMessages.Len(),
 		w.pendingMessages.Size(),
 		w.pendingMessages.EarliestTimeTick(),
-		w.lastTimeTickMessage.TimeTick(),
+		w.pendingMessages.LastTimeTick(),
 	)
 }
 
@@ -98,14 +109,13 @@ func (w *WriteAheadBuffer) ReadFromExclusiveTimeTick(ctx context.Context, timeti
 	}
 	return &WriteAheadBufferReader{
 		nextOffset:    nextOffset,
-		lastTimeTick:  timetick,
 		snapshot:      snapshot,
 		underlyingBuf: w,
 	}, nil
 }
 
 // createSnapshotFromOffset creates a snapshot of the buffer from the given offset.
-func (w *WriteAheadBuffer) createSnapshotFromOffset(ctx context.Context, offset int, timeTick uint64) ([]messageWithOffset, error) {
+func (w *WriteAheadBuffer) createSnapshotFromOffset(ctx context.Context, offset int) ([]messageWithOffset, error) {
 	w.cond.L.Lock()
 	if w.closed {
 		w.cond.L.Unlock()
@@ -123,18 +133,6 @@ func (w *WriteAheadBuffer) createSnapshotFromOffset(ctx context.Context, offset 
 			return nil, err
 		}
 
-		// error is eof, which means that the time tick is behind the message buffer.
-		// check if the last time tick is greater than the given time tick.
-		// if so, return it to update the timetick.
-		// lastTimeTickMessage will never be nil if call this api.
-		if w.lastTimeTickMessage.TimeTick() > timeTick {
-			msg := messageWithOffset{
-				Message: w.lastTimeTickMessage,
-				Offset:  w.pendingMessages.CurrentOffset(),
-			}
-			w.cond.L.Unlock()
-			return []messageWithOffset{msg}, nil
-		}
 		// Block until the buffer updates.
 		if err := w.cond.Wait(ctx); err != nil {
 			return nil, err
@@ -161,24 +159,13 @@ func (w *WriteAheadBuffer) createSnapshotFromTimeTick(ctx context.Context, timeT
 			return nil, 0, err
 		}
 
-		// error is eof, which means that the time tick is behind the message buffer.
-		// The lastTimeTickMessage should always be greater or equal to the lastTimeTick in the pending queue.
+		// The requested timetick is exactly the latest persisted message, so the
+		// reader can start from the next offset and wait for future appends.
 		if w.pendingMessages.LastTimeTick() == timeTick {
 			offset := w.pendingMessages.CurrentOffset() + 1
 			w.cond.L.Unlock()
 			return nil, offset, nil
 		}
-
-		if w.lastTimeTickMessage.TimeTick() > timeTick {
-			// check if the last time tick is greater than the given time tick, return it to update the timetick.
-			msg := messageWithOffset{
-				Message: w.lastTimeTickMessage,
-				Offset:  w.pendingMessages.CurrentOffset(), // We add a extra timetick message, so reuse the current offset.
-			}
-			w.cond.L.Unlock()
-			return []messageWithOffset{msg}, msg.Offset, nil
-		}
-
 		if err := w.cond.Wait(ctx); err != nil {
 			return nil, 0, err
 		}
@@ -187,7 +174,12 @@ func (w *WriteAheadBuffer) createSnapshotFromTimeTick(ctx context.Context, timeT
 
 func (w *WriteAheadBuffer) Close() {
 	w.cond.L.Lock()
+	if w.closed {
+		w.cond.L.Unlock()
+		return
+	}
 	w.metrics.Close()
 	w.closed = true
 	w.cond.L.Unlock()
+	w.maintenanceManager.unregister(w)
 }

--- a/internal/streamingnode/server/wal/interceptors/wab/write_ahead_buffer_test.go
+++ b/internal/streamingnode/server/wal/interceptors/wab/write_ahead_buffer_test.go
@@ -12,76 +12,13 @@ import (
 	"github.com/milvus-io/milvus/pkg/v3/mlog"
 	"github.com/milvus-io/milvus/pkg/v3/streaming/util/message"
 	"github.com/milvus-io/milvus/pkg/v3/streaming/walimpls/impls/walimplstest"
-	"github.com/milvus-io/milvus/pkg/v3/util/syncutil"
 )
-
-func TestWriteAheadBufferWithOnlyTrivialTimeTick(t *testing.T) {
-	ctx := context.Background()
-	wb := NewWriteAheadBuffer("pchannel", mlog.With(), 5*1024*1024, 30*time.Second, createTimeTickMessage(0, true))
-
-	// Test timeout
-	ctx, cancel := context.WithTimeout(ctx, 1*time.Millisecond)
-	defer cancel()
-	r, err := wb.ReadFromExclusiveTimeTick(ctx, 100)
-	assert.Nil(t, r)
-	assert.ErrorIs(t, err, context.DeadlineExceeded)
-
-	readErr := syncutil.NewFuture[struct{}]()
-	expectedLastTimeTick := uint64(10000)
-	go func() {
-		r, err := wb.ReadFromExclusiveTimeTick(context.Background(), 100)
-		assert.NoError(t, err)
-		assert.NotNil(t, r)
-		lastTimeTick := uint64(0)
-		for {
-			msg, err := r.Next(context.Background())
-			assert.NoError(t, err)
-			assert.NotNil(t, msg)
-			assert.Greater(t, msg.TimeTick(), lastTimeTick)
-			lastTimeTick = msg.TimeTick()
-			if msg.TimeTick() > expectedLastTimeTick {
-				break
-			}
-		}
-		// Because there's no more message updated, so the Next operation should be blocked forever.
-		ctx, cancel = context.WithTimeout(ctx, 5*time.Millisecond)
-		defer cancel()
-		msg, err := r.Next(ctx)
-		assert.Nil(t, msg)
-		assert.ErrorIs(t, err, context.DeadlineExceeded)
-		readErr.Set(struct{}{})
-	}()
-
-	// Current the cache last timetick will be push to 100,
-	// But we make a exclusive read, so the read operation should be blocked.
-	wb.Append(nil, createTimeTickMessage(100, false))
-	ctx, cancel = context.WithTimeout(ctx, 5*time.Millisecond)
-	defer cancel()
-	_, err = readErr.GetWithContext(ctx)
-	assert.ErrorIs(t, err, context.DeadlineExceeded)
-
-	nextTimeTick := uint64(100)
-	for {
-		nextTimeTick += uint64(rand.Int31n(1000) + 1)
-		wb.Append(nil, createTimeTickMessage(nextTimeTick, false))
-		if nextTimeTick > expectedLastTimeTick {
-			break
-		}
-	}
-	readErr.Get()
-
-	r, err = wb.ReadFromExclusiveTimeTick(context.Background(), 0)
-	assert.NoError(t, err)
-	msg, err := r.Next(context.Background())
-	assert.NoError(t, err)
-	assert.Equal(t, message.MessageTypeTimeTick, msg.MessageType())
-	assert.Equal(t, nextTimeTick, msg.TimeTick())
-}
 
 func TestWriteAheadBuffer(t *testing.T) {
 	// Concurrent add message into bufffer and make syncup.
 	// The reader should never lost any message if no eviction happen.
-	wb := NewWriteAheadBuffer("pchannel", mlog.With(), 5*1024*1024, 30*time.Second, createTimeTickMessage(1, true))
+	wb := NewWriteAheadBuffer(newTestMaintenanceManager(t), "pchannel", mlog.With(), 5*1024*1024, 30*time.Second, createTimeTickMessage(1))
+	t.Cleanup(wb.Close)
 	expectedLastTimeTick := uint64(10000)
 	ch := make(chan struct{})
 	totalCnt := 0
@@ -97,7 +34,7 @@ func TestWriteAheadBuffer(t *testing.T) {
 					break
 				}
 			}
-			wb.Append(msgs, createTimeTickMessage(msgs[len(msgs)-1].TimeTick(), true))
+			wb.Append(msgs, createTimeTickMessage(msgs[len(msgs)-1].TimeTick()))
 			totalCnt += (len(msgs) + 1)
 			if nextTimeTick > expectedLastTimeTick {
 				break
@@ -176,7 +113,7 @@ func TestWriteAheadBuffer(t *testing.T) {
 	defer cancel()
 	_, err = r2.Next(ctx)
 	assert.ErrorIs(t, err, context.DeadlineExceeded)
-	wb.Append(nil, createTimeTickMessage(timeticks[len(timeticks)-1]+1, false))
+	wb.Append(nil, createTimeTickMessage(timeticks[len(timeticks)-1]+1))
 	msg, err = r1.Next(ctx)
 	assert.Equal(t, message.MessageTypeTimeTick, msg.MessageType())
 	assert.NoError(t, err)
@@ -185,14 +122,89 @@ func TestWriteAheadBuffer(t *testing.T) {
 	assert.NoError(t, err)
 }
 
+func TestWriteAheadBufferIdleEviction(t *testing.T) {
+	manager := NewMaintenanceManager(5 * time.Millisecond)
+	defer manager.Close()
+
+	wb := NewWriteAheadBuffer(
+		manager,
+		"pchannel",
+		mlog.With(),
+		5*1024*1024,
+		20*time.Millisecond,
+		createTimeTickMessage(0),
+	)
+	defer wb.Close()
+
+	msgs := make([]message.ImmutableMessage, 0, 99)
+	for i := 1; i < 100; i++ {
+		msgs = append(msgs, createInsertMessage(uint64(i)))
+	}
+	wb.Append(msgs, createTimeTickMessage(99))
+
+	assert.Eventually(t, func() bool {
+		wb.cond.L.Lock()
+		defer wb.cond.L.Unlock()
+		return wb.pendingMessages.Len() == 1
+	}, time.Second, 5*time.Millisecond)
+
+	wb.cond.L.Lock()
+	defer wb.cond.L.Unlock()
+	assert.Equal(t, uint64(99), wb.pendingMessages.buf[0].Message.TimeTick())
+}
+
+func TestMaintenanceManagerMaintainsMultipleBuffersAndUnregistersOnClose(t *testing.T) {
+	manager := NewMaintenanceManager(5 * time.Millisecond)
+	defer manager.Close()
+
+	first := NewWriteAheadBuffer(
+		manager,
+		"pchannel-1",
+		mlog.With(),
+		5*1024*1024,
+		20*time.Millisecond,
+		createTimeTickMessage(0),
+	)
+	second := NewWriteAheadBuffer(
+		manager,
+		"pchannel-2",
+		mlog.With(),
+		5*1024*1024,
+		20*time.Millisecond,
+		createTimeTickMessage(0),
+	)
+	defer second.Close()
+
+	first.Append([]message.ImmutableMessage{createInsertMessage(1)}, createTimeTickMessage(1))
+	second.Append([]message.ImmutableMessage{createInsertMessage(1)}, createTimeTickMessage(1))
+
+	assert.Eventually(t, func() bool {
+		return pendingMessageCount(first) == 1 && pendingMessageCount(second) == 1
+	}, time.Second, 5*time.Millisecond)
+
+	first.Close()
+	manager.mu.Lock()
+	assert.Len(t, manager.buffers, 1)
+	_, registered := manager.buffers[second]
+	manager.mu.Unlock()
+	assert.True(t, registered)
+
+	manager.Close()
+	manager.mu.Lock()
+	assert.Empty(t, manager.buffers)
+	manager.mu.Unlock()
+	second.Close()
+}
+
 func TestWriteAheadBufferEviction(t *testing.T) {
-	wb := NewWriteAheadBuffer("pchannel", mlog.With(), 5*1024*1024, 50*time.Millisecond, createTimeTickMessage(0, true))
+	wb := NewWriteAheadBuffer(newTestMaintenanceManager(t), "pchannel", mlog.With(), 5*1024*1024, 50*time.Millisecond, createTimeTickMessage(0))
+	t.Cleanup(wb.Close)
 
 	msgs := make([]message.ImmutableMessage, 0)
 	for i := 1; i < 100; i++ {
 		msgs = append(msgs, createInsertMessage(uint64(i)))
 	}
-	wb.Append(msgs, createTimeTickMessage(99, true))
+	wb.Append(msgs, createTimeTickMessage(99))
 
 	// We can read from 0 to 100 messages
 	r, err := wb.ReadFromExclusiveTimeTick(context.Background(), 0)
@@ -206,9 +218,9 @@ func TestWriteAheadBufferEviction(t *testing.T) {
 	for i := 100; i < 200; i++ {
 		msgs = append(msgs, createInsertMessage(uint64(i)))
 	}
-	wb.Append(msgs, createTimeTickMessage(199, true))
+	wb.Append(msgs, createTimeTickMessage(199))
 	time.Sleep(60 * time.Millisecond)
-	wb.Append(nil, createTimeTickMessage(200, false))
+	wb.Append(nil, createTimeTickMessage(200))
 	// wait for expiration.
 
 	lastTimeTick := uint64(0)
@@ -228,18 +240,27 @@ func TestWriteAheadBufferEviction(t *testing.T) {
 	assert.Equal(t, uint64(99), lastTimeTick)
 }
 
-func createTimeTickMessage(timetick uint64, persist bool) message.ImmutableMessage {
-	b := message.NewTimeTickMessageBuilderV1().
+func createTimeTickMessage(timetick uint64) message.ImmutableMessage {
+	msg := message.NewTimeTickMessageBuilderV1().
 		WithAllVChannel().
 		WithHeader(&message.TimeTickMessageHeader{}).
-		WithBody(&msgpb.TimeTickMsg{})
-	if !persist {
-		b.WithNotPersisted()
-	}
-	msg := b.MustBuildMutable()
+		WithBody(&msgpb.TimeTickMsg{}).
+		MustBuildMutable()
 	return msg.WithTimeTick(timetick).IntoImmutableMessage(
 		walimplstest.NewTestMessageID(1),
 	)
+}
+
+func newTestMaintenanceManager(t *testing.T) *MaintenanceManager {
+	manager := NewMaintenanceManager(time.Hour)
+	t.Cleanup(manager.Close)
+	return manager
+}
+
+func pendingMessageCount(buffer *WriteAheadBuffer) int {
+	buffer.cond.L.Lock()
+	defer buffer.cond.L.Unlock()
+	return buffer.pendingMessages.Len()
 }
 
 func createInsertMessage(timetick uint64) message.ImmutableMessage {

--- a/internal/streamingnode/server/wal/utility/context.go
+++ b/internal/streamingnode/server/wal/utility/context.go
@@ -15,7 +15,6 @@ type walCtxKey int
 
 var (
 	extraAppendResultValue walCtxKey = 1
-	notPersistedValue      walCtxKey = 2
 	metricsValue           walCtxKey = 3
 	flushFromOldArchValue  walCtxKey = 4
 )
@@ -26,25 +25,6 @@ type ExtraAppendResult struct {
 	TxnCtx                 *message.TxnContext
 	Extra                  protoreflect.ProtoMessage
 	LastConfirmedMessageID message.MessageID
-}
-
-// NotPersistedHint is the hint of not persisted message.
-type NotPersistedHint struct {
-	MessageID message.MessageID // The reused MessageID.
-}
-
-// WithNotPersisted set not persisted message to context
-func WithNotPersisted(ctx context.Context, hint *NotPersistedHint) context.Context {
-	return context.WithValue(ctx, notPersistedValue, hint)
-}
-
-// GetNotPersisted get not persisted message from context
-func GetNotPersisted(ctx context.Context) *NotPersistedHint {
-	val := ctx.Value(notPersistedValue)
-	if val == nil {
-		return nil
-	}
-	return val.(*NotPersistedHint)
 }
 
 // WithExtraAppendResult set extra to context

--- a/internal/streamingnode/server/wal/utility/context_test.go
+++ b/internal/streamingnode/server/wal/utility/context_test.go
@@ -11,16 +11,6 @@ import (
 	"github.com/milvus-io/milvus/pkg/v3/streaming/walimpls/impls/walimplstest"
 )
 
-func TestWithNotPersisted(t *testing.T) {
-	ctx := context.Background()
-	hint := &NotPersistedHint{MessageID: walimplstest.NewTestMessageID(1)}
-	ctx = WithNotPersisted(ctx, hint)
-
-	retrievedHint := GetNotPersisted(ctx)
-	assert.NotNil(t, retrievedHint)
-	assert.True(t, retrievedHint.MessageID.EQ(hint.MessageID))
-}
-
 func TestWithExtraAppendResult(t *testing.T) {
 	ctx := context.Background()
 	extra := &anypb.Any{}


### PR DESCRIPTION
issue: milvus-io/milvus#40451

- WAB maintenance: add one StreamingNode-level maintainer that evicts expired entries from idle PChannel buffers while retaining the latest durable overlap boundary
- TimeTick persistence: remove the obsolete non-persisted TimeTick and WAL append-bypass paths so catch-up and tailing share persisted boundaries
- lifecycle and observability: register buffers with node resources, unregister them on close, and refresh WAB metrics after background eviction