### PR TITLE
fix: resolve broadcaster deadlock by separating callback resolution from lock scope

### DIFF
--- a/internal/streamingcoord/server/broadcaster/broadcast_deadlock_test.go
+++ b/internal/streamingcoord/server/broadcaster/broadcast_deadlock_test.go
@@ -1,0 +1,372 @@
+package broadcaster
+
+import (
+	"context"
+	"sync"
+	"sync/atomic"
+	"testing"
+	"time"
+
+	"github.com/cockroachdb/errors"
+	"github.com/stretchr/testify/mock"
+	"github.com/stretchr/testify/require"
+
+	"github.com/milvus-io/milvus-proto/go-api/v3/msgpb"
+	"github.com/milvus-io/milvus-proto/go-api/v3/schemapb"
+	"github.com/milvus-io/milvus/internal/mocks/mock_metastore"
+	"github.com/milvus-io/milvus/internal/streamingcoord/server/broadcaster/registry"
+	"github.com/milvus-io/milvus/internal/streamingcoord/server/resource"
+	"github.com/milvus-io/milvus/pkg/v3/mlog"
+	"github.com/milvus-io/milvus/pkg/v3/proto/messagespb"
+	"github.com/milvus-io/milvus/pkg/v3/proto/streamingpb"
+	"github.com/milvus-io/milvus/pkg/v3/streaming/util/message"
+	"github.com/milvus-io/milvus/pkg/v3/streaming/util/types"
+	"github.com/milvus-io/milvus/pkg/v3/streaming/walimpls/impls/walimplstest"
+	"github.com/milvus-io/milvus/pkg/v3/util/paramtable"
+	"github.com/milvus-io/milvus/pkg/v3/util/typeutil"
+)
+
+func TestAckWaitsForCallbackWithoutHoldingTaskOrManagerLock(t *testing.T) {
+	registry.ResetRegistration()
+	paramtable.Init()
+
+	meta := mock_metastore.NewMockStreamingCoordCataLog(t)
+	meta.EXPECT().SaveBroadcastTask(mock.Anything, uint64(100), mock.Anything).Return(nil).Once()
+	resource.InitForTest(resource.OptStreamingCatalog(meta))
+
+	metrics := newBroadcasterMetrics()
+	ackScheduler := newAckCallbackScheduler(mlog.With())
+	task := newBroadcastTaskFromProto(createNewBroadcastTask(100, []string{"v1", "v2"}), metrics, ackScheduler)
+	task.SetLogger(mlog.With())
+
+	managerCtx, managerCancel := context.WithCancel(context.Background())
+	defer managerCancel()
+	bm := &broadcastTaskManager{
+		lifetime: typeutil.NewLifetime(),
+		ctx:      managerCtx,
+		cancel:   managerCancel,
+		mu:       &sync.Mutex{},
+		tasks:    map[uint64]*broadcastTask{100: task},
+	}
+	bm.SetLogger(mlog.With())
+
+	ackMsg := newDropCollectionAckMessage(100, "v1")
+	ackDone := make(chan error, 2)
+	go func() { ackDone <- bm.Ack(context.Background(), ackMsg) }()
+	go func() { ackDone <- bm.Ack(context.Background(), ackMsg) }()
+	requireNoResult(t, ackDone, 50*time.Millisecond, "ack should wait for callback registration")
+
+	stateDone := make(chan streamingpb.BroadcastTaskState, 1)
+	go func() { stateDone <- task.State() }()
+	select {
+	case state := <-stateDone:
+		require.Equal(t, streamingpb.BroadcastTaskState_BROADCAST_TASK_STATE_PENDING, state)
+	case <-time.After(time.Second):
+		t.Fatal("task lock is held while waiting for ack-once callback")
+	}
+
+	lookupDone := make(chan bool, 1)
+	go func() {
+		_, ok := bm.getBroadcastTaskByID(100)
+		lookupDone <- ok
+	}()
+	select {
+	case ok := <-lookupDone:
+		require.True(t, ok)
+	case <-time.After(time.Second):
+		t.Fatal("manager lock is held while waiting for ack-once callback")
+	}
+
+	var callbackCalls atomic.Int32
+	callbackVChannels := make(chan string, 2)
+	registry.RegisterDropCollectionV1AckOnceCallback(func(ctx context.Context, result message.AckResultDropCollectionMessageV1) error {
+		callbackCalls.Add(1)
+		callbackVChannels <- result.Message.VChannel()
+		return nil
+	})
+
+	for range 2 {
+		select {
+		case err := <-ackDone:
+			require.NoError(t, err)
+		case <-time.After(5 * time.Second):
+			t.Fatal("ack did not resume after callback registration")
+		}
+	}
+	require.Equal(t, int32(1), callbackCalls.Load(), "duplicate ACK must invoke ack-once callback once")
+	require.Equal(t, "v1", <-callbackVChannels)
+	task.mu.Lock()
+	vchannelIdx := findIdxOfVChannel("v1", task.header().VChannels)
+	acked := task.task.AckedVchannelBitmap[vchannelIdx]
+	task.mu.Unlock()
+	require.Equal(t, byte(1), acked)
+}
+
+func TestGetOrCreateDoesNotHoldManagerLockWhileInspectingTask(t *testing.T) {
+	paramtable.Init()
+	metrics := newBroadcasterMetrics()
+	ackScheduler := newAckCallbackScheduler(mlog.With())
+	task := newBroadcastTaskFromProto(createNewBroadcastTask(101, []string{"v1"}), metrics, ackScheduler)
+	task.SetLogger(mlog.With())
+	bm := &broadcastTaskManager{
+		mu:    &sync.Mutex{},
+		tasks: map[uint64]*broadcastTask{101: task},
+	}
+	bm.SetLogger(mlog.With())
+	ackMsg := newDropCollectionAckMessage(101, "v1")
+
+	task.mu.Lock()
+	bm.mu.Lock()
+	type getResult struct {
+		task *broadcastTask
+		ok   bool
+	}
+	getDone := make(chan getResult, 1)
+	go func() {
+		got, ok := bm.getOrCreateBroadcastTask(ackMsg)
+		getDone <- getResult{task: got, ok: ok}
+	}()
+	// Queue getOrCreate behind bm.mu so it is the first waiter when the lock is released.
+	time.Sleep(20 * time.Millisecond)
+	bm.mu.Unlock()
+	time.Sleep(20 * time.Millisecond)
+
+	lookupDone := make(chan bool, 1)
+	go func() {
+		_, ok := bm.getBroadcastTaskByID(101)
+		lookupDone <- ok
+	}()
+	select {
+	case ok := <-lookupDone:
+		require.True(t, ok)
+	case <-time.After(time.Second):
+		task.mu.Unlock()
+		t.Fatal("getOrCreate held bm.mu while blocked on task.mu")
+	}
+
+	task.mu.Unlock()
+	select {
+	case result := <-getDone:
+		require.True(t, result.ok)
+		require.Same(t, task, result.task)
+	case <-time.After(time.Second):
+		t.Fatal("getOrCreate did not finish after task lock was released")
+	}
+}
+
+func TestPendingSchemaScanSkipsLockedUnrelatedTask(t *testing.T) {
+	paramtable.Init()
+	metrics := newBroadcasterMetrics()
+	ackScheduler := newAckCallbackScheduler(mlog.With())
+
+	dropTask := newBroadcastTaskFromProto(createNewBroadcastTask(102, []string{"v1"}), metrics, ackScheduler)
+	createMsg := message.NewCreateCollectionMessageBuilderV1().
+		WithHeader(&message.CreateCollectionMessageHeader{CollectionId: 10}).
+		WithBody(&msgpb.CreateCollectionRequest{
+			CollectionSchema: &schemapb.CollectionSchema{FileResourceIds: []int64{11, 12}},
+		}).
+		WithBroadcast([]string{"v1"}).
+		MustBuildBroadcast().
+		WithBroadcastID(103)
+	createProto := createNewWaitAckBroadcastTaskFromMessage(
+		createMsg,
+		streamingpb.BroadcastTaskState_BROADCAST_TASK_STATE_PENDING,
+		[]byte{0},
+	)
+	createTask := newBroadcastTaskFromProto(createProto, metrics, ackScheduler)
+
+	bm := &broadcastTaskManager{
+		mu: &sync.Mutex{},
+		tasks: map[uint64]*broadcastTask{
+			102: dropTask,
+			103: createTask,
+		},
+	}
+
+	dropTask.mu.Lock()
+	scanDone := make(chan map[int64][]int64, 1)
+	go func() { scanDone <- bm.GetPendingSchemaFileResources() }()
+	select {
+	case resources := <-scanDone:
+		require.ElementsMatch(t, []int64{11, 12}, resources[10])
+	case <-time.After(time.Second):
+		dropTask.mu.Unlock()
+		t.Fatal("schema recovery scan waited on an unrelated DropCollection task")
+	}
+	dropTask.mu.Unlock()
+}
+
+func TestFastAckResolvesCallbackOutsideTaskLock(t *testing.T) {
+	registry.ResetRegistration()
+	paramtable.Init()
+
+	meta := mock_metastore.NewMockStreamingCoordCataLog(t)
+	meta.EXPECT().SaveBroadcastTask(mock.Anything, uint64(104), mock.Anything).Return(nil).Once()
+	resource.InitForTest(resource.OptStreamingCatalog(meta))
+
+	metrics := newBroadcasterMetrics()
+	ackScheduler := newAckCallbackScheduler(mlog.With())
+	commitMsg := message.NewCommitImportMessageBuilderV2().
+		WithHeader(&message.CommitImportMessageHeader{CollectionId: 10, JobId: 20}).
+		WithBody(&messagespb.CommitImportMessageBody{}).
+		WithBroadcast([]string{"v1"}).
+		MustBuildBroadcast().
+		WithBroadcastID(104)
+	task := newBroadcastTaskFromBroadcastMessage(commitMsg, metrics, ackScheduler)
+	task.SetLogger(mlog.With())
+
+	result := map[string]*types.AppendResult{
+		"v1": {
+			MessageID:              walimplstest.NewTestMessageID(1),
+			LastConfirmedMessageID: walimplstest.NewTestMessageID(2),
+			TimeTick:               100,
+		},
+	}
+	fastAckDone := make(chan error, 1)
+	go func() { fastAckDone <- task.FastAck(context.Background(), result) }()
+	requireNoResult(t, fastAckDone, 50*time.Millisecond, "FastAck should wait for callback registration")
+
+	stateDone := make(chan streamingpb.BroadcastTaskState, 1)
+	go func() { stateDone <- task.State() }()
+	select {
+	case <-stateDone:
+	case <-time.After(time.Second):
+		t.Fatal("FastAck held task.mu while waiting for callback registration")
+	}
+
+	var callbackCalls atomic.Int32
+	registry.RegisterCommitImportV2AckOnceCallback(func(ctx context.Context, result message.AckResultCommitImportMessageV2) error {
+		callbackCalls.Add(1)
+		return nil
+	})
+	select {
+	case err := <-fastAckDone:
+		require.NoError(t, err)
+	case <-time.After(5 * time.Second):
+		t.Fatal("FastAck did not resume after callback registration")
+	}
+	require.Equal(t, int32(1), callbackCalls.Load())
+}
+
+func TestFastAckWithAckSyncUpDoesNotWaitForCallback(t *testing.T) {
+	registry.ResetRegistration()
+	paramtable.Init()
+
+	metrics := newBroadcasterMetrics()
+	ackScheduler := newAckCallbackScheduler(mlog.With())
+	dropMsg := message.NewDropCollectionMessageBuilderV1().
+		WithHeader(&message.DropCollectionMessageHeader{}).
+		WithBody(&msgpb.DropCollectionRequest{}).
+		WithBroadcast([]string{"v1"}, message.OptBuildBroadcastAckSyncUp()).
+		MustBuildBroadcast().
+		WithBroadcastID(105)
+	task := newBroadcastTaskFromBroadcastMessage(dropMsg, metrics, ackScheduler)
+
+	done := make(chan error, 1)
+	go func() { done <- task.FastAck(context.Background(), nil) }()
+	select {
+	case err := <-done:
+		require.NoError(t, err)
+	case <-time.After(time.Second):
+		t.Fatal("AckSyncUp FastAck waited for an ack-once callback it must not use")
+	}
+}
+
+func TestAckOnceCallbackFailureRemainsRetryable(t *testing.T) {
+	registry.ResetRegistration()
+	paramtable.Init()
+
+	meta := mock_metastore.NewMockStreamingCoordCataLog(t)
+	meta.EXPECT().SaveBroadcastTask(mock.Anything, uint64(106), mock.Anything).Return(nil).Once()
+	resource.InitForTest(resource.OptStreamingCatalog(meta))
+
+	var callbackCalls atomic.Int32
+	registry.RegisterDropCollectionV1AckOnceCallback(func(ctx context.Context, result message.AckResultDropCollectionMessageV1) error {
+		if callbackCalls.Add(1) == 1 {
+			return errors.New("injected callback failure")
+		}
+		return nil
+	})
+
+	metrics := newBroadcasterMetrics()
+	ackScheduler := newAckCallbackScheduler(mlog.With())
+	task := newBroadcastTaskFromProto(createNewBroadcastTask(106, []string{"v1"}), metrics, ackScheduler)
+	task.SetLogger(mlog.With())
+	ackMsg := newDropCollectionAckMessage(106, "v1")
+
+	err := task.Ack(context.Background(), ackMsg)
+	require.EqualError(t, err, "injected callback failure")
+	require.NoError(t, task.Ack(context.Background(), ackMsg))
+	require.Equal(t, int32(2), callbackCalls.Load())
+}
+
+func TestCloseCancelsAckWaitingForCallbackRegistration(t *testing.T) {
+	registry.ResetRegistration()
+	paramtable.Init()
+
+	logger := mlog.With()
+	metrics := newBroadcasterMetrics()
+	ackScheduler := newAckCallbackScheduler(logger)
+	broadcastScheduler := newBroadcasterScheduler(nil, logger)
+	task := newBroadcastTaskFromProto(createNewBroadcastTask(107, []string{"v1", "v2"}), metrics, ackScheduler)
+	task.SetLogger(logger)
+
+	managerCtx, managerCancel := context.WithCancel(context.Background())
+	bm := &broadcastTaskManager{
+		lifetime:           typeutil.NewLifetime(),
+		ctx:                managerCtx,
+		cancel:             managerCancel,
+		mu:                 &sync.Mutex{},
+		tasks:              map[uint64]*broadcastTask{107: task},
+		broadcastScheduler: broadcastScheduler,
+		ackScheduler:       ackScheduler,
+	}
+	bm.SetLogger(logger)
+	ackScheduler.bm = bm
+	ackScheduler.Initialize(nil, nil, bm)
+
+	ackDone := make(chan error, 1)
+	go func() {
+		ackDone <- bm.Ack(context.WithoutCancel(context.Background()), newDropCollectionAckMessage(107, "v1"))
+	}()
+	requireNoResult(t, ackDone, 50*time.Millisecond, "ack should be waiting before Close")
+
+	closeDone := make(chan struct{})
+	go func() {
+		bm.Close()
+		close(closeDone)
+	}()
+	select {
+	case <-closeDone:
+	case <-time.After(5 * time.Second):
+		t.Fatal("broadcaster Close hung behind an unresolved ack-once callback")
+	}
+	select {
+	case err := <-ackDone:
+		require.ErrorIs(t, err, context.Canceled)
+	case <-time.After(time.Second):
+		t.Fatal("in-flight ACK was not canceled by broadcaster Close")
+	}
+}
+
+func newDropCollectionAckMessage(broadcastID uint64, vchannel string) message.ImmutableMessage {
+	return message.NewDropCollectionMessageBuilderV1().
+		WithHeader(&message.DropCollectionMessageHeader{}).
+		WithBody(&msgpb.DropCollectionRequest{}).
+		WithBroadcast([]string{vchannel}).
+		MustBuildBroadcast().
+		WithBroadcastID(broadcastID).
+		SplitIntoMutableMessage()[0].
+		WithTimeTick(100).
+		WithLastConfirmed(walimplstest.NewTestMessageID(1)).
+		IntoImmutableMessage(walimplstest.NewTestMessageID(2))
+}
+
+func requireNoResult[T any](t *testing.T, ch <-chan T, wait time.Duration, message string) {
+	t.Helper()
+	select {
+	case <-ch:
+		t.Fatal(message)
+	case <-time.After(wait):
+	}
+}

