### PR TITLE
enhance: serialize broadcast acknowledgements with a FIFO queue

### DIFF
--- a/internal/streamingnode/server/wal/recovery/broadcast_ack_module.go
+++ b/internal/streamingnode/server/wal/recovery/broadcast_ack_module.go
@@ -2,6 +2,7 @@ package recovery
 
 import (
 	"context"
+	"sync"
 
 	"go.uber.org/atomic"
 
@@ -50,7 +51,9 @@ type broadcastAckModule struct {
 	runtime      moduleapi.Runtime
 	acked        *atomic.Uint64
 	mode         moduleMode
-	lastAckTask  *broadcastAckTask
+	ackTaskMu    sync.Mutex
+	ackTaskHead  *broadcastAckTask
+	ackTaskTail  *broadcastAckTask
 	ack          func(context.Context, message.ImmutableMessage) error
 }
 
@@ -87,8 +90,7 @@ func (m *broadcastAckModule) ObserveMessage(ctx context.Context, msg message.Imm
 	}
 	task := m.newTask(msg)
 	if m.runtime.Scheduler != nil {
-		m.lastAckTask = task
-		m.runtime.Scheduler.Submit(task)
+		m.enqueueTask(task)
 	}
 	return moduleapi.ObserveResult{Data: barrier}
 }
@@ -106,8 +108,42 @@ func (m *broadcastAckModule) newTask(msg message.ImmutableMessage) *broadcastAck
 	return &broadcastAckTask{
 		module:   m,
 		msg:      msg,
-		previous: m.lastAckTask,
 		frontier: m.buildFrontier(msg),
+	}
+}
+
+func (m *broadcastAckModule) enqueueTask(task *broadcastAckTask) {
+	m.ackTaskMu.Lock()
+	shouldSubmit := m.ackTaskTail == nil
+	if shouldSubmit {
+		m.ackTaskHead = task
+	} else {
+		m.ackTaskTail.next = task
+	}
+	m.ackTaskTail = task
+	m.ackTaskMu.Unlock()
+
+	if shouldSubmit {
+		m.runtime.Scheduler.Submit(task)
+	}
+}
+
+func (m *broadcastAckModule) finishTask(task *broadcastAckTask) {
+	m.ackTaskMu.Lock()
+	if m.ackTaskHead != task {
+		m.ackTaskMu.Unlock()
+		return
+	}
+	next := task.next
+	task.next = nil
+	m.ackTaskHead = next
+	if next == nil {
+		m.ackTaskTail = nil
+	}
+	m.ackTaskMu.Unlock()
+
+	if next != nil {
+		m.runtime.Scheduler.Submit(next)
 	}
 }
 
