### PR TITLE
enhance: propagate cancellation to transform log scans

### DIFF
--- a/internal/streamingnode/server/wal/vchannel/transformlog/task.go
+++ b/internal/streamingnode/server/wal/vchannel/transformlog/task.go
@@ -60,7 +60,7 @@ func (t *transformFlushTask) Execute(ctx context.Context) error {
 		if result.NextTargetTimeTick > 0 {
 			t.log.submitFlushTask(result.NextTargetTimeTick)
 		}
-		if t.log.shouldMaterialize() && !t.log.HasPendingMaterializeTask() {
+		if t.log.shouldMaterialize(ctx) && !t.log.HasPendingMaterializeTask() {
 			t.log.submitMaterializeTask(t.log.dataCheckpointTimeTick())
 		}
 		t.log.notifyUpdated()

--- a/internal/streamingnode/server/wal/vchannel/transformlog/task_test.go
+++ b/internal/streamingnode/server/wal/vchannel/transformlog/task_test.go
@@ -19,12 +19,14 @@ package transformlog
 import (
 	"context"
 	"testing"
+	"time"
 
 	"github.com/cockroachdb/errors"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 
 	"github.com/milvus-io/milvus/internal/streamingnode/server/wal/moduleapi"
+	"github.com/milvus-io/milvus/pkg/v3/proto/streamingpb"
 	"github.com/milvus-io/milvus/pkg/v3/util/nodescheduler"
 )
 
@@ -95,6 +97,42 @@ func TestTransformTaskDoesNotInterpretCanceledContext(t *testing.T) {
 	require.ErrorIs(t, err, context.Canceled)
 	require.True(t, errors.Is(err, nodescheduler.ErrDelay))
 	assert.False(t, task.Done())
+}
+
+func TestTransformFlushTaskCancellationStopsColdMaterializeScan(t *testing.T) {
+	store := newBlockingReadStore()
+	defer store.release()
+	require.NoError(t, store.WriteTransformLogChunk(context.Background(), "v1", &streamingpb.TransformLogChunk{
+		ChunkId: 0,
+		Entries: []*streamingpb.TransformLogEntry{
+			testTransformLogDeleteEntry(10, 1),
+		},
+	}))
+	transformLog := New(Config{
+		VChannel: "v1",
+		Store:    store,
+		Meta: &streamingpb.VChannelTransformLogMeta{
+			CheckpointTimeTick: 10,
+			NextChunkId:        1,
+		},
+	})
+	task := &transformFlushTask{transformTaskBase: transformTaskBase{log: transformLog}}
+
+	ctx, cancel := context.WithCancel(context.Background())
+	done := make(chan error, 1)
+	go func() {
+		done <- task.Execute(ctx)
+	}()
+	store.waitReadStarted(t)
+	cancel()
+
+	select {
+	case err := <-done:
+		require.NoError(t, err)
+		assert.True(t, task.Done())
+	case <-time.After(time.Second):
+		t.Fatal("transform flush task did not stop after cancellation")
+	}
 }
 
 type testTransformTask struct {

--- a/internal/streamingnode/server/wal/vchannel/transformlog/transform_log.go
+++ b/internal/streamingnode/server/wal/vchannel/transformlog/transform_log.go
@@ -395,11 +395,11 @@ func (t *TransformLog) hasFlushWork() bool {
 	return !t.buffer.IsEmpty() || t.buffer.IsFlushing()
 }
 
-func (t *TransformLog) shouldMaterialize() bool {
+func (t *TransformLog) shouldMaterialize(ctx context.Context) bool {
 	t.mu.Lock()
 	targetTimeTick := t.meta.GetCheckpointTimeTick()
 	t.mu.Unlock()
-	rows, bytes, err := t.pendingMaterializeStats(context.TODO(), targetTimeTick)
+	rows, bytes, err := t.pendingMaterializeStats(ctx, targetTimeTick)
 	if err != nil {
 		return false
 	}

--- a/internal/streamingnode/server/wal/vchannel/transformlog/transform_log_test.go
+++ b/internal/streamingnode/server/wal/vchannel/transformlog/transform_log_test.go
@@ -460,9 +460,9 @@ func TestShouldMaterializeUsesUnmaterializedRowsAndBytes(t *testing.T) {
 		Entries: []*streamingpb.TransformLogEntry{testTransformLogDeleteEntry(10, 1, 2)},
 	})}
 
-	assert.True(t, transformLog.shouldMaterialize())
+	assert.True(t, transformLog.shouldMaterialize(context.Background()))
 	transformLog.meta.MaterializedTimeTick = 10
-	assert.False(t, transformLog.shouldMaterialize())
+	assert.False(t, transformLog.shouldMaterialize(context.Background()))
 }
 
 func TestSplitMaterializeGroupsSplitsSingleBlockByRowLimit(t *testing.T) {


### PR DESCRIPTION
## What changed

- Pass the node scheduler task context into the pending TransformLog materialization scan.
- Allow cold chunk reads and waits to stop when the task is canceled.
- Add a regression test covering cancellation during a blocked cold chunk read.

## Why

RecoveryStorage owns TransformLog tasks through a scoped node scheduler. During WAL or RecoveryStorage shutdown, task handles are canceled, but the pending materialization scan used context.TODO(), so object-storage reads could continue and delay shutdown.

This change does not alter normal materialization thresholds or TransformLog durability semantics.

## Verification

`PKG_CONFIG_PATH=/home/ubuntu/milvus/internal/core/output/lib/pkgconfig LD_LIBRARY_PATH=/home/ubuntu/milvus/internal/core/output/lib go test -tags dynamic,test -gcflags="all=-N -l" -count=1 ./internal/streamingnode/server/wal/vchannel/transformlog`