### PR TITLE
fix: remove empty shard view managers after durable cleanup

### DIFF
--- a/internal/views/coord/coordview/shard_view_manager.go
+++ b/internal/views/coord/coordview/shard_view_manager.go
@@ -29,6 +29,7 @@ type ShardViewManager struct {
 	shardID        qviews.ShardID
 	eventSubmitter dirtyViewEventSubmitter
 	observe        func(qviews.ShardID, *ShardStats)
+	onEmpty        func(qviews.ShardID, *ShardViewManager)
 
 	// All active views keyed by version for O(1) lookup.
 	views map[qviews.QueryViewVersion]*CoordQueryViewStateMachine
@@ -180,6 +181,14 @@ func (m *ShardViewManager) SetStatsObserver(observer func(qviews.ShardID, *Shard
 	m.mu.Lock()
 	defer m.mu.Unlock()
 	m.observe = observer
+}
+
+// setOnEmpty installs the callback invoked after the manager's last
+// QueryView has completed durable removal.
+func (m *ShardViewManager) setOnEmpty(callback func(qviews.ShardID, *ShardViewManager)) {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	m.onEmpty = callback
 }
 
 // Stats returns an atomic snapshot of this shard's current placement state.
@@ -709,13 +718,20 @@ func (m *ShardViewManager) removeView(target *CoordQueryViewStateMachine) {
 // Dropped QueryView state has been persisted by DirtyViewFlushScheduler.
 func (m *ShardViewManager) finalizeRemoval(target *CoordQueryViewStateMachine) {
 	m.mu.Lock()
-	defer m.mu.Unlock()
 	if m.views[target.Version()] != target {
+		m.mu.Unlock()
 		return
 	}
 	m.removeView(target)
 	m.unpinReference(target)
 	m.publishStatsLocked()
+	empty := len(m.views) == 0
+	onEmpty := m.onEmpty
+	m.mu.Unlock()
+
+	if empty && onEmpty != nil {
+		onEmpty(m.shardID, m)
+	}
 }
 
 func (m *ShardViewManager) hasPendingRemoval(target *CoordQueryViewStateMachine) bool {

--- a/internal/views/coord/coordview/shard_view_registry.go
+++ b/internal/views/coord/coordview/shard_view_registry.go
@@ -105,6 +105,7 @@ func RecoverShardViewRegistry(
 		registry.addCollectionShardLocked(sid)
 		registry.addNodeShardsLocked(sid, stats)
 		mgr.SetStatsObserver(registry.onShardStatsChanged)
+		mgr.setOnEmpty(registry.removeEmptyManager)
 	}
 	// Recovery sync callbacks may update manager stats immediately. Install all
 	// observers and indexes before releasing the held recovery events so those
@@ -133,6 +134,7 @@ func (r *ShardViewRegistry) Ensure(shardID qviews.ShardID) *ShardViewManager {
 
 	mgr := newShardViewManager(r.ctx, shardID, r.flushScheduler, nil, r.dataViewReferences)
 	mgr.SetStatsObserver(r.onShardStatsChanged)
+	mgr.setOnEmpty(r.removeEmptyManager)
 	stats := emptyShardStats()
 
 	r.mu.Lock()
@@ -168,6 +170,28 @@ func (r *ShardViewRegistry) Get(shardID qviews.ShardID) *ShardViewManager {
 	r.mu.RLock()
 	defer r.mu.RUnlock()
 	return r.shards[shardID]
+}
+
+// removeEmptyManager reclaims a manager after its last QueryView has completed
+// durable removal. Recheck both emptiness and identity because the callback is
+// invoked after releasing the manager lock.
+func (r *ShardViewRegistry) removeEmptyManager(shardID qviews.ShardID, manager *ShardViewManager) {
+	manager.mu.Lock()
+	defer manager.mu.Unlock()
+	if len(manager.views) != 0 {
+		return
+	}
+
+	r.mu.Lock()
+	defer r.mu.Unlock()
+	if r.shards[shardID] != manager {
+		return
+	}
+	r.removeNodeShardsLocked(shardID, r.stats[shardID])
+	r.removeCollectionShardLocked(shardID)
+	delete(r.stats, shardID)
+	delete(r.shards, shardID)
+	r.version++
 }
 
 // Snapshot returns the current resident immutable shard-view snapshot. It
@@ -308,6 +332,19 @@ func (r *ShardViewRegistry) addCollectionShardLocked(shardID qviews.ShardID) {
 		r.collectionShards[channel.CollectionID()] = shards
 	}
 	shards[shardID] = struct{}{}
+}
+
+func (r *ShardViewRegistry) removeCollectionShardLocked(shardID qviews.ShardID) {
+	channel, err := metautil.ParseChannel(shardID.VChannel, metautil.NewDynChannelMapper())
+	if err != nil {
+		return
+	}
+	collectionID := channel.CollectionID()
+	shards := r.collectionShards[collectionID]
+	delete(shards, shardID)
+	if len(shards) == 0 {
+		delete(r.collectionShards, collectionID)
+	}
 }
 
 func (r *ShardViewRegistry) addNodeShardsLocked(shardID qviews.ShardID, stats *ShardStats) {

--- a/internal/views/coord/coordview/shard_view_registry_test.go
+++ b/internal/views/coord/coordview/shard_view_registry_test.go
@@ -81,6 +81,44 @@ func TestRegistry_EnsureCreatesOnce(t *testing.T) {
 	assert.Len(t, reg.Snapshot().StatsMap(), 1)
 }
 
+func TestRegistry_RemovesManagerAfterLastViewDropped(t *testing.T) {
+	catalog := newMockCatalog()
+	s := newMockSyncer()
+	reg := newTestRegistry(t, catalog, s)
+	shardID := qviews.ShardID{
+		ReplicaID: 1,
+		VChannel:  "by-dev-rootcoord-dml_100v0",
+	}
+	mgr := reg.Ensure(shardID)
+	builder := testBuilderForShard(100, shardID)
+	builder.SetAssignments(nil)
+
+	require.NoError(t, mgr.AddPreparing(context.Background(), builder))
+	require.NoError(t, reg.flushScheduler.Flush(context.Background()))
+	require.NoError(t, mgr.RequestRelease(context.Background()))
+	require.NoError(t, reg.flushScheduler.Flush(context.Background()))
+
+	version := testVersion(1, 1, 1)
+	sn := qviews.NewStreamingNodeFromVChannel(shardID.VChannel)
+	callback := s.findOnSyncResponse(sn, version)
+	require.NotNil(t, callback)
+	response := qviews.NewQueryViewAtStreamingNode(&viewpb.QueryViewMeta{
+		CollectionId: 100,
+		ReplicaId:    shardID.ReplicaID,
+		Vchannel:     shardID.VChannel,
+		Version:      version.IntoProto(),
+		State:        viewpb.QueryViewState_QueryViewStateDropped,
+	}, &viewpb.QueryViewOfStreamingNode{})
+	require.True(t, callback(response))
+	require.NoError(t, reg.flushScheduler.Flush(context.Background()))
+
+	assert.Nil(t, reg.Get(shardID))
+	assert.Empty(t, reg.CollectionShards(100))
+	assert.Empty(t, reg.ShardIDs())
+	assert.NotContains(t, reg.Snapshot().StatsMap(), shardID)
+	assert.NotSame(t, mgr, reg.Ensure(shardID))
+}
+
 func TestRegistry_RecoverWithPersistedViews(t *testing.T) {
 	catalog := newMockCatalog()
 
@@ -269,6 +307,12 @@ func TestRecoverShardViewRegistryAllowsTerminalCleanup(t *testing.T) {
 	require.Equal(t, qviews.QueryViewStateDropping, manager.views[testVersion(3, 1, 2)].State())
 	manager.mu.Unlock()
 	require.Empty(t, refs.unpins)
+
+	version := testVersion(3, 1, 2)
+	simulateNodeResponse(t, s, testSN, version, qviews.QueryViewStateDropped)
+	simulateNodeResponse(t, s, testQN1, version, qviews.QueryViewStateDropped)
+	require.NoError(t, registry.flushScheduler.Flush(context.Background()))
+	require.Nil(t, registry.Get(qviews.NewShardIDFromQVMeta(view.GetMeta())))
 }
 
 func TestRecoverShardViewRegistryRollsBackReferencesOnFailure(t *testing.T) {


### PR DESCRIPTION
## Background

PR https://github.com/chyezh/milvus/pull/63 introduced scoped QueryView reconciliation backed by `ShardViewRegistry` reverse indexes. After the final QueryView of a shard reached `Dropped` and its ETCD key was durably removed, `ShardViewManager` deleted the view but the registry continued retaining the now-empty manager, its shard entry, and collection index.

That left registry topology out of sync with the durable QueryView lifecycle. Later scoped or full snapshots could continue including an old replica shard that no longer had any QueryView, and cleanup depended on a later reconciliation/full-scan cycle.

Issue: https://github.com/milvus-io/milvus/issues/40451

## What changed

- Install a lifecycle callback on both newly created and recovered shard view managers.
- Invoke the callback only after the final QueryView has completed durable `Dropped` removal.
- Immediately remove the empty manager from registry shard state, stats, collection/node reverse indexes, and advance the registry version.
- Recheck manager identity and emptiness under lock before deletion.
- Cover both normal release and recovery cleanup paths.

## Why cleanup happens in `finalizeRemoval`

`RequestRelease` only starts asynchronous teardown, so deleting the manager there would hide a release that is still waiting for node acknowledgements. `finalizeRemoval` runs only after every relevant node has reported `Dropped` and the catalog has successfully removed the QueryView key from ETCD. This is the first point where the manager can be removed without waiting for another reconcile cycle.

The callback is invoked after releasing the manager lock. The registry then reacquires the manager lock to revalidate emptiness and acquires the registry lock to verify identity and remove the indexes.

## Test Plan

- `go test -race -count=1 -tags dynamic,test -gcflags='all=-N -l' ./internal/views/coord/coordview -timeout 300s`
- `go test -race -count=1 -tags dynamic,test -gcflags='all=-N -l' ./internal/views/coord/balancer -timeout 300s`
- `gofumpt -l` on all changed Go files
- `git diff --check`