@@ -201,23 +237,15 @@ func (b *broadcastAckBarrier) TimeTick() uint64 {
 type broadcastAckTask struct {
 	module   *broadcastAckModule
 	msg      message.ImmutableMessage
-	previous *broadcastAckTask
 	frontier walcheckpoint.Barrier
-	done     atomic.Bool
-}
-
-func (t *broadcastAckTask) Done() bool {
-	return t.done.Load()
+	next     *broadcastAckTask
 }
 
 func (t *broadcastAckTask) Execute(ctx context.Context) error {
-	if t.previous != nil && !t.previous.Done() {
-		return nodescheduler.ErrDelay
-	}
 	if t.frontier != nil && t.frontier.TimeTick() < t.msg.TimeTick() {
 		return nodescheduler.ErrDelay
 	}
-	defer t.done.Store(true)
+	defer t.module.finishTask(t)
 	if err := t.module.ack(ctx, t.msg); err != nil {
 		return err
 	}

--- a/internal/streamingnode/server/wal/recovery/recovery_storage_impl_test.go
+++ b/internal/streamingnode/server/wal/recovery/recovery_storage_impl_test.go
@@ -514,7 +514,7 @@ func TestBroadcastAckModulePreconditionsFollowMessageFlow(t *testing.T) {
 		ready bool
 	}{
 		{
-			name: "commit import waits only for previous ack",
+			name: "commit import has no data frontier",
 			msg: newAckPreconditionMessage(t, message.NewCommitImportMessageBuilderV2().
 				WithVChannel("v1").
 				WithHeader(&message.CommitImportMessageHeader{CollectionId: 1, JobId: 10}).
@@ -635,6 +635,61 @@ func TestBroadcastAckModuleReturnsBarrierForEveryBroadcastHeader(t *testing.T) {
 
 	require.NotNil(t, result.Data)
 }
+
+func TestBroadcastAckModuleSchedulesOnlyQueueHead(t *testing.T) {
+	frontierTimeTick := uint64(9)
+	scheduler := &recordingAckTaskScheduler{}
+	module := newBroadcastAckModule("test-pchannel", &recordingFrontierView{
+		barrier: walcheckpoint.BarrierFunc(func() uint64 { return frontierTimeTick }),
+	}, moduleapi.Runtime{Scheduler: scheduler})
+	module.SwitchIntoMetaAndData()
+
+	acked := make([]message.MessageType, 0, 2)
+	module.ack = func(_ context.Context, msg message.ImmutableMessage) error {
+		acked = append(acked, msg.MessageType())
+		return nil
+	}
+
+	flush := newBroadcastAckMessage(t, message.NewManualFlushMessageBuilderV2().
+		WithBroadcast([]string{"v1"}).
+		WithHeader(&message.ManualFlushMessageHeader{CollectionId: 1}).
+		WithBody(&message.ManualFlushMessageBody{}))
+	create := newBroadcastAckMessage(t, message.NewCreateCollectionMessageBuilderV1().
+		WithBroadcast([]string{"v1"}).
+		WithHeader(&message.CreateCollectionMessageHeader{CollectionId: 2, PartitionIds: []int64{10}}).
+		WithBody(&msgpb.CreateCollectionRequest{CollectionSchema: &schemapb.CollectionSchema{}}))
+
+	module.ObserveMessage(context.Background(), flush)
+	module.ObserveMessage(context.Background(), create)
+	require.Len(t, scheduler.tasks, 1)
+
+	require.ErrorIs(t, scheduler.tasks[0].Execute(context.Background()), nodescheduler.ErrDelay)
+	require.Len(t, scheduler.tasks, 1)
+
+	frontierTimeTick = flush.TimeTick()
+	require.NoError(t, scheduler.tasks[0].Execute(context.Background()))
+	require.Len(t, scheduler.tasks, 2)
+	require.NoError(t, scheduler.tasks[1].Execute(context.Background()))
+	assert.Equal(t, []message.MessageType{
+		message.MessageTypeManualFlush,
+		message.MessageTypeCreateCollection,
+	}, acked)
+}
+
+type recordingAckTaskScheduler struct {
+	tasks []nodescheduler.Task
+}
+
+func (s *recordingAckTaskScheduler) Submit(task nodescheduler.Task) nodescheduler.TaskHandle {
+	s.tasks = append(s.tasks, task)
+	return recordingAckTaskHandle{}
+}
+
+type recordingAckTaskHandle struct{}
+
+func (recordingAckTaskHandle) Cancel() {}
+
+func (recordingAckTaskHandle) Wait(context.Context) error { return nil }
 
 func newAckPreconditionMessage(t *testing.T, builder interface{ MustBuildMutable() message.MutableMessage }) message.ImmutableMessage {
 	t.Helper()


### PR DESCRIPTION
## What problem does this solve?

Broadcast acknowledgements on a StreamingNode PChannel must be processed in message order. Previously, every acknowledgement task was submitted to the process-level NodeScheduler as soon as its message was observed. Tasks behind the queue head repeatedly returned `nodescheduler.ErrDelay` until their predecessor completed.

When recovery or DDL bursts accumulate acknowledgements, these non-runnable tasks repeatedly cycle through the shared scheduler queue and compete with other node-level work, even though only the oldest acknowledgement can make progress.

## What does this change?

- Maintain a mutex-protected FIFO acknowledgement queue inside `broadcastAckModule`.
- Submit only the queue head to `NodeScheduler`.
- Remove the completed head and submit the next task.
- Preserve the existing data-frontier checks, per-PChannel ordering, ACK behavior, and barrier notification semantics.

This is a scheduling optimization only. It does not batch ACK RPCs or relax durability and ordering requirements.

Source commit: `origin/qv-work@002643556c41075375a8b216de39e808e0ae87c5`

## Test Plan

- `source scripts/setenv.sh && go test -count=1 -tags dynamic,test -gcflags="all=-N -l" ./internal/streamingnode/server/wal/recovery -run "^TestBroadcastAckModule" -timeout 300s`
- `source scripts/setenv.sh && go test -race -count=1 -tags dynamic,test -gcflags="all=-N -l" ./internal/streamingnode/server/wal/recovery -run "^TestBroadcastAckModule" -timeout 300s`