### PR TITLE
enhance: fast ack load config broadcasts

### DIFF
--- a/docs/agent_guides/streaming-system/message/message-semantic-collection.md
+++ b/docs/agent_guides/streaming-system/message/message-semantic-collection.md
@@ -25,8 +25,8 @@ All broadcast messages implicitly carry **SharedCluster** via the Broadcaster.
 | CreateSegment *(SelfControlled)* | Single VChannel | No | — |
 | Flush *(SelfControlled)* | Single VChannel | No | — |
 | ManualFlush | Single VChannel | Yes (VChannel) | — |
-| AlterLoadConfig | Broadcast: VChannels + CChannel (AckSyncUp) | No | SharedDBName + ExclusiveCollectionName |
-| DropLoadConfig | Broadcast: VChannels + CChannel (AckSyncUp) | No | SharedDBName + ExclusiveCollectionName (or ExclusiveCluster) |
+| AlterLoadConfig | Broadcast: CChannel | No | SharedDBName + ExclusiveCollectionName |
+| DropLoadConfig | Broadcast: CChannel | No | SharedDBName + ExclusiveCollectionName (or ExclusiveCluster) |
 | BatchUpdateManifest | Broadcast: CChannel | No | SharedDBName + SharedCollectionName |
 | RefreshExternalCollection | Broadcast: CChannel | No | — |
 
@@ -43,8 +43,8 @@ All broadcast messages implicitly carry **SharedCluster** via the Broadcaster.
 - **Insert** / **Delete**: DML on a single VChannel. CipherEnabled.
 - **CreateSegment** / **Flush**: WAL-generated (SelfControlled). Allocates or seals a growing segment.
 - **ManualFlush**: Seals all growing segments for a collection on a VChannel.
-- **AlterLoadConfig**: Modifies load configuration — partition set, replica count, load fields, etc. Broadcasts to all collection VChannels plus the CChannel with AckSyncUp. StreamingNode consumes the VChannel copies to persist vchannel load state; QueryView state machines later drive StreamingNode resource loading through `Acquire`.
-- **DropLoadConfig**: Removes load configuration, unloading/releasing from query nodes. Broadcasts to all collection VChannels plus the CChannel with AckSyncUp. Uses ExclusiveCluster when part of DropCollection flow.
+- **AlterLoadConfig**: Modifies load configuration — partition set, replica count, load fields, etc. Broadcasts only to the CChannel and uses append-result FastAck. The callback persists the desired load config in QueryCoord; the Balancer expands shards from DataView, and QueryView state machines drive StreamingNode resource loading through `Acquire`.
+- **DropLoadConfig**: Removes load configuration, unloading/releasing from query nodes. Broadcasts only to the CChannel and uses append-result FastAck. Uses ExclusiveCluster when part of DropCollection flow.
 - **BatchUpdateManifest**: Updates segment manifest versions in batch. Used after compaction or index building. CChannel-only.
 - **RefreshExternalCollection**: Submits an external collection refresh job using a pre-allocated job ID from the WAL message. CChannel-only.
 

--- a/docs/design-docs/design_docs/qviews/balancer_design.md
+++ b/docs/design-docs/design_docs/qviews/balancer_design.md
@@ -49,8 +49,7 @@ DDL Callbacks (WAL message acknowledgment)
 │  │  • ETCD persistence      │ │    across all shards     │  │
 │  └──────────────────────────┘ └──────────────────────────┘  │
 │  CollectionLoadManager lives in loadmgr and connects DDL     │
-│  broadcast results to LoadConfigStore, ShardEnsurer, and     │
-│  Balancer.                                                   │
+│  broadcast results to LoadConfigStore and Balancer.          │
 │                                                              │
 │  ┌─────────────┐ ┌─────────────┐ ┌─────────────┐            │
 │  │ShardViewMgr │ │ShardViewMgr │ │ShardViewMgr │  ...       │
@@ -232,7 +231,6 @@ loadmgr.CollectionLoadManager
 │   ├── Replica RG constraints (persisted, embedded in LoadConfig)
 │   └── Full-config writes with orphan cleanup
 │
-├── ShardEnsurer             ← uses broadcast result vchannels
 └── DirtyCollectionNotifier  ← injected balancer trigger callback
 ```
 
@@ -341,8 +339,7 @@ disappear when the shard no longer references that node.
 ```go
 type CollectionLoadManager interface {
     // Facade parses the WAL ack broadcast result, calls LoadConfigStore.Put,
-    // ensures shard managers for the vchannels acknowledged by the broadcast,
-    // and triggers Balancer. No CollectionShardProvider is needed.
+    // and triggers Balancer. Balancer derives shards from DataView.
     UpdateLoadConfig(ctx context.Context, result message.BroadcastResultAlterLoadConfigMessageV2) error
     ReleaseCollection(ctx context.Context, msg *messagespb.DropLoadConfigMessageHeader) error
 }