--- a/internal/streamingcoord/server/broadcaster/broadcast_manager.go
+++ b/internal/streamingcoord/server/broadcaster/broadcast_manager.go
@@ -15,6 +15,7 @@ import (
 	"github.com/milvus-io/milvus/pkg/v3/proto/streamingpb"
 	"github.com/milvus-io/milvus/pkg/v3/streaming/util/message"
 	"github.com/milvus-io/milvus/pkg/v3/streaming/util/types"
+	"github.com/milvus-io/milvus/pkg/v3/util/contextutil"
 	"github.com/milvus-io/milvus/pkg/v3/util/merr"
 	"github.com/milvus-io/milvus/pkg/v3/util/replicateutil"
 	"github.com/milvus-io/milvus/pkg/v3/util/typeutil"
@@ -26,12 +27,12 @@ func RecoverBroadcaster(ctx context.Context) (Broadcaster, error) {
 	if err != nil {
 		return nil, err
 	}
-	return newBroadcastTaskManager(tasks), nil
+	return newBroadcastTaskManager(ctx, tasks), nil
 }
 
 // newBroadcastTaskManager creates a new broadcast task manager with recovery info.
 // return the manager, the pending broadcast tasks and the pending ack callback tasks.
-func newBroadcastTaskManager(protos []*streamingpb.BroadcastTask) *broadcastTaskManager {
+func newBroadcastTaskManager(ctx context.Context, protos []*streamingpb.BroadcastTask) *broadcastTaskManager {
 	logger := resource.Resource().Logger().With(mlog.FieldComponent("broadcaster"))
 	metrics := newBroadcasterMetrics()
 	rkLocker := newResourceKeyLocker()
@@ -76,8 +77,11 @@ func newBroadcastTaskManager(protos []*streamingpb.BroadcastTask) *broadcastTask
 		tasks[task.Header().BroadcastID] = task
 	}
 
+	managerCtx, cancel := context.WithCancel(ctx)
 	m := &broadcastTaskManager{
 		lifetime:           typeutil.NewLifetime(),
+		ctx:                managerCtx,
+		cancel:             cancel,
 		mu:                 &sync.Mutex{},
 		tasks:              tasks,
 		resourceKeyLocker:  rkLocker,
@@ -99,7 +103,10 @@ func newBroadcastTaskManager(protos []*streamingpb.BroadcastTask) *broadcastTask
 type broadcastTaskManager struct {
 	mlog.Binder
 
-	lifetime           *typeutil.Lifetime
+	lifetime *typeutil.Lifetime
+	ctx      context.Context
+	cancel   context.CancelFunc
+	// mu only protects tasks. Never call a broadcastTask method while holding mu.
 	mu                 *sync.Mutex
 	tasks              map[uint64]*broadcastTask // map the broadcastID to the broadcastTaskState
 	resourceKeyLocker  *resourceKeyLocker
@@ -251,6 +258,8 @@ func (bm *broadcastTaskManager) Ack(ctx context.Context, msg message.ImmutableMe
 		return status.NewOnShutdownError("broadcaster is closing")
 	}
 	defer bm.lifetime.Done()
+	ctx, cancel := bm.withLifecycleContext(ctx)
+	defer cancel()
 
 	t, ok := bm.getOrCreateBroadcastTask(msg)
 	if !ok {
@@ -285,6 +294,9 @@ func (bm *broadcastTaskManager) DropTombstone(ctx context.Context, broadcastID u
 // Close closes the broadcast task manager.
 func (bm *broadcastTaskManager) Close() {
 	bm.lifetime.SetState(typeutil.LifetimeStateStopped)
+	if bm.cancel != nil {
+		bm.cancel()
+	}
 	bm.lifetime.Wait()
 
 	bm.broadcastScheduler.Close()
@@ -308,14 +320,14 @@ func (bm *broadcastTaskManager) addBroadcastTask(msg message.BroadcastMutableMes
 // if the task is not found, it will create a new task.
 func (bm *broadcastTaskManager) getOrCreateBroadcastTask(msg message.ImmutableMessage) (*broadcastTask, bool) {
 	bm.mu.Lock()
-	defer bm.mu.Unlock()
-
 	bh := msg.BroadcastHeader()
-	t, ok := bm.tasks[msg.BroadcastHeader().BroadcastID]
+	t, ok := bm.tasks[bh.BroadcastID]
 	if ok {
+		bm.mu.Unlock()
 		return t, t.State() != streamingpb.BroadcastTaskState_BROADCAST_TASK_STATE_TOMBSTONE
 	}
 	if msg.ReplicateHeader() == nil {
+		bm.mu.Unlock()
 		bm.Logger().Warn(context.TODO(), "try to recover task from the wal from non-replicate message, ignore it")
 		return nil, false
 	}
@@ -323,6 +335,7 @@ func (bm *broadcastTaskManager) getOrCreateBroadcastTask(msg message.ImmutableMe
 	newBroadcastTask := newBroadcastTaskFromImmutableMessage(msg, bm.metrics, bm.ackScheduler)
 	newBroadcastTask.SetLogger(bm.Logger())
 	bm.tasks[bh.BroadcastID] = newBroadcastTask
+	bm.mu.Unlock()
 	return newBroadcastTask, true
 }
 
@@ -346,18 +359,9 @@ func (bm *broadcastTaskManager) removeBroadcastTask(broadcastID uint64) {
 // getIncompleteBroadcastTasks returns all incomplete broadcast tasks that have pending messages.
 // Tasks in PENDING or REPLICATED state with pending messages are considered incomplete.
 func (bm *broadcastTaskManager) getIncompleteBroadcastTasks() []*broadcastTask {
-	bm.mu.Lock()
-	defer bm.mu.Unlock()
-
 	var result []*broadcastTask
-	for _, task := range bm.tasks {
-		state := task.State()
-		if state != streamingpb.BroadcastTaskState_BROADCAST_TASK_STATE_PENDING &&
-			state != streamingpb.BroadcastTaskState_BROADCAST_TASK_STATE_REPLICATED {
-			continue
-		}
-		msgs := task.PendingBroadcastMessages()
-		if len(msgs) == 0 {
+	for _, task := range bm.snapshotBroadcastTasks() {
+		if !task.HasPendingMessagesInIncompleteState() {
 			continue
 		}
 		result = append(result, task)
@@ -369,36 +373,41 @@ func (bm *broadcastTaskManager) getIncompleteBroadcastTasks() []*broadcastTask {
 // for all non-tombstone schema broadcast tasks. Used during recovery to rebuild
 // file resource refCnt for resources referenced by pending schema changes.
 func (bm *broadcastTaskManager) GetPendingSchemaFileResources() map[int64][]int64 {
+	result := make(map[int64][]int64)
+	for _, task := range bm.snapshotBroadcastTasks() {
+		typ := task.MessageTypeWithVersion()
+		if typ != message.MessageTypeCreateCollectionV1 && typ != message.MessageTypeAlterCollectionV2 {
+			continue
+		}
+		collectionID, ids, ok := task.PendingSchemaFileResourceSnapshot()
+		if !ok {
+			continue
+		}
+		appendPendingFileResourceIDs(result, collectionID, ids)
+	}
+	return result
+}
+
+// snapshotBroadcastTasks copies the task pointers while holding the manager
+// lock. Task-local inspection must happen after the manager lock is released.
+func (bm *broadcastTaskManager) snapshotBroadcastTasks() []*broadcastTask {
 	bm.mu.Lock()
 	defer bm.mu.Unlock()
 
-	result := make(map[int64][]int64)
+	tasks := make([]*broadcastTask, 0, len(bm.tasks))
 	for _, task := range bm.tasks {
-		if task.State() == streamingpb.BroadcastTaskState_BROADCAST_TASK_STATE_TOMBSTONE {
-			continue
-		}
-		switch task.msg.MessageTypeWithVersion() {
-		case message.MessageTypeCreateCollectionV1:
-			createMsg, err := message.AsMutableCreateCollectionMessageV1(task.msg)
-			if err != nil {
-				continue
-			}
-			body := createMsg.MustBody()
-			ids := body.CollectionSchema.GetFileResourceIds()
-			appendPendingFileResourceIDs(result, createMsg.Header().CollectionId, ids)
-		case message.MessageTypeAlterCollectionV2:
-			alterMsg, err := message.AsMutableAlterCollectionMessageV2(task.msg)
-			if err != nil {
-				continue
-			}
-			schema := alterMsg.MustBody().GetUpdates().GetSchema()
-			ids := schema.GetFileResourceIds()
-			appendPendingFileResourceIDs(result, alterMsg.Header().CollectionId, ids)
-		default:
-			continue
-		}
+		tasks = append(tasks, task)
 	}
-	return result
+	return tasks
+}
+
+func (bm *broadcastTaskManager) withLifecycleContext(ctx context.Context) (context.Context, context.CancelFunc) {
+	if bm.ctx == nil {
+		// Some focused tests build the manager directly. Production managers
+		// always have a lifecycle context from newBroadcastTaskManager.
+		return context.WithCancel(ctx)
+	}
+	return contextutil.MergeContext(ctx, bm.ctx)
 }
 
 func appendPendingFileResourceIDs(result map[int64][]int64, collectionID int64, ids []int64) {

--- a/internal/streamingcoord/server/broadcaster/broadcast_task.go
+++ b/internal/streamingcoord/server/broadcaster/broadcast_task.go
@@ -25,15 +25,16 @@ func newBroadcastTaskFromProto(proto *streamingpb.BroadcastTask, metrics *broadc
 	fixAckInfoFromProto(proto, len(msg.BroadcastHeader().VChannels))
 
 	bt := &broadcastTask{
-		mu:                   sync.Mutex{},
-		taskMetricsGuard:     m,
-		msg:                  msg,
-		task:                 proto,
-		dirty:                false, // the task is recovered from the recovery info, so it's persisted.
-		ackCallbackScheduler: ackCallbackScheduler,
-		done:                 make(chan struct{}),
-		allAcked:             make(chan struct{}),
-		allAckedClosed:       false,
+		mu:                     sync.Mutex{},
+		taskMetricsGuard:       m,
+		msg:                    msg,
+		messageTypeWithVersion: msg.MessageTypeWithVersion(),
+		task:                   proto,
+		dirty:                  false, // the task is recovered from the recovery info, so it's persisted.
+		ackCallbackScheduler:   ackCallbackScheduler,
+		done:                   make(chan struct{}),
+		allAcked:               make(chan struct{}),
+		allAckedClosed:         false,
 	}
 	if isAllDone(bt.task) {
 		bt.closeAllAcked()
@@ -67,10 +68,11 @@ func newBroadcastTaskFromBroadcastMessage(msg message.BroadcastMutableMessage, m
 	m := metrics.NewBroadcastTask(msg.MessageType(), streamingpb.BroadcastTaskState_BROADCAST_TASK_STATE_PENDING, msg.BroadcastHeader().ResourceKeys.Collect())
 	header := msg.BroadcastHeader()
 	bt := &broadcastTask{
-		Binder:           mlog.Binder{},
-		taskMetricsGuard: m,
-		mu:               sync.Mutex{},
-		msg:              msg,
+		Binder:                 mlog.Binder{},
+		taskMetricsGuard:       m,
+		mu:                     sync.Mutex{},
+		msg:                    msg,
+		messageTypeWithVersion: msg.MessageTypeWithVersion(),
 		task: &streamingpb.BroadcastTask{
 			Message:             msg.IntoMessageProto(),
 			State:               streamingpb.BroadcastTaskState_BROADCAST_TASK_STATE_PENDING,
@@ -101,16 +103,18 @@ type broadcastTask struct {
 	mlog.Binder
 	*taskMetricsGuard
 
-	mu                       sync.Mutex
-	msg                      message.BroadcastMutableMessage // protected by mu since MarkIgnore may mutate it.
-	task                     *streamingpb.BroadcastTask
-	dirty                    bool // a flag to indicate that the task has been modified and needs to be saved into the recovery info.
-	done                     chan struct{}
-	allAcked                 chan struct{}
-	allAckedClosed           bool
-	guards                   *lockGuards
-	ackCallbackScheduler     *ackCallbackScheduler
-	joinAckCallbackScheduled bool // a flag to indicate that the join ack callback is scheduled.
+	mu                     sync.Mutex
+	msg                    message.BroadcastMutableMessage // protected by mu since MarkIgnore may mutate it.
+	messageTypeWithVersion message.MessageTypeWithVersion  // immutable after construction; safe to read without mu.
+	task                   *streamingpb.BroadcastTask
+	dirty                  bool // a flag to indicate that the task has been modified and needs to be saved into the recovery info.
+	done                   chan struct{}
+	allAcked               chan struct{}
+	allAckedClosed         bool
+	guards                 *lockGuards
+	ackCallbackScheduler   *ackCallbackScheduler
+	// a flag to indicate that the join ack callback is scheduled.
+	joinAckCallbackScheduled bool
 }
 
 // SetLogger sets the logger of the broadcast task.
@@ -195,7 +199,12 @@ func (b *broadcastTask) State() streamingpb.BroadcastTaskState {
 func (b *broadcastTask) PendingBroadcastMessages() []message.MutableMessage {
 	b.mu.Lock()
 	defer b.mu.Unlock()
+	return b.pendingBroadcastMessages()
+}
 
+// pendingBroadcastMessages returns pending messages without acquiring b.mu.
+// Caller must hold b.mu.
+func (b *broadcastTask) pendingBroadcastMessages() []message.MutableMessage {
 	msg := message.NewBroadcastMutableMessageBeforeAppend(b.task.Message.Payload, b.task.Message.Properties)
 	msgs := msg.SplitIntoMutableMessage()
 	// filter out the vchannel that has been acked.
@@ -207,6 +216,54 @@ func (b *broadcastTask) PendingBroadcastMessages() []message.MutableMessage {
 		pendingMessages = append(pendingMessages, msg)
 	}
 	return pendingMessages
+}
+
+// HasPendingMessagesInIncompleteState atomically checks whether this task is
+// eligible for force-promote recovery and still has messages to broadcast.
+func (b *broadcastTask) HasPendingMessagesInIncompleteState() bool {
+	b.mu.Lock()
+	defer b.mu.Unlock()
+
+	if b.task.State != streamingpb.BroadcastTaskState_BROADCAST_TASK_STATE_PENDING &&
+		b.task.State != streamingpb.BroadcastTaskState_BROADCAST_TASK_STATE_REPLICATED {
+		return false
+	}
+	return len(b.pendingBroadcastMessages()) > 0
+}
+
+// MessageTypeWithVersion returns the immutable message type cached when the
+// task is constructed. MarkIgnore may replace b.msg but never changes its type.
+func (b *broadcastTask) MessageTypeWithVersion() message.MessageTypeWithVersion {
+	return b.messageTypeWithVersion
+}
+
+// PendingSchemaFileResourceSnapshot returns the collection and file resource
+// IDs referenced by a non-tombstone CreateCollection or AlterCollection task.
+func (b *broadcastTask) PendingSchemaFileResourceSnapshot() (int64, []int64, bool) {
+	b.mu.Lock()
+	defer b.mu.Unlock()
+
+	if b.task.State == streamingpb.BroadcastTaskState_BROADCAST_TASK_STATE_TOMBSTONE {
+		return 0, nil, false
+	}
+	switch b.messageTypeWithVersion {
+	case message.MessageTypeCreateCollectionV1:
+		createMsg, err := message.AsMutableCreateCollectionMessageV1(b.msg)
+		if err != nil {
+			return 0, nil, false
+		}
+		ids := createMsg.MustBody().CollectionSchema.GetFileResourceIds()
+		return createMsg.Header().CollectionId, append([]int64(nil), ids...), true
+	case message.MessageTypeAlterCollectionV2:
+		alterMsg, err := message.AsMutableAlterCollectionMessageV2(b.msg)
+		if err != nil {
+			return 0, nil, false
+		}
+		ids := alterMsg.MustBody().GetUpdates().GetSchema().GetFileResourceIds()
+		return alterMsg.Header().CollectionId, append([]int64(nil), ids...), true
+	default:
+		return 0, nil, false
+	}
 }
 
 // IsAlterReplicateConfigMessage returns true if this task is an AlterReplicateConfig message.
@@ -315,21 +372,27 @@ func (b *broadcastTask) getImmutableMessageFromVChannel(vchannel string, result 
 // Ack acknowledges the message at the specified vchannel.
 // return true if all the vchannels are acked at first time, false if not.
 func (b *broadcastTask) Ack(ctx context.Context, msgs message.ImmutableMessage) (err error) {
+	callback, err := registry.ResolveMessageAckOnceCallback(ctx, b.messageTypeWithVersion)
+	if err != nil {
+		return err
+	}
+
 	b.mu.Lock()
 	defer b.mu.Unlock()
 
-	return b.ack(ctx, msgs)
+	return b.ack(ctx, callback, msgs)
 }
 
 // ack acknowledges the message at the specified vchannel.
-func (b *broadcastTask) ack(ctx context.Context, msgs ...message.ImmutableMessage) (err error) {
+// Caller must resolve callback before acquiring b.mu and hold b.mu while calling.
+func (b *broadcastTask) ack(ctx context.Context, callback registry.ResolvedMessageAckOnceCallback, msgs ...message.ImmutableMessage) (err error) {
 	isControlChannelAcked := b.copyAndSetAckedCheckpoints(msgs...)
 	if !b.dirty {
 		return nil
 	}
 	// because the incoming ack operation is always with one vchannel at a time or with all the vchannels at once,
 	// so we don't need to filter the vchannel that has been acked.
-	if err := registry.CallMessageAckOnceCallbacks(ctx, msgs...); err != nil {
+	if err := registry.CallResolvedMessageAckOnceCallbacks(ctx, callback, msgs...); err != nil {
 		return err
 	}
 	if err := b.saveTaskIfDirty(ctx, b.Logger()); err != nil {
@@ -450,15 +513,25 @@ func findIdxOfVChannel(vchannel string, vchannels []string) int {
 func (b *broadcastTask) FastAck(ctx context.Context, broadcastResult map[string]*types.AppendResult) error {
 	// Broadcast operation is done.
 	b.mu.Lock()
-	defer b.mu.Unlock()
-
 	b.ObserveBroadcastDone()
 
 	if b.header().AckSyncUp {
 		// Because the ack sync up is enabled, the ack operation want to be synced up at comsuming side of streaming node,
 		// so we can not make a fast ack operation here to speed up the ack operation.
+		b.mu.Unlock()
 		return nil
 	}
+	b.mu.Unlock()
+
+	// Callback registration may depend on coordinator startup. Never wait for
+	// that future while holding the task lock.
+	callback, err := registry.ResolveMessageAckOnceCallback(ctx, b.messageTypeWithVersion)
+	if err != nil {
+		return err
+	}
+
+	b.mu.Lock()
+	defer b.mu.Unlock()
 
 	// because we need to wait for the streamingnode to ack the message,
 	// however, if the message is already write into wal, the message is determined,
@@ -467,7 +540,7 @@ func (b *broadcastTask) FastAck(ctx context.Context, broadcastResult map[string]
 	for vchannel := range broadcastResult {
 		msgs = append(msgs, b.getImmutableMessageFromVChannel(vchannel, broadcastResult[vchannel]))
 	}
-	return b.ack(ctx, msgs...)
+	return b.ack(ctx, callback, msgs...)
 }
 
 // DropTombstone drops the tombstone of the broadcast task.

--- a/internal/streamingcoord/server/broadcaster/registry/ack_once_message_callback.go
+++ b/internal/streamingcoord/server/broadcaster/registry/ack_once_message_callback.go
@@ -16,7 +16,12 @@ import (
 // It will be called when the message is acked by streamingnode at one channel at a time.
 type (
 	MessageAckOnceCallback[H proto.Message, B proto.Message] = func(ctx context.Context, result message.AckResult[H, B]) error
-	messageInnerAckOnceCallback                              = func(ctx context.Context, msg message.ImmutableMessage) error
+	// ResolvedMessageAckOnceCallback is an ack-once callback whose registration
+	// future has already been resolved. Resolving and invoking are deliberately
+	// separate so callers can wait for component registration without holding
+	// task-local locks.
+	ResolvedMessageAckOnceCallback func(ctx context.Context, msg message.ImmutableMessage) error
+	messageInnerAckOnceCallback    = ResolvedMessageAckOnceCallback
 )
 
 // messageAckOnceCallbacks is the map of message type to the ack once callback function.
@@ -75,18 +80,56 @@ func CallMessageAckOnceCallbacks(ctx context.Context, msgs ...message.ImmutableM
 	return nil
 }
 
-// callMessageAckOnceCallback calls the ack once callback function for the message type.
-func callMessageAckOnceCallback(ctx context.Context, msg message.ImmutableMessage) error {
+// ResolveMessageAckOnceCallback waits until the ack-once callback for typ is
+// registered. A nil callback means the message type has no ack-once callback.
+func ResolveMessageAckOnceCallback(ctx context.Context, typ message.MessageTypeWithVersion) (ResolvedMessageAckOnceCallback, error) {
 	messageAckOnceCallbacksMu.RLock()
-	callbackFuture, ok := messageAckOnceCallbacks[msg.MessageTypeWithVersion()]
+	callbackFuture, ok := messageAckOnceCallbacks[typ]
 	messageAckOnceCallbacksMu.RUnlock()
 	if !ok {
-		// No callback need tobe called, return nil
-		return nil
+		return nil, nil
 	}
 	callback, err := callbackFuture.GetWithContext(ctx)
 	if err != nil {
-		return merr.Wrap(err, "when waiting callback registered")
+		return nil, merr.Wrap(err, "when waiting callback registered")
 	}
-	return callback(ctx, msg)
+	return callback, nil
+}
+
+// CallResolvedMessageAckOnceCallbacks invokes a callback that has already been
+// resolved. Multiple messages retain the existing parallel invocation behavior.
+func CallResolvedMessageAckOnceCallbacks(ctx context.Context, callback ResolvedMessageAckOnceCallback, msgs ...message.ImmutableMessage) error {
+	if callback == nil || len(msgs) == 0 {
+		return nil
+	}
+	if len(msgs) == 1 {
+		return callback(ctx, msgs[0])
+	}
+	wg := &sync.WaitGroup{}
+	wg.Add(len(msgs))
+	errc := make(chan error, len(msgs))
+	for _, msg := range msgs {
+		msg := msg
+		go func() {
+			defer wg.Done()
+			errc <- callback(ctx, msg)
+		}()
+	}
+	wg.Wait()
+	close(errc)
+	for err := range errc {
+		if err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
+// callMessageAckOnceCallback calls the ack once callback function for the message type.
+func callMessageAckOnceCallback(ctx context.Context, msg message.ImmutableMessage) error {
+	callback, err := ResolveMessageAckOnceCallback(ctx, msg.MessageTypeWithVersion())
+	if err != nil {
+		return err
+	}
+	return CallResolvedMessageAckOnceCallbacks(ctx, callback, msg)
 }

--- a/internal/util/metrics/c_registry.go
+++ b/internal/util/metrics/c_registry.go
@@ -40,6 +40,7 @@ import (
 	"github.com/prometheus/client_golang/prometheus"
 	dto "github.com/prometheus/client_model/go"
 	"github.com/prometheus/common/expfmt"
+	"github.com/prometheus/common/model"
 	"golang.org/x/exp/maps"
 	"google.golang.org/protobuf/proto"
 
@@ -138,8 +139,6 @@ type CRegistry struct {
 
 // Gather implements Gatherer.
 func (r *CRegistry) Gather() (res []*dto.MetricFamily, err error) {
-	var parser expfmt.TextParser
-
 	r.mtx.RLock()
 	defer r.mtx.RUnlock()
 
@@ -147,7 +146,7 @@ func (r *CRegistry) Gather() (res []*dto.MetricFamily, err error) {
 	metricsStr := C.GoString(cMetricsStr)
 	C.free(unsafe.Pointer(cMetricsStr))
 
-	out, err := parser.TextToMetricFamilies(strings.NewReader(metricsStr))
+	out, err := parseTextMetrics(metricsStr)
 	if err != nil {
 		mlog.Error(context.TODO(), "fail to parse knowhere prometheus metrics", mlog.Err(err))
 		return res, err
@@ -157,7 +156,7 @@ func (r *CRegistry) Gather() (res []*dto.MetricFamily, err error) {
 	metricsStr = C.GoString(cMetricsStr)
 	C.free(unsafe.Pointer(cMetricsStr))
 
-	out1, err := parser.TextToMetricFamilies(strings.NewReader(metricsStr))
+	out1, err := parseTextMetrics(metricsStr)
 	if err != nil {
 		mlog.Error(context.TODO(), "fail to parse storage prometheus metrics", mlog.Err(err))
 		return res, err
@@ -173,6 +172,11 @@ func (r *CRegistry) Gather() (res []*dto.MetricFamily, err error) {
 
 	res = NormalizeMetricFamilies(out)
 	return res, err
+}
+
+func parseTextMetrics(metricsStr string) (map[string]*dto.MetricFamily, error) {
+	parser := expfmt.NewTextParser(model.LegacyValidation)
+	return parser.TextToMetricFamilies(strings.NewReader(metricsStr))
 }
 
 // gatherJemallocMetrics collects comprehensive jemalloc stats and returns them as metric families.

--- a/internal/util/metrics/c_registry_test.go
+++ b/internal/util/metrics/c_registry_test.go
@@ -1,0 +1,39 @@
+// Licensed to the LF AI & Data foundation under one
+// or more contributor license agreements. See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership. The ASF licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License. You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package metrics
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestParseTextMetrics(t *testing.T) {
+	const metricsText = `# HELP milvus_c_registry_test_total Test metric.
+# TYPE milvus_c_registry_test_total counter
+milvus_c_registry_test_total{source="core"} 1
+`
+
+	metricFamilies, err := parseTextMetrics(metricsText)
+	require.NoError(t, err)
+	require.Contains(t, metricFamilies, "milvus_c_registry_test_total")
+}
+
+func TestParseTextMetricsUsesLegacyValidation(t *testing.T) {
+	_, err := parseTextMetrics(`{"metric.name",source="core"} 1`)
+	require.ErrorContains(t, err, `invalid metric name "metric.name"`)
+}


### PR DESCRIPTION
## Summary
- Fix deadlock in broadcaster where ack-once callback future resolution blocked while holding both the manager lock and task lock during coordinator slow startup/recovery.
- Separate callback resolution (`ResolveMessageAckOnceCallback`) from the locked ack path so futures are awaited without holding any task/manager locks.
- Add lifecycle context to `broadcastTaskManager` so `Close()` cancels in-flight ack waits cleanly.
- Fix `CRegistry.Gather()` to use `expfmt.NewTextParser(model.LegacyValidation)` instead of the deprecated zero-value `expfmt.TextParser`.

## Test plan
- [x] Added `broadcast_deadlock_test.go` covering:
  - Ack waits for callback without holding task or manager lock
  - `getOrCreate` does not hold manager lock while inspecting task
  - `GetPendingSchemaFileResources` scan skips locked unrelated tasks
  - `FastAck` resolves callback outside task lock
  - `FastAck` with AckSyncUp returns immediately
  - Callback failure remains retryable
  - `Close()` cancels ack waiting for callback registration
- [x] Added `c_registry_test.go` for the new `parseTextMetrics` helper


Made with [Cursor](https://cursor.com)