### PR TITLE
enhance: optimize load config and replicate role reads

### DIFF
--- a/internal/querycoordv2/ddl_callbacks_drop_load_info.go
+++ b/internal/querycoordv2/ddl_callbacks_drop_load_info.go
@@ -42,7 +42,8 @@ func (s *Server) broadcastDropLoadConfigCollectionV2ForReleaseCollection(ctx con
 		return err
 	}
 
-	if s.qviewsRuntime.loadConfigStore.Snapshot().ConfigsMap()[req.GetCollectionID()] == nil {
+	isLoaded := s.qviewsRuntime.loadConfigStore.Contains(req.GetCollectionID())
+	if !isLoaded {
 		return errReleaseCollectionNotLoaded
 	}
 	msg := message.NewDropLoadConfigMessageBuilderV2().

--- a/internal/streamingcoord/server/balancer/channel/manager.go
+++ b/internal/streamingcoord/server/balancer/channel/manager.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"sort"
 	"sync"
+	"sync/atomic"
 
 	"github.com/cockroachdb/errors"
 	"github.com/samber/lo"
@@ -90,6 +91,11 @@ func RecoverChannelManager(ctx context.Context, incomingChannel ...string) (*Cha
 		streamingVersion: streamingVersion,
 		replicateConfig:  replicateConfig,
 	}
+	replicateRole := replicateutil.RolePrimary
+	if replicateConfig != nil {
+		replicateRole = replicateConfig.GetCurrentCluster().Role()
+	}
+	cm.replicateRole.Store(int32(replicateRole))
 
 	// Register the channel manager singleton after recovery.
 	register(cm)
@@ -225,6 +231,7 @@ type ChannelManager struct {
 	// 1 if streaming service has been run once.
 	streamingEnableNotifiers []*syncutil.AsyncTaskNotifier[struct{}]
 	replicateConfig          *replicateutil.ConfigHelper
+	replicateRole            atomic.Int32 // lock-free snapshot published after replicateConfig is persisted
 	shardAssignmentProvider  ShardAssignmentProvider
 }
 
@@ -271,13 +278,7 @@ func (cm *ChannelManager) IsStreamingVersionAtLeast(version int64) bool {
 
 // ReplicateRole returns the replicate role of the channel manager.
 func (cm *ChannelManager) ReplicateRole() replicateutil.Role {
-	cm.cond.L.Lock()
-	defer cm.cond.L.Unlock()
-
-	if cm.replicateConfig == nil {
-		return replicateutil.RolePrimary
-	}
-	return cm.replicateConfig.GetCurrentCluster().Role()
+	return replicateutil.Role(cm.replicateRole.Load())
 }
 
 // AddPChannels adds new PChannels dynamically. Channels that already exist are skipped.
@@ -667,6 +668,7 @@ func (cm *ChannelManager) UpdateReplicateConfiguration(ctx context.Context, resu
 	cm.cond.UnsafeBroadcast()
 	cm.version.Local++
 	cm.metrics.UpdateAssignmentVersion(cm.version.Local)
+	cm.replicateRole.Store(int32(config.GetCurrentCluster().Role()))
 	return nil
 }
 

--- a/internal/streamingcoord/server/balancer/channel/manager_test.go
+++ b/internal/streamingcoord/server/balancer/channel/manager_test.go
@@ -3,7 +3,9 @@ package channel
 import (
 	"context"
 	"strings"
+	"sync"
 	"testing"
+	"time"
 
 	"github.com/cockroachdb/errors"
 	"github.com/stretchr/testify/assert"
@@ -23,6 +25,27 @@ import (
 	"github.com/milvus-io/milvus/pkg/v3/util/replicateutil"
 	"github.com/milvus-io/milvus/pkg/v3/util/syncutil"
 )
+
+func TestReplicateRoleDoesNotWaitForChannelManagerLock(t *testing.T) {
+	m := &ChannelManager{
+		cond: syncutil.NewContextCond(&sync.Mutex{}),
+	}
+
+	m.cond.L.Lock()
+	defer m.cond.L.Unlock()
+
+	roleCh := make(chan replicateutil.Role, 1)
+	go func() {
+		roleCh <- m.ReplicateRole()
+	}()
+
+	select {
+	case role := <-roleCh:
+		assert.Equal(t, replicateutil.RolePrimary, role)
+	case <-time.After(time.Second):
+		t.Fatal("ReplicateRole blocked on the channel manager lock")
+	}
+}
 
 func TestChannelManager(t *testing.T) {
 	ResetStaticPChannelStatsManager()
@@ -782,7 +805,7 @@ func TestAddPChannels_UnavailableInReplication(t *testing.T) {
 			{ClusterId: "by-dev2", Pchannels: []string{"ch3", "ch4"}},
 		},
 		CrossClusterTopology: []*commonpb.CrossClusterTopology{
-			{SourceClusterId: "by-dev", TargetClusterId: "by-dev2"},
+			{SourceClusterId: "by-dev2", TargetClusterId: "by-dev"},
 		},
 	}
 	catalog.EXPECT().GetReplicateConfiguration(mock.Anything).Return(
@@ -791,6 +814,7 @@ func TestAddPChannels_UnavailableInReplication(t *testing.T) {
 
 	m, err := RecoverChannelManager(ctx, "ch1", "ch2")
 	assert.NoError(t, err)
+	assert.Equal(t, replicateutil.RoleSecondary, m.ReplicateRole())
 
 	// ch1 and ch2 should be available (in replicateConfig)
 	assert.True(t, m.channels[ChannelID{Name: "ch1"}].AvailableInReplication())

--- a/internal/views/coord/loadmgr/load_config_store.go
+++ b/internal/views/coord/loadmgr/load_config_store.go
@@ -161,6 +161,14 @@ func (s *LoadConfigStore) Remove(ctx context.Context, collectionID int64) error 
 	return nil
 }
 
+// Contains reports whether a collection has a live load config without
+// materializing the full balancer snapshot.
+func (s *LoadConfigStore) Contains(collectionID int64) bool {
+	s.mu.RLock()
+	defer s.mu.RUnlock()
+	return s.configs[collectionID] != nil
+}
+
 // Snapshot returns the current immutable load-config view. It refreshes the
 // resident snapshot lazily when the live version has advanced. The returned
 // maps point at the store's copy-on-write snapshots and must be treated as

--- a/internal/views/coord/loadmgr/load_config_store_test.go
+++ b/internal/views/coord/loadmgr/load_config_store_test.go
@@ -194,6 +194,24 @@ func TestRemove_NonExistent(t *testing.T) {
 	require.NoError(t, store.Remove(context.Background(), 999))
 }
 
+func TestContainsDoesNotRefreshSnapshot(t *testing.T) {
+	store, catalog := newTestStore(t)
+	resident := store.Snapshot()
+
+	expectFullSave(catalog, 1)
+	require.NoError(t, store.Put(context.Background(), sampleConfig()))
+	require.Same(t, resident, store.snapshot)
+	assert.True(t, store.Contains(100))
+	assert.False(t, store.Contains(999))
+	require.Same(t, resident, store.snapshot)
+
+	catalog.EXPECT().ReleaseReplicas(mock.Anything, int64(100)).Return(nil).Once()
+	catalog.EXPECT().ReleaseCollection(mock.Anything, int64(100)).Return(nil).Once()
+	require.NoError(t, store.Remove(context.Background(), 100))
+	assert.False(t, store.Contains(100))
+	require.Same(t, resident, store.snapshot)
+}
+
 func TestSnapshot_ReturnsAllConfigs(t *testing.T) {
 	store, catalog := newTestStore(t)
 	expectFullSave(catalog, 2)


### PR DESCRIPTION
## What

- add a direct `LoadConfigStore.Contains` path for release collection validation without refreshing the balancer snapshot
- publish the persisted StreamingCoord replication role through an atomic snapshot so role checks do not wait for the ChannelManager lock
- add focused coverage for snapshot residency, recovered secondary role, and non-blocking role reads

## Verification

- `go test -tags dynamic,test -gcflags="all=-N -l" -count=1 ./internal/views/coord/loadmgr -run "TestContainsDoesNotRefreshSnapshot|TestRemove"`
- QueryCoord and StreamingCoord package tests were attempted but local compilation is blocked because `milvus_core.pc` is unavailable in `PKG_CONFIG_PATH`.