@@ -351,18 +348,13 @@ type CollectionLoadManager interface {
 **DDL callback integration**:
 
 ```
-// Before (legacy):
-WAL ack → LoadCollectionJob → CollectionManager.PutCollection() + ReplicaManager.Spawn()
-
-// After (new):
-WAL ack of collection-vchannel AlterLoadConfig broadcast
+WAL ack of CChannel AlterLoadConfig broadcast
         → CollectionLoadManager.UpdateLoadConfig(result)
          ├── parse result.Message.Header() → LoadConfig
          ├── LoadConfigStore.Put(fullCfg)  // full write + orphan cleanup
-         ├── ShardViewRegistry.Ensure(replicaID, vchannel) for result vchannels
          └── Balancer.Trigger(DirtyCollections: [collID])
 
-WAL ack of collection-vchannel DropLoadConfig broadcast
+WAL ack of CChannel DropLoadConfig broadcast
         → CollectionLoadManager.ReleaseCollection(msg.Header())
          ├── LoadConfigStore.Remove(collID)
          └── Balancer.Trigger(DirtyCollections: [collID])
@@ -370,11 +362,10 @@ WAL ack of collection-vchannel DropLoadConfig broadcast
          // sees "desired absent + current exists" → actionRelease
 ```
 
-`AlterLoadConfig` and `DropLoadConfig` are broadcast to all vchannels of the collection,
-not only to CChannel. Coord still uses the broadcast completion callback to update
-`CollectionLoadManager`. StreamingNode does not persist a vchannel-local load config;
-QueryView metadata identifies the versioned load info used when the local state machine
-acquires resources.
+`AlterLoadConfig` and `DropLoadConfig` are CChannel-only broadcasts. Coord uses the
+broadcast completion callback to update `CollectionLoadManager`. StreamingNode does not
+persist a vchannel-local load config; QueryView metadata identifies the versioned load
+info used when the local state machine acquires resources.
 
 **Release semantics (Option A)**: `ReleaseCollection` immediately removes the LoadConfig and triggers Balancer. Orphan views (view exists but no config) are naturally detected by reconcile Phase 1 and released via `RequestRelease`. No "releasing" state needed. Crash recovery is handled uniformly by reconcile.
 
@@ -966,9 +957,9 @@ rebuilding it per shard, or double-counting the replacement view.
 ### 5.2 Load Collection
 
 ```
-1. Load RPC → broadcast AlterLoadConfigMessage to all collection vchannels → WAL ack
+1. Load RPC → broadcast AlterLoadConfigMessage to CChannel → append-result FastAck
 2. DDL callback: CollectionLoadManager.UpdateLoadConfig(result)
-   → persist load config + ensure result vchannel ShardViewManagers + Trigger(DirtyCollections: [C1])
+   → persist load config + Trigger(DirtyCollections: [C1])
 3. Balancer resolves C1, reads only its DataView and resident ShardStats, and
    expands its DataView shards across the configured replicas
 4. policy.Plan(snap, [shards of C1]):
@@ -1001,7 +992,7 @@ rebuilding it per shard, or double-counting the replacement view.
 | Balancer | Single goroutine reconcile loop. `Trigger()` is thread-safe (enqueue only). |
 | SnapshotBuilder | Row-count ledger is owned by the serialized reconcile loop; a separate mutex protects observer-written dirty shard marks. |
 | BalancePolicy | Stateless pure function; receives immutable snapshot. Thread-safe by definition. |
-| CollectionLoadManager | Delegates desired-state mutation to LoadConfigStore (RWMutex); shard creation is an injected callback. |
+| CollectionLoadManager | Delegates desired-state mutation to LoadConfigStore (RWMutex). |
 | ShardViewRegistry | RWMutex protects resident managers, stats, reverse indexes, and observer registration. |
 | ShardViewManager | `sync.Mutex` per instance (existing). `Stats()` returns an atomic snapshot. |
 
@@ -1012,7 +1003,7 @@ rebuilding it per shard, or double-counting the replacement view.
 | Balancer | Scheduling framework: work queue + reconcile loop + plan executor | Work queue |
 | SnapshotBuilder | Resolve trigger scope, compose scoped snapshots, and maintain cluster-wide row totals | Row-count ledger + dirty shard set |
 | BalancePolicy | Batch planning: classify dirty shards + compute normalized incremental assignments + emit changed optional candidates | None |
-| CollectionLoadManager | Load-config lifecycle: DDL broadcast-result handling, desired-state persistence, shard ensure callback from result vchannels, dirty collection notify. | None beyond dependencies |
+| CollectionLoadManager | Load-config lifecycle: DDL broadcast-result handling, desired-state persistence, dirty collection notify. | None beyond dependencies |
 | ShardViewRegistry | Actual shard view state aggregation, scoped snapshots, reverse indexes, and stats notifications. | Resident managers + stats + indexes + snapshot cache |
 | ShardViewManager | Per-shard multi-version view management (existing). Exposes `Stats()` for aggregation. | Per-shard state |
 

--- a/internal/querycoordv2/ddl_callbacks_alter_load_info_load_collection.go
+++ b/internal/querycoordv2/ddl_callbacks_alter_load_info_load_collection.go
@@ -163,7 +163,7 @@ func (s *Server) generateAlterLoadConfigMessageForLoadCollection(
 	return message.NewAlterLoadConfigMessageBuilderV2().
 		WithHeader(header).
 		WithBody(&messagespb.AlterLoadConfigMessageBody{}).
-		WithBroadcast(collectionLoadConfigBroadcastChannels(coll), message.OptBuildBroadcastAckSyncUp()).
+		WithBroadcast([]string{loadConfigBroadcastChannel()}).
 		MustBuildBroadcast(), nil
 }
 
@@ -284,11 +284,8 @@ func sortedInt64s(values []int64) []int64 {
 	return out
 }
 
-func collectionLoadConfigBroadcastChannels(coll *milvuspb.DescribeCollectionResponse) []string {
-	channels := make([]string, 0, len(coll.GetVirtualChannelNames())+1)
-	channels = append(channels, streaming.WAL().ControlChannel())
-	channels = append(channels, coll.GetVirtualChannelNames()...)
-	return channels
+func loadConfigBroadcastChannel() string {
+	return streaming.WAL().ControlChannel()
 }
 
 // getDefaultResourceGroupsAndReplicaNumber gets the default resource groups and replica number for the collection.

--- a/internal/querycoordv2/ddl_callbacks_alter_load_info_load_partitions.go
+++ b/internal/querycoordv2/ddl_callbacks_alter_load_info_load_partitions.go
@@ -61,10 +61,10 @@ func (s *Server) broadcastAlterLoadConfigCollectionV2ForLoadPartitions(ctx conte
 		partitionIDsSet.Insert(partition)
 	}
 	alterLoadConfigReq := &job.AlterLoadConfigRequest{
-		Meta:              s.meta,
-		CollectionInfo:    coll,
-		BroadcastChannels: collectionLoadConfigBroadcastChannels(coll),
-		Current:           s.getCurrentLoadConfig(ctx, req.GetCollectionID()),
+		Meta:           s.meta,
+		CollectionInfo: coll,
+		ControlChannel: loadConfigBroadcastChannel(),
+		Current:        s.getCurrentLoadConfig(ctx, req.GetCollectionID()),
 		Expected: job.ExpectedLoadConfig{
 			ExpectedPartitionIDs:             partitionIDsSet.Collect(),
 			ExpectedReplicaNumber:            expectedReplicasNumber,

--- a/internal/querycoordv2/ddl_callbacks_alter_load_info_release_partitions.go
+++ b/internal/querycoordv2/ddl_callbacks_alter_load_info_release_partitions.go
@@ -66,16 +66,16 @@ func (s *Server) broadcastAlterLoadConfigCollectionV2ForReleasePartitions(ctx co
 				CollectionId: coll.CollectionID,
 			}).
 			WithBody(&message.DropLoadConfigMessageBody{}).
-			WithBroadcast(collectionLoadConfigBroadcastChannels(coll), message.OptBuildBroadcastAckSyncUp()).
+			WithBroadcast([]string{loadConfigBroadcastChannel()}).
 			MustBuildBroadcast()
 		collectionReleased = true
 	} else {
 		// only some partitions are released, alter the load config.
 		alterLoadConfigReq := &job.AlterLoadConfigRequest{
-			Meta:              s.meta,
-			CollectionInfo:    coll,
-			BroadcastChannels: collectionLoadConfigBroadcastChannels(coll),
-			Current:           s.getCurrentLoadConfig(ctx, req.GetCollectionID()),
+			Meta:           s.meta,
+			CollectionInfo: coll,
+			ControlChannel: loadConfigBroadcastChannel(),
+			Current:        s.getCurrentLoadConfig(ctx, req.GetCollectionID()),
 			Expected: job.ExpectedLoadConfig{
 				ExpectedPartitionIDs:             partitionIDsSet.Collect(),
 				ExpectedReplicaNumber:            currentLoadConfig.GetReplicaNumber(),

--- a/internal/querycoordv2/ddl_callbacks_alter_load_info_test.go
+++ b/internal/querycoordv2/ddl_callbacks_alter_load_info_test.go
@@ -27,15 +27,15 @@ import (
 	"github.com/milvus-io/milvus/internal/metastore/mocks"
 	"github.com/milvus-io/milvus/internal/querycoordv2/meta"
 	"github.com/milvus-io/milvus/internal/views/coord/balancer"
-	"github.com/milvus-io/milvus/internal/views/qviews"
 	"github.com/milvus-io/milvus/pkg/v3/proto/messagespb"
 	"github.com/milvus-io/milvus/pkg/v3/proto/querypb"
 	"github.com/milvus-io/milvus/pkg/v3/streaming/util/message"
+	"github.com/milvus-io/milvus/pkg/v3/util/funcutil"
 )
 
 func buildAlterLoadConfigBroadcastResult(collectionID int64, vchannels ...string) message.BroadcastResultAlterLoadConfigMessageV2 {
 	if len(vchannels) == 0 {
-		vchannels = []string{"v0", "v1"}
+		vchannels = []string{funcutil.GetControlChannel("test")}
 	}
 	broadcastMsg := message.NewAlterLoadConfigMessageBuilderV2().
 		WithHeader(&messagespb.AlterLoadConfigMessageHeader{
@@ -88,7 +88,5 @@ func TestAlterLoadConfigV2AckCallbackUpdatesQViewsRuntime(t *testing.T) {
 	require.NoError(t, s.alterLoadConfigV2AckCallback(ctx, buildAlterLoadConfigBroadcastResult(100)))
 
 	assert.Contains(t, runtime.loadConfigStore.Snapshot().ConfigsMap(), int64(100))
-	assert.NotNil(t, runtime.shardViewRegistry.Get(qviews.ShardID{ReplicaID: 1000, VChannel: "v0"}))
-	assert.NotNil(t, runtime.shardViewRegistry.Get(qviews.ShardID{ReplicaID: 1000, VChannel: "v1"}))
 	assert.Equal(t, []balancer.TriggerScope{{DirtyCollections: []int64{100}}}, fakeBalancer.triggers)
 }

--- a/internal/querycoordv2/ddl_callbacks_alter_load_info_transfer_replica.go
+++ b/internal/querycoordv2/ddl_callbacks_alter_load_info_transfer_replica.go
@@ -76,10 +76,10 @@ func (s *Server) broadcastAlterLoadConfigCollectionV2ForTransferReplica(ctx cont
 	replicaNumbers[req.GetTargetResourceGroup()] += int(req.NumReplica)
 
 	alterLoadConfigReq := &job.AlterLoadConfigRequest{
-		Meta:              s.meta,
-		CollectionInfo:    coll,
-		BroadcastChannels: collectionLoadConfigBroadcastChannels(coll),
-		Current:           currentLoadConfig,
+		Meta:           s.meta,
+		CollectionInfo: coll,
+		ControlChannel: loadConfigBroadcastChannel(),
+		Current:        currentLoadConfig,
 		Expected: job.ExpectedLoadConfig{
 			ExpectedPartitionIDs:             currentLoadConfig.GetPartitionIDs(),
 			ExpectedReplicaNumber:            replicaNumbers,

--- a/internal/querycoordv2/ddl_callbacks_drop_load_info.go
+++ b/internal/querycoordv2/ddl_callbacks_drop_load_info.go
@@ -52,7 +52,7 @@ func (s *Server) broadcastDropLoadConfigCollectionV2ForReleaseCollection(ctx con
 			CollectionId: coll.GetCollectionID(),
 		}).
 		WithBody(&message.DropLoadConfigMessageBody{}).
-		WithBroadcast(collectionLoadConfigBroadcastChannels(coll), message.OptBuildBroadcastAckSyncUp()).
+		WithBroadcast([]string{loadConfigBroadcastChannel()}).
 		MustBuildBroadcast()
 
 	_, err = broadcaster.Broadcast(ctx, msg)

--- a/internal/querycoordv2/ddl_callbacks_drop_load_info_test.go
+++ b/internal/querycoordv2/ddl_callbacks_drop_load_info_test.go
@@ -30,6 +30,7 @@ import (
 	"github.com/milvus-io/milvus/pkg/v3/proto/messagespb"
 	"github.com/milvus-io/milvus/pkg/v3/proto/querypb"
 	"github.com/milvus-io/milvus/pkg/v3/streaming/util/message"
+	"github.com/milvus-io/milvus/pkg/v3/util/funcutil"
 )
 
 func TestDropLoadConfigV2AckCallbackUpdatesQViewsRuntime(t *testing.T) {
@@ -72,18 +73,16 @@ func TestDropLoadConfigV2AckCallbackUpdatesQViewsRuntime(t *testing.T) {
 }
 
 func buildDropLoadConfigBroadcastResult(collectionID int64) message.BroadcastResultDropLoadConfigMessageV2 {
+	controlChannel := funcutil.GetControlChannel("test")
 	broadcastMsg := message.NewDropLoadConfigMessageBuilderV2().
 		WithHeader(&messagespb.DropLoadConfigMessageHeader{
 			CollectionId: collectionID,
 		}).
 		WithBody(&messagespb.DropLoadConfigMessageBody{}).
-		WithBroadcast([]string{"v0", "v1"}).
+		WithBroadcast([]string{controlChannel}).
 		MustBuildBroadcast()
 	return message.BroadcastResultDropLoadConfigMessageV2{
 		Message: message.MustAsBroadcastDropLoadConfigMessageV2(broadcastMsg),
-		Results: map[string]*message.AppendResult{
-			"v0": {},
-			"v1": {},
-		},
+		Results: map[string]*message.AppendResult{controlChannel: {}},
 	}
 }

--- a/internal/querycoordv2/ddl_callbacks_load_config_qviews_test.go
+++ b/internal/querycoordv2/ddl_callbacks_load_config_qviews_test.go
@@ -42,7 +42,7 @@ import (
 	"github.com/milvus-io/milvus/pkg/v3/util/paramtable"
 )
 
-func TestLoadCollectionBroadcastsLoadConfigToCollectionVChannels(t *testing.T) {
+func TestLoadCollectionBroadcastsLoadConfigToControlChannel(t *testing.T) {
 	ctx := context.Background()
 	server, catalog, broker := newLoadConfigQViewsServer(t)
 	collectionID := int64(100)
@@ -63,16 +63,13 @@ func TestLoadCollectionBroadcastsLoadConfigToCollectionVChannels(t *testing.T) {
 		CollectionID: collectionID,
 	}))
 	require.NotNil(t, captured)
-	assert.ElementsMatch(t,
-		[]string{streaming.WAL().ControlChannel(), "v0", "v1"},
-		captured.BroadcastHeader().VChannels,
-	)
-	assert.True(t, captured.BroadcastHeader().AckSyncUp)
+	assert.Equal(t, []string{streaming.WAL().ControlChannel()}, captured.BroadcastHeader().VChannels)
+	assert.False(t, captured.BroadcastHeader().AckSyncUp)
 	assert.Empty(t, server.meta.GetAll(ctx))
 	catalog.AssertNotCalled(t, "SaveCollection", mock.Anything, mock.Anything)
 }
 
-func TestLoadPartitionsBroadcastsLoadConfigToCollectionVChannels(t *testing.T) {
+func TestLoadPartitionsBroadcastsLoadConfigToControlChannel(t *testing.T) {
 	ctx := context.Background()
 	server, _, broker := newLoadConfigQViewsServer(t)
 	collectionID := int64(100)
@@ -92,11 +89,8 @@ func TestLoadPartitionsBroadcastsLoadConfigToCollectionVChannels(t *testing.T) {
 		PartitionIDs: []int64{10},
 	}))
 	require.NotNil(t, captured)
-	assert.ElementsMatch(t,
-		[]string{streaming.WAL().ControlChannel(), "v0", "v1"},
-		captured.BroadcastHeader().VChannels,
-	)
-	assert.True(t, captured.BroadcastHeader().AckSyncUp)
+	assert.Equal(t, []string{streaming.WAL().ControlChannel()}, captured.BroadcastHeader().VChannels)
+	assert.False(t, captured.BroadcastHeader().AckSyncUp)
 }
 
 func TestReleaseCollectionUsesQViewsLoadConfigAsLoadedSource(t *testing.T) {
@@ -127,14 +121,11 @@ func TestReleaseCollectionUsesQViewsLoadConfigAsLoadedSource(t *testing.T) {
 		CollectionID: collectionID,
 	}))
 	require.NotNil(t, captured)
-	assert.ElementsMatch(t,
-		[]string{streaming.WAL().ControlChannel(), "v0", "v1"},
-		captured.BroadcastHeader().VChannels,
-	)
-	assert.True(t, captured.BroadcastHeader().AckSyncUp)
+	assert.Equal(t, []string{streaming.WAL().ControlChannel()}, captured.BroadcastHeader().VChannels)
+	assert.False(t, captured.BroadcastHeader().AckSyncUp)
 }
 
-func TestReleasePartitionsDropLoadConfigBroadcastsToCollectionVChannels(t *testing.T) {
+func TestReleasePartitionsDropLoadConfigBroadcastsToControlChannel(t *testing.T) {
 	ctx := context.Background()
 	server, catalog, broker := newLoadConfigQViewsServer(t)
 	collectionID := int64(100)
@@ -170,11 +161,8 @@ func TestReleasePartitionsDropLoadConfigBroadcastsToCollectionVChannels(t *testi
 	require.NoError(t, err)
 	require.True(t, collectionReleased)
 	require.NotNil(t, captured)
-	assert.ElementsMatch(t,
-		[]string{streaming.WAL().ControlChannel(), "v0", "v1"},
-		captured.BroadcastHeader().VChannels,
-	)
-	assert.True(t, captured.BroadcastHeader().AckSyncUp)
+	assert.Equal(t, []string{streaming.WAL().ControlChannel()}, captured.BroadcastHeader().VChannels)
+	assert.False(t, captured.BroadcastHeader().AckSyncUp)
 }
 
 func newLoadConfigQViewsServer(t *testing.T) (*Server, *metastoremocks.QueryCoordCatalog, *meta.MockBroker) {

--- a/internal/querycoordv2/job/job_load_test.go
+++ b/internal/querycoordv2/job/job_load_test.go
@@ -30,6 +30,7 @@ import (
 	"github.com/milvus-io/milvus/pkg/v3/proto/messagespb"
 	"github.com/milvus-io/milvus/pkg/v3/proto/querypb"
 	"github.com/milvus-io/milvus/pkg/v3/streaming/util/message"
+	"github.com/milvus-io/milvus/pkg/v3/util/funcutil"
 	"github.com/milvus-io/milvus/pkg/v3/util/merr"
 	"github.com/milvus-io/milvus/pkg/v3/util/paramtable"
 	"github.com/milvus-io/milvus/pkg/v3/util/typeutil"
@@ -69,6 +70,26 @@ func (suite *LoadCollectionJobSuite) buildBroadcastResult(collectionID int64, pa
 			controlChannel: {},
 		},
 	}
+}
+
+func (suite *LoadCollectionJobSuite) TestGenerateAlterLoadConfigMessageUsesControlChannelWithoutAckSyncUp() {
+	controlChannel := funcutil.GetControlChannel("test")
+	msg, err := GenerateAlterLoadConfigMessage(context.Background(), &AlterLoadConfigRequest{
+		CollectionInfo: &milvuspb.DescribeCollectionResponse{
+			DbId:         10,
+			CollectionID: 100,
+		},
+		ControlChannel: controlChannel,
+		Expected: ExpectedLoadConfig{
+			ExpectedPartitionIDs:  []int64{20},
+			ExpectedReplicaNumber: map[string]int{},
+		},
+	})
+
+	suite.NoError(err)
+	suite.NotNil(msg)
+	suite.Equal([]string{controlChannel}, msg.BroadcastHeader().VChannels)
+	suite.False(msg.BroadcastHeader().AckSyncUp)
 }
 
 // TestDescribeCollectionNotFound tests that Execute returns nil when the collection is not found.

--- a/internal/querycoordv2/job/load_config.go
+++ b/internal/querycoordv2/job/load_config.go
@@ -32,11 +32,11 @@ import (
 )
 
 type AlterLoadConfigRequest struct {
-	Meta              *meta.Meta
-	CollectionInfo    *milvuspb.DescribeCollectionResponse
-	BroadcastChannels []string
-	Expected          ExpectedLoadConfig
-	Current           CurrentLoadConfig
+	Meta           *meta.Meta
+	CollectionInfo *milvuspb.DescribeCollectionResponse
+	ControlChannel string
+	Expected       ExpectedLoadConfig
+	Current        CurrentLoadConfig
 }
 
 // CheckIfLoadPartitionsExecutable checks if the load partitions is executable.
@@ -168,7 +168,7 @@ func GenerateAlterLoadConfigMessage(ctx context.Context, req *AlterLoadConfigReq
 	return message.NewAlterLoadConfigMessageBuilderV2().
 		WithHeader(header).
 		WithBody(&messagespb.AlterLoadConfigMessageBody{}).
-		WithBroadcast(req.BroadcastChannels, message.OptBuildBroadcastAckSyncUp()).
+		WithBroadcast([]string{req.ControlChannel}).
 		MustBuildBroadcast(), nil
 }
 

--- a/internal/querycoordv2/qviews_runtime.go
+++ b/internal/querycoordv2/qviews_runtime.go
@@ -140,9 +140,6 @@ func newQViewsRuntime(ctx context.Context, deps qviewsRuntimeDependencies) (*qvi
 	}
 	loadManager := loadmgr.NewCollectionLoadManager(
 		loadConfigStore,
-		func(shardID qviews.ShardID) {
-			shardViewRegistry.Ensure(shardID)
-		},
 		func(collectionID int64) {
 			balancerController.Trigger(balancer.TriggerScope{DirtyCollections: []int64{collectionID}})
 		},

--- a/internal/querycoordv2/qviews_runtime_test.go
+++ b/internal/querycoordv2/qviews_runtime_test.go
@@ -113,7 +113,7 @@ func TestQViewsRuntimePassesReferenceManagerToRegistry(t *testing.T) {
 	require.Equal(t, []qviews.DataVersion{{StreamingVersion: 1, CompactVersion: 1}}, refs.recovered)
 }
 
-func TestQViewsRuntimeLoadManagerEnsuresShardsAndTriggersBalancer(t *testing.T) {
+func TestQViewsRuntimeLoadManagerTriggersBalancer(t *testing.T) {
 	ctx := context.Background()
 	catalog := metastoremocks.NewQueryCoordCatalog(t)
 	catalog.EXPECT().GetCollections(mock.Anything).Return(nil, nil).Once()
@@ -139,8 +139,7 @@ func TestQViewsRuntimeLoadManagerEnsuresShardsAndTriggersBalancer(t *testing.T) 
 	catalog.EXPECT().SaveReplica(mock.Anything, mock.Anything).Return(nil).Once()
 	require.NoError(t, runtime.loadManager.UpdateLoadConfig(ctx, testAlterLoadConfigResult()))
 
-	assert.NotNil(t, runtime.shardViewRegistry.Get(qviews.ShardID{ReplicaID: 1000, VChannel: "v0"}))
-	assert.NotNil(t, runtime.shardViewRegistry.Get(qviews.ShardID{ReplicaID: 1000, VChannel: "v1"}))
+	assert.Empty(t, runtime.shardViewRegistry.ShardIDs())
 	assert.Equal(t, []balancer.TriggerScope{{DirtyCollections: []int64{100}}}, fakeBalancer.triggers)
 }
 
@@ -160,6 +159,7 @@ func testPersistedQueryView(collectionID int64, shardID qviews.ShardID) *viewpb.
 }
 
 func testAlterLoadConfigResult() message.BroadcastResultAlterLoadConfigMessageV2 {
+	controlChannel := funcutil.GetControlChannel("test")
 	broadcastMsg := message.NewAlterLoadConfigMessageBuilderV2().
 		WithHeader(&messagespb.AlterLoadConfigMessageHeader{
 			DbId:         1,
@@ -170,15 +170,11 @@ func testAlterLoadConfigResult() message.BroadcastResultAlterLoadConfigMessageV2
 			},
 		}).
 		WithBody(&messagespb.AlterLoadConfigMessageBody{}).
-		WithBroadcast([]string{"v0", "v1", "by-dev-rootcoord-dml" + funcutil.ControlChannelSuffix}).
+		WithBroadcast([]string{controlChannel}).
 		MustBuildBroadcast()
 	return message.BroadcastResultAlterLoadConfigMessageV2{
 		Message: message.MustAsBroadcastAlterLoadConfigMessageV2(broadcastMsg),
-		Results: map[string]*message.AppendResult{
-			"v0": {},
-			"v1": {},
-			"by-dev-rootcoord-dml" + funcutil.ControlChannelSuffix: {},
-		},
+		Results: map[string]*message.AppendResult{controlChannel: {}},
 	}
 }
 

--- a/internal/views/coord/balancer/balancer_test.go
+++ b/internal/views/coord/balancer/balancer_test.go
@@ -71,13 +71,12 @@ func TestBalancer_ReconcileDirtyShardAppliesPrepare(t *testing.T) {
 	assert.NotEmpty(t, stats.Segments)
 }
 
-func TestBalancer_ReconcileDirtyCollectionExpandsTrackedShards(t *testing.T) {
+func TestBalancer_ReconcileDirtyCollectionCreatesDataViewShards(t *testing.T) {
 	const collID, replicaID int64 = 1, 10
 	shardID := qviews.ShardID{ReplicaID: replicaID, VChannel: "v0"}
 
 	store := storeWithConfig(t, collID, replicaID, []int64{100}, []int64{1})
 	reg := emptyRegistry(t)
-	reg.Ensure(shardID)
 	builder := NewSnapshotBuilder(
 		store,
 		reg,
@@ -101,7 +100,9 @@ func TestBalancer_ReconcileDirtyCollectionExpandsTrackedShards(t *testing.T) {
 	b.Trigger(TriggerScope{DirtyCollections: []int64{collID}})
 	require.NoError(t, b.Reconcile(context.Background()))
 
-	stats := reg.Get(shardID).Stats()
+	mgr := reg.Get(shardID)
+	require.NotNil(t, mgr)
+	stats := mgr.Stats()
 	assert.NotNil(t, stats.PreparingVersion)
 }
 

--- a/internal/views/coord/loadmgr/manager.go
+++ b/internal/views/coord/loadmgr/manager.go
@@ -11,11 +11,6 @@ import (
 	"github.com/milvus-io/milvus/pkg/v3/util/metautil"
 )
 
-// ShardEnsurer creates the actual shard view manager for a replica+vchannel
-// pair. It is injected so loadmgr does not depend on the concrete coordview
-// registry package.
-type ShardEnsurer func(qviews.ShardID)
-
 // DirtyCollectionNotifier is called after desired load state changes. The
 // outer Balancer adapter can translate this into TriggerScope{DirtyCollections}.
 type DirtyCollectionNotifier func(collectionID int64)
@@ -28,9 +23,8 @@ type ShardAssignmentNotifier func()
 // CollectionLoadManager is the Coord-side facade over desired load config
 // lifecycle.
 type CollectionLoadManager struct {
-	store       *LoadConfigStore
-	ensureShard ShardEnsurer
-	notify      DirtyCollectionNotifier
+	store  *LoadConfigStore
+	notify DirtyCollectionNotifier
 
 	mu                      sync.RWMutex
 	discoverableShards      map[qviews.ShardID]discoverableShard
@@ -46,20 +40,18 @@ type discoverableShard struct {
 
 func NewCollectionLoadManager(
 	store *LoadConfigStore,
-	ensureShard ShardEnsurer,
 	notify DirtyCollectionNotifier,
 ) *CollectionLoadManager {
 	return &CollectionLoadManager{
 		store:              store,
-		ensureShard:        ensureShard,
 		notify:             notify,
 		discoverableShards: make(map[qviews.ShardID]discoverableShard),
 	}
 }
 
 // UpdateLoadConfig applies an AlterLoadConfig WAL ack to desired state and
-// notifies the reconciler. The ack result already contains every vchannel that
-// received the broadcast, so no extra collection-shard provider is needed.
+// notifies the reconciler. The Balancer expands collection shards from the
+// latest DataView and creates shard managers when it applies the plan.
 func (m *CollectionLoadManager) UpdateLoadConfig(
 	ctx context.Context,
 	result message.BroadcastResultAlterLoadConfigMessageV2,
@@ -72,7 +64,6 @@ func (m *CollectionLoadManager) UpdateLoadConfig(
 	if err := m.store.Put(ctx, cfg); err != nil {
 		return err
 	}
-	m.ensureConfiguredShards(cfg, result.GetVChannelsWithoutControlChannel())
 	m.notifyCollection(cfg.CollectionID)
 	return nil
 }
@@ -188,20 +179,6 @@ func (m *CollectionLoadManager) notifyShardAssignmentsChanged() {
 	m.mu.RUnlock()
 	if notifier != nil {
 		notifier()
-	}
-}
-
-func (m *CollectionLoadManager) ensureConfiguredShards(cfg *LoadConfig, vchannels []string) {
-	if m.ensureShard == nil {
-		return
-	}
-	for _, replica := range cfg.Replicas {
-		for _, vchannel := range vchannels {
-			m.ensureShard(qviews.ShardID{
-				ReplicaID: replica.ReplicaID,
-				VChannel:  vchannel,
-			})
-		}
 	}
 }
 

--- a/internal/views/coord/loadmgr/manager_test.go
+++ b/internal/views/coord/loadmgr/manager_test.go
@@ -44,29 +44,24 @@ func sampleAlterLoadConfigHeader() *messagespb.AlterLoadConfigMessageHeader {
 }
 
 func sampleAlterLoadConfigResult() message.BroadcastResultAlterLoadConfigMessageV2 {
+	controlChannel := funcutil.GetControlChannel("test")
 	broadcastMsg := message.NewAlterLoadConfigMessageBuilderV2().
 		WithHeader(sampleAlterLoadConfigHeader()).
 		WithBody(&messagespb.AlterLoadConfigMessageBody{}).
-		WithBroadcast([]string{"v0", "v1", "by-dev-rootcoord-dml" + funcutil.ControlChannelSuffix}).
+		WithBroadcast([]string{controlChannel}).
 		MustBuildBroadcast()
 	return message.BroadcastResultAlterLoadConfigMessageV2{
 		Message: message.MustAsBroadcastAlterLoadConfigMessageV2(broadcastMsg),
-		Results: map[string]*message.AppendResult{
-			"v0": {},
-			"v1": {},
-			"by-dev-rootcoord-dml" + funcutil.ControlChannelSuffix: {},
-		},
+		Results: map[string]*message.AppendResult{controlChannel: {}},
 	}
 }
 
 func TestCollectionLoadManager_UpdateLoadConfig(t *testing.T) {
 	catalog := mocks.NewQueryCoordCatalog(t)
 	store := newEmptyLoadConfigStore(t, catalog)
-	var ensured []qviews.ShardID
 	var notified []int64
 	manager := NewCollectionLoadManager(
 		store,
-		func(shardID qviews.ShardID) { ensured = append(ensured, shardID) },
 		func(collectionID int64) { notified = append(notified, collectionID) },
 	)
 
@@ -80,12 +75,6 @@ func TestCollectionLoadManager_UpdateLoadConfig(t *testing.T) {
 	require.Len(t, cfg.Replicas, 2)
 	assert.Equal(t, int64(1000), cfg.Replicas[0].ReplicaID)
 	assert.Equal(t, "rg1", cfg.Replicas[0].ResourceGroup)
-	assert.ElementsMatch(t, []qviews.ShardID{
-		{ReplicaID: 1000, VChannel: "v0"},
-		{ReplicaID: 1000, VChannel: "v1"},
-		{ReplicaID: 1001, VChannel: "v0"},
-		{ReplicaID: 1001, VChannel: "v1"},
-	}, ensured)
 	assert.Equal(t, []int64{100}, notified)
 }
 
@@ -95,7 +84,6 @@ func TestCollectionLoadManager_ReleaseCollectionKeepsRegistryForReconcile(t *tes
 	var notified []int64
 	manager := NewCollectionLoadManager(
 		store,
-		func(qviews.ShardID) {},
 		func(collectionID int64) { notified = append(notified, collectionID) },
 	)
 
@@ -117,7 +105,7 @@ func TestCollectionLoadManager_DiscoverableShardAssignments(t *testing.T) {
 	catalog := mocks.NewQueryCoordCatalog(t)
 	store := newEmptyLoadConfigStore(t, catalog)
 	var assignmentUpdates int
-	manager := NewCollectionLoadManager(store, nil, nil)
+	manager := NewCollectionLoadManager(store, nil)
 	manager.SetShardAssignmentNotifier(func() { assignmentUpdates++ })
 
 	shardID := qviews.ShardID{


### PR DESCRIPTION
## What changed

- Broadcast AlterLoadConfig and DropLoadConfig only to the control channel.
- Leave AckSyncUp unset so the broadcaster can acknowledge these messages from the WAL append result without waiting for StreamingNode consumption.
- Let CollectionLoadManager persist the desired load configuration and trigger the existing QueryView balancer.
- Reuse the balancer's DataView shard expansion and prepare-plan application to create shard view managers.
- Update the streaming message semantics and QueryView balancer design documentation.

## Why

Load-config broadcasts previously targeted both the control channel and every collection VChannel. AckSyncUp kept the callback on the StreamingNode consumer ACK path, where unrelated control-channel messages share FIFO consumption and each ACK persists its BroadcastTask. For load-config changes, QueryView reconciliation already drives the actual shard resource state from the persisted desired config and DataView, so waiting for per-VChannel consumer ACKs is unnecessary.

## Verification

- `source scripts/setenv.sh && go test -v -tags dynamic,test -gcflags="all=-N -l" -count=1 ./internal/querycoordv2 -run 'Test(LoadCollectionBroadcastsLoadConfigToControlChannel|LoadPartitionsBroadcastsLoadConfigToControlChannel|ReleaseCollectionUsesQViewsLoadConfigAsLoadedSource|ReleasePartitionsDropLoadConfigBroadcastsToControlChannel|AlterLoadConfigV2AckCallbackUpdatesQViewsRuntime|DropLoadConfigV2AckCallbackUpdatesQViewsRuntime|QViewsRuntimeLoadManagerTriggersBalancer)$' -timeout 300s`
- `source scripts/setenv.sh && go test -v -tags dynamic,test -gcflags="all=-N -l" -count=1 ./internal/querycoordv2/job -run 'TestLoadCollectionJob/TestGenerateAlterLoadConfigMessageUsesControlChannelWithoutAckSyncUp$' -timeout 300s`
- `go test -tags dynamic,test -gcflags="all=-N -l" -count=1 ./internal/views/coord/loadmgr -run 'TestCollectionLoadManager_'`
- `source scripts/setenv.sh && go test -v -tags dynamic,test -gcflags="all=-N -l" -count=1 ./internal/views/coord/balancer -run 'TestBalancer_ReconcileDirtyCollectionCreatesDataViewShards$' -timeout 300s`
- `git diff --check`
