### PR TITLE
enhance: reduce load config store lock contention

### DIFF
--- a/internal/views/coord/loadmgr/load_config_store.go
+++ b/internal/views/coord/loadmgr/load_config_store.go
@@ -6,6 +6,7 @@ import (
 
 	"github.com/milvus-io/milvus/internal/metastore"
 	"github.com/milvus-io/milvus/pkg/v3/proto/querypb"
+	"github.com/milvus-io/milvus/pkg/v3/util/lock"
 )
 
 // LoadConfigStore persists and serves the per-collection desired load state.
@@ -25,9 +26,12 @@ import (
 //
 // All methods are safe for concurrent use.
 type LoadConfigStore struct {
-	mu      sync.RWMutex
-	catalog metastore.QueryCoordCatalog
-	version uint64
+	// mu protects the shared in-memory state.
+	mu sync.RWMutex
+	// collectionLocks serializes persistence and in-memory commits per collection.
+	collectionLocks *lock.KeyLock[int64]
+	catalog         metastore.QueryCoordCatalog
+	version         uint64
 
 	// configs keeps the live in-memory snapshot per collection.
 	configs  map[int64]*LoadConfig
@@ -77,10 +81,11 @@ func RecoverLoadConfigStore(ctx context.Context, catalog metastore.QueryCoordCat
 	}
 
 	store := &LoadConfigStore{
-		catalog:  catalog,
-		version:  1,
-		configs:  configs,
-		versions: versions,
+		collectionLocks: lock.NewKeyLock[int64](),
+		catalog:         catalog,
+		version:         1,
+		configs:         configs,
+		versions:        versions,
 	}
 	return store, nil
 }
@@ -92,10 +97,13 @@ func (s *LoadConfigStore) Put(ctx context.Context, cfg *LoadConfig) error {
 	if cfg == nil {
 		return nil
 	}
-	s.mu.Lock()
-	defer s.mu.Unlock()
+	collectionID := cfg.CollectionID
+	s.collectionLocks.Lock(collectionID)
+	defer s.collectionLocks.Unlock(collectionID)
 
-	existing := s.configs[cfg.CollectionID]
+	s.mu.RLock()
+	existing := s.configs[collectionID]
+	s.mu.RUnlock()
 
 	// Delete orphans (items present in existing but absent from cfg) first,
 	// so stale ETCD keys do not linger after partition / replica removal.
@@ -113,7 +121,8 @@ func (s *LoadConfigStore) Put(ctx context.Context, cfg *LoadConfig) error {
 	}
 
 	// Save the full collection (including all partitions) and all replicas.
-	if err := s.catalog.SaveCollection(ctx,
+	if err := s.catalog.SaveCollection(
+		ctx,
 		cfg.toCollectionLoadInfoProto(),
 		cfg.toPartitionLoadInfoProtos()...,
 	); err != nil {
@@ -129,9 +138,11 @@ func (s *LoadConfigStore) Put(ctx context.Context, cfg *LoadConfig) error {
 		}
 	}
 
+	s.mu.Lock()
 	s.replaceInMemoryLocked(cfg)
 	s.version++
-	s.versions[cfg.CollectionID] = s.version
+	s.versions[collectionID] = s.version
+	s.mu.Unlock()
 	return nil
 }
 
@@ -139,10 +150,12 @@ func (s *LoadConfigStore) Put(ctx context.Context, cfg *LoadConfig) error {
 // (CollectionLoadInfo + PartitionLoadInfo keys + all Replicas).
 // No-op if the collection is not present.
 func (s *LoadConfigStore) Remove(ctx context.Context, collectionID int64) error {
-	s.mu.Lock()
-	defer s.mu.Unlock()
+	s.collectionLocks.Lock(collectionID)
+	defer s.collectionLocks.Unlock(collectionID)
 
+	s.mu.RLock()
 	existing := s.configs[collectionID]
+	s.mu.RUnlock()
 	if existing == nil {
 		return nil
 	}
@@ -155,9 +168,11 @@ func (s *LoadConfigStore) Remove(ctx context.Context, collectionID int64) error 
 		return err
 	}
 
+	s.mu.Lock()
 	delete(s.configs, collectionID)
 	s.version++
 	delete(s.versions, collectionID)
+	s.mu.Unlock()
 	return nil
 }
 

--- a/internal/views/coord/loadmgr/load_config_store_test.go
+++ b/internal/views/coord/loadmgr/load_config_store_test.go
@@ -2,7 +2,9 @@ package loadmgr
 
 import (
 	"context"
+	"sync/atomic"
 	"testing"
+	"time"
 
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/mock"
@@ -169,6 +171,132 @@ func TestPut_EmptyReplicasSkipsSaveReplica(t *testing.T) {
 		Return(nil).Once()
 	// No SaveReplica expected when Replicas is empty.
 	require.NoError(t, store.Put(context.Background(), cfg))
+}
+
+func TestPut_DifferentCollectionsPersistConcurrently(t *testing.T) {
+	store, catalog := newTestStore(t)
+	cfg1 := sampleConfig()
+	cfg1.Replicas = nil
+	cfg2 := sampleConfig()
+	cfg2.CollectionID = 101
+	cfg2.Replicas = nil
+
+	entered := make(chan int64, 2)
+	release := make(chan struct{})
+	catalog.EXPECT().
+		SaveCollection(mock.Anything, mock.Anything, mock.Anything, mock.Anything).
+		Run(func(_ context.Context, collection *querypb.CollectionLoadInfo, _ ...*querypb.PartitionLoadInfo) {
+			entered <- collection.GetCollectionID()
+			<-release
+		}).
+		Return(nil).
+		Times(2)
+	errs := make(chan error, 2)
+	go func() { errs <- store.Put(context.Background(), cfg1) }()
+	go func() { errs <- store.Put(context.Background(), cfg2) }()
+
+	seen := make(map[int64]struct{}, 2)
+	timer := time.NewTimer(time.Second)
+	for len(seen) < 2 {
+		select {
+		case collectionID := <-entered:
+			seen[collectionID] = struct{}{}
+		case <-timer.C:
+			close(release)
+			require.FailNow(t, "different collections did not persist concurrently")
+		}
+	}
+	if !timer.Stop() {
+		<-timer.C
+	}
+	close(release)
+
+	require.NoError(t, <-errs)
+	require.NoError(t, <-errs)
+	assert.Contains(t, store.Snapshot().ConfigsMap(), cfg1.CollectionID)
+	assert.Contains(t, store.Snapshot().ConfigsMap(), cfg2.CollectionID)
+}
+
+func TestPut_SameCollectionPersistsSerially(t *testing.T) {
+	store, catalog := newTestStore(t)
+	cfg := sampleConfig()
+	cfg.Replicas = nil
+	firstEntered := make(chan struct{})
+	secondEntered := make(chan struct{})
+	releaseFirst := make(chan struct{})
+	var calls atomic.Int32
+	catalog.EXPECT().
+		SaveCollection(mock.Anything, mock.Anything, mock.Anything, mock.Anything).
+		Run(func(context.Context, *querypb.CollectionLoadInfo, ...*querypb.PartitionLoadInfo) {
+			switch calls.Add(1) {
+			case 1:
+				close(firstEntered)
+				<-releaseFirst
+			case 2:
+				close(secondEntered)
+			}
+		}).
+		Return(nil).
+		Times(2)
+	errs := make(chan error, 2)
+	go func() { errs <- store.Put(context.Background(), cfg) }()
+	<-firstEntered
+
+	secondStarted := make(chan struct{})
+	go func() {
+		close(secondStarted)
+		errs <- store.Put(context.Background(), cfg.Clone())
+	}()
+	<-secondStarted
+
+	select {
+	case <-secondEntered:
+		close(releaseFirst)
+		require.FailNow(t, "same collection persisted concurrently")
+	case <-time.After(100 * time.Millisecond):
+	}
+	close(releaseFirst)
+
+	require.NoError(t, <-errs)
+	require.NoError(t, <-errs)
+	select {
+	case <-secondEntered:
+	case <-time.After(time.Second):
+		require.FailNow(t, "second put did not continue after the first completed")
+	}
+}
+
+func TestSnapshot_DoesNotWaitForCollectionPersistence(t *testing.T) {
+	store, catalog := newTestStore(t)
+	cfg := sampleConfig()
+	cfg.Replicas = nil
+	entered := make(chan struct{})
+	release := make(chan struct{})
+	catalog.EXPECT().
+		SaveCollection(mock.Anything, mock.Anything, mock.Anything, mock.Anything).
+		Run(func(context.Context, *querypb.CollectionLoadInfo, ...*querypb.PartitionLoadInfo) {
+			close(entered)
+			<-release
+		}).
+		Return(nil).
+		Once()
+	putDone := make(chan error, 1)
+	go func() { putDone <- store.Put(context.Background(), cfg) }()
+	<-entered
+
+	snapshotDone := make(chan *LoadConfigSnapshot, 1)
+	go func() { snapshotDone <- store.Snapshot() }()
+	select {
+	case snapshot := <-snapshotDone:
+		assert.NotContains(t, snapshot.ConfigsMap(), int64(100))
+	case <-time.After(time.Second):
+		close(release)
+		require.FailNow(t, "snapshot waited for collection persistence")
+	}
+
+	close(release)
+	require.NoError(t, <-putDone)
+	assert.Contains(t, store.Snapshot().ConfigsMap(), int64(100))
 }
 
 func TestRemove(t *testing.T) {


### PR DESCRIPTION
## Background

Load-on-search can generate frequent load and release transitions across many collections. LoadConfigStore previously held a single global mutex while performing Catalog operations, including ETCD I/O. A slow persistence operation for one collection therefore blocked load-config updates for every other collection and also delayed Snapshot readers.

This becomes increasingly visible under load-on-search churn, where unrelated collections may enter or leave the loaded state at the same time.

## Changes

- Serialize Catalog persistence and in-memory commits with a per-collection key lock.
- Hold the shared state mutex only while reading or committing in-memory state.
- Keep Put and Remove ordered for the same collection while allowing independent collections to persist concurrently.
- Let Snapshot return the last committed state without waiting for in-flight Catalog I/O.
- Add concurrency tests for cross-collection persistence, same-collection serialization, and non-blocking snapshots.

## Verification

- `go test -tags dynamic,test -gcflags="all=-N -l" -count=1 ./internal/views/coord/loadmgr`
- `go test -race -tags dynamic,test -gcflags="all=-N -l" -count=1 ./internal/views/coord/loadmgr`
- Repeated the three concurrency-focused tests 100 times