### PR TITLE
enhance: make query view concurrency configurable

### DIFF
--- a/configs/milvus.yaml
+++ b/configs/milvus.yaml
@@ -565,6 +565,8 @@ queryCoord:
   resourceExhaustionPenaltyDuration: 30
   resourceExhaustionCleanupInterval: 10 # Interval (in seconds) for cleaning up expired resource exhaustion marks on query nodes.
   cleanExcludeSegmentInterval: 60 # the time duration of clean pipeline exclude segment which used for filter invalid data, in seconds
+  queryView:
+    fullReconsileInterval: 10 # Interval in seconds for periodic QueryView full reconciliation.
   ip:  # TCP/IP address of queryCoord. If not specified, use the first unicastable address
   port: 19531 # TCP port of queryCoord
   grpc:

--- a/configs/milvus.yaml
+++ b/configs/milvus.yaml
@@ -720,6 +720,9 @@ queryNode:
   bloomFilterApplyParallelFactor: 2 # parallel factor when to apply pk to bloom filter, default to 2*CPU_CORE_NUM
   workerPooling:
     size: 10 # the size for worker querynode client pool
+  queryView:
+    segmentCatchupConcurrency: 4 # Maximum number of concurrent QueryView sealed segment TransformLog catch-up tasks on each QueryNode.
+    transformLogDrainConcurrency: 4 # Maximum number of concurrent QueryView TransformLog backlog drain tasks on each QueryNode.
   idfOracle:
     preload: true # Whether to parse and merge BM25 stats into current during load before first target. When false, stats are only written to disk and loaded on first SyncDistribution.
     readBufferSize: 4194304 # Read buffer size in bytes for streaming BM25 stats from remote storage. Reduces per-read overhead through the storage SDK.
@@ -1469,6 +1472,10 @@ streamingNode:
 
 # Any configuration related to the streaming service.
 streaming:
+  queryView:
+    liveEventDispatchConcurrencyPerPChannel: 4 # Maximum number of QueryRuntimes dispatching live events concurrently on each PChannel.
+  transformLog:
+    catchupConcurrencyPerStream: 4 # Maximum number of TransformLog subscriptions catching up concurrently on each stream.
   walBalancer:
     # The interval of balance task trigger at background, 1 min by default.
     # It's ok to set it into duration string, such as 30s or 1m30s, see time.ParseDuration

--- a/internal/querycoordv2/qviews_runtime.go
+++ b/internal/querycoordv2/qviews_runtime.go
@@ -18,6 +18,7 @@ package querycoordv2
 
 import (
 	"context"
+	"time"
 
 	clientv3 "go.etcd.io/etcd/client/v3"
 
@@ -37,6 +38,7 @@ import (
 	"github.com/milvus-io/milvus/pkg/v3/kv"
 	"github.com/milvus-io/milvus/pkg/v3/mlog"
 	"github.com/milvus-io/milvus/pkg/v3/util/merr"
+	"github.com/milvus-io/milvus/pkg/v3/util/paramtable"
 )
 
 type qviewsBalancer interface {
@@ -127,12 +129,14 @@ func newQViewsRuntime(ctx context.Context, deps qviewsRuntimeDependencies) (*qvi
 	}
 
 	nodeProvider := nodeview.NewQueryNodeProvider(ctx, deps.queryNodeClient, deps.resourceGroupManager)
+	balanceConfig := balancer.DefaultBalanceConfig()
+	balanceConfig.TickerInterval = paramtable.Get().QueryCoordCfg.QueryViewFullReconsileInterval.GetAsDuration(time.Second)
 	builder := balancer.NewSnapshotBuilder(
 		loadConfigStore,
 		shardViewRegistry,
 		nodeProvider,
 		deps.dataViewProvider,
-		balancer.DefaultBalanceConfig(),
+		balanceConfig,
 	)
 	balancerController := qviewsBalancer(balancer.NewDefaultBalancer(builder, shardViewRegistry, nil))
 	if deps.balancerFactory != nil {

--- a/internal/querynodev2/qnview/queryview_segment_readiness_manager.go
+++ b/internal/querynodev2/qnview/queryview_segment_readiness_manager.go
@@ -28,13 +28,16 @@ type QueryViewSegmentReadinessManager struct {
 	segments map[int64]*transformSegmentState
 }
 
-const transformCatchupWorkerCount = 4
-
-func NewQueryViewSegmentReadinessManager(physical PhysicalSegmentManager, buffer TransformLogBuffer, collections ...QueryViewCollectionRuntimeManager) *QueryViewSegmentReadinessManager {
-	return NewQueryViewSegmentReadinessManagerWithScheduler(nodescheduler.Get(), physical, buffer, collections...)
-}
-
-func NewQueryViewSegmentReadinessManagerWithScheduler(scheduler nodescheduler.Scheduler, physical PhysicalSegmentManager, buffer TransformLogBuffer, collections ...QueryViewCollectionRuntimeManager) *QueryViewSegmentReadinessManager {
+func NewQueryViewSegmentReadinessManagerWithScheduler(
+	scheduler nodescheduler.Scheduler,
+	physical PhysicalSegmentManager,
+	buffer TransformLogBuffer,
+	catchupConcurrency int,
+	collections ...QueryViewCollectionRuntimeManager,
+) *QueryViewSegmentReadinessManager {
+	if catchupConcurrency <= 0 {
+		panic("query view segment catch-up concurrency must be positive")
+	}
 	var collectionManager QueryViewCollectionRuntimeManager
 	if len(collections) > 0 {
 		collectionManager = collections[0]
@@ -48,7 +51,7 @@ func NewQueryViewSegmentReadinessManagerWithScheduler(scheduler nodescheduler.Sc
 		views:        make(map[qviews.QueryViewKey]*transformViewRef),
 		segments:     make(map[int64]*transformSegmentState),
 	}
-	for i := 0; i < transformCatchupWorkerCount; i++ {
+	for i := 0; i < catchupConcurrency; i++ {
 		go m.catchupWorker()
 	}
 	return m

--- a/internal/querynodev2/qnview/queryview_segment_readiness_manager_test.go
+++ b/internal/querynodev2/qnview/queryview_segment_readiness_manager_test.go
@@ -38,7 +38,7 @@ func TestQueryViewSegmentReadinessManager_AcquireUsesNodeScheduler(t *testing.T)
 		acquire: func(AcquirePhysicalSegments) { physicalCalled <- struct{}{} },
 		release: func(req ReleaseSegments) { req.OnDropped() },
 	}
-	mgr := NewQueryViewSegmentReadinessManagerWithScheduler(nodeScheduler, physical, &fakeTransformLogBuffer{}, collections)
+	mgr := NewQueryViewSegmentReadinessManagerWithScheduler(nodeScheduler, physical, &fakeTransformLogBuffer{}, 4, collections)
 
 	mgr.Acquire(AcquireSegments{
 		Key: key, Meta: meta, View: view,
@@ -307,7 +307,7 @@ func TestQueryViewSegmentReadinessManager_RetriesRetryableCollectionAcquireInNod
 		acquire: func(AcquirePhysicalSegments) { physicalCalled <- struct{}{} },
 		release: func(req ReleaseSegments) { req.OnDropped() },
 	}
-	mgr := NewQueryViewSegmentReadinessManagerWithScheduler(nodeScheduler, physical, &fakeTransformLogBuffer{}, collections)
+	mgr := NewQueryViewSegmentReadinessManagerWithScheduler(nodeScheduler, physical, &fakeTransformLogBuffer{}, 4, collections)
 
 	unrecoverable := make(chan struct{}, 1)
 	mgr.Acquire(AcquireSegments{

--- a/internal/querynodev2/qnview/segment_manager_test_fixtures_test.go
+++ b/internal/querynodev2/qnview/segment_manager_test_fixtures_test.go
@@ -440,7 +440,7 @@ func newTestQueryViewSegmentReadinessManager(t *testing.T, physical PhysicalSegm
 	t.Helper()
 	scheduler := nodescheduler.New(4)
 	t.Cleanup(scheduler.Close)
-	return NewQueryViewSegmentReadinessManagerWithScheduler(scheduler, physical, buffer, collections...)
+	return NewQueryViewSegmentReadinessManagerWithScheduler(scheduler, physical, buffer, 4, collections...)
 }
 
 func newTestViewScopedPhysicalSegmentManager(t *testing.T, scheduler nodescheduler.Scheduler, streams ...SegmentLoadInfoStream) *ViewScopedPhysicalSegmentManager {

--- a/internal/querynodev2/qvresource/qv_segment_manager.go
+++ b/internal/querynodev2/qvresource/qv_segment_manager.go
@@ -8,6 +8,7 @@ import (
 	qvtransformlogbuffer "github.com/milvus-io/milvus/internal/querynodev2/transformlogbuffer"
 	"github.com/milvus-io/milvus/internal/streamingnode/server/wal"
 	"github.com/milvus-io/milvus/pkg/v3/util/nodescheduler"
+	"github.com/milvus-io/milvus/pkg/v3/util/paramtable"
 )
 
 type queryViewPhysicalSegmentLoader struct {
@@ -41,7 +42,16 @@ func NewQueryViewSegmentManager(ctx context.Context, manager *segments.Manager, 
 		newQueryViewSegmentResourceEstimator(loader),
 	)
 	collectionRuntime := newQueryViewCollectionRuntimeManager(meta, manager.Collection)
-	return qnview.NewQueryViewSegmentReadinessManagerWithScheduler(nodeScheduler, physicalManager, qvtransformlogbuffer.New(streams), collectionRuntime)
+	return qnview.NewQueryViewSegmentReadinessManagerWithScheduler(
+		nodeScheduler,
+		physicalManager,
+		qvtransformlogbuffer.New(
+			streams,
+			paramtable.Get().QueryNodeCfg.QueryViewTransformLogDrainConcurrency.GetAsInt(),
+		),
+		paramtable.Get().QueryNodeCfg.QueryViewSegmentCatchupConcurrency.GetAsInt(),
+		collectionRuntime,
+	)
 }
 
 func newQueryViewPhysicalSegmentLoader(collections qvCollectionManager, segments qvSegmentManager, loader qvSegmentLoader) *queryViewPhysicalSegmentLoader {

--- a/internal/querynodev2/transformlogbuffer/buffer.go
+++ b/internal/querynodev2/transformlogbuffer/buffer.go
@@ -25,14 +25,17 @@ type Buffer struct {
 	drainTasks chan *registration
 }
 
-func New(streams wal.TransformLogStreamManager) *Buffer {
+func New(streams wal.TransformLogStreamManager, drainConcurrency int) *Buffer {
+	if drainConcurrency <= 0 {
+		panic("query view transform log drain concurrency must be positive")
+	}
 	b := &Buffer{
 		streams:           streams,
 		streamsByPChannel: make(map[string]*streamState),
 		channels:          make(map[string]*vchannelBuffer),
 		drainTasks:        make(chan *registration, 1024),
 	}
-	for i := 0; i < 4; i++ {
+	for i := 0; i < drainConcurrency; i++ {
 		go b.drainWorker()
 	}
 	return b

--- a/internal/querynodev2/transformlogbuffer/buffer_test.go
+++ b/internal/querynodev2/transformlogbuffer/buffer_test.go
@@ -268,7 +268,7 @@ func (s *fakeSegment) appliedTicks() []uint64 {
 
 func TestBufferAcquireMultiplexesVChannelsOnOnePChannelStream(t *testing.T) {
 	streams := newFakeStreamManager()
-	buffer := New(streams)
+	buffer := New(streams, 4)
 
 	guard1, err := buffer.Acquire(context.Background(), newTestQueryView("p_1v0", 50))
 	require.NoError(t, err)
@@ -299,7 +299,7 @@ func TestBufferAcquireWaitsForSubscriptionResult(t *testing.T) {
 	stream.subscribeStarted = make(chan struct{}, 1)
 	stream.subscribeRelease = make(chan struct{})
 	streams.streams["v1"] = stream
-	buffer := New(streams)
+	buffer := New(streams, 4)
 
 	type acquireResult struct {
 		guard qnview.TransformLogGuard
@@ -344,7 +344,7 @@ func TestBufferAcquireWaitsForSameVChannelSubscriptionResult(t *testing.T) {
 	stream.subscribeStarted = make(chan struct{}, 1)
 	stream.subscribeRelease = make(chan struct{})
 	streams.streams["v1"] = stream
-	buffer := New(streams)
+	buffer := New(streams, 4)
 
 	type acquireResult struct {
 		guard qnview.TransformLogGuard
@@ -392,7 +392,7 @@ func TestBufferAcquireReturnsUnrecoverableSubscriptionError(t *testing.T) {
 	stream := newFakeStream()
 	stream.subscribeErr = wal.ErrTransformLogStartPointTruncated
 	streams.streams["v1"] = stream
-	buffer := New(streams)
+	buffer := New(streams, 4)
 
 	guard, err := buffer.Acquire(context.Background(), newTestQueryView("v1", 50))
 	require.Nil(t, guard)
@@ -404,7 +404,7 @@ func TestBufferAcquireDoesNotPoisonBufferOnRecoverableSubscriptionError(t *testi
 	stream := newFakeStream()
 	stream.subscribeErrs = []error{errors.New("transient stream failure")}
 	streams.streams["v1"] = stream
-	buffer := New(streams)
+	buffer := New(streams, 4)
 
 	guard, err := buffer.Acquire(context.Background(), newTestQueryView("v1", 50))
 	require.Nil(t, guard)
@@ -422,7 +422,7 @@ func TestBufferAcquireReturnsHandlerErrorBeforeSubscriptionReady(t *testing.T) {
 	stream := newFakeStream()
 	stream.subscribeEvent = &wal.TransformLogStreamEvent{Err: errors.New("catchup failed")}
 	streams.streams["v1"] = stream
-	buffer := New(streams)
+	buffer := New(streams, 4)
 
 	guard, err := buffer.Acquire(context.Background(), newTestQueryView("v1", 50))
 	require.Nil(t, guard)
@@ -431,7 +431,7 @@ func TestBufferAcquireReturnsHandlerErrorBeforeSubscriptionReady(t *testing.T) {
 
 func TestBufferAcquireReusesVChannelSubscriptionAndRegistersFromLocalBuffer(t *testing.T) {
 	streams := newFakeStreamManager()
-	buffer := New(streams)
+	buffer := New(streams, 4)
 	view1 := newTestQueryView("v1", 50)
 	view2 := newTestQueryView("v1", 80)
 
@@ -472,7 +472,7 @@ func TestBufferAcquireReusesVChannelSubscriptionAndRegistersFromLocalBuffer(t *t
 
 func TestBufferRegistrationKeepsApplyingLiveEntriesAfterSyncUp(t *testing.T) {
 	streams := newFakeStreamManager()
-	buffer := New(streams)
+	buffer := New(streams, 4)
 	guard, err := buffer.Acquire(context.Background(), newTestQueryView("v1", 50))
 	require.NoError(t, err)
 	defer guard.Release()
@@ -496,7 +496,7 @@ func TestBufferRegistrationKeepsApplyingLiveEntriesAfterSyncUp(t *testing.T) {
 
 func TestBufferRegisterSegmentReturnsBeforeCatchupDrainCompletes(t *testing.T) {
 	streams := newFakeStreamManager()
-	buffer := New(streams)
+	buffer := New(streams, 4)
 	guard, err := buffer.Acquire(context.Background(), newTestQueryView("p_1v0", 50))
 	require.NoError(t, err)
 	defer guard.Release()
@@ -545,7 +545,7 @@ func TestBufferRegisterSegmentReturnsBeforeCatchupDrainCompletes(t *testing.T) {
 
 func TestBufferRegisterSegmentDrainsEntriesArrivingDuringCatchupBeforeLiveAttach(t *testing.T) {
 	streams := newFakeStreamManager()
-	buffer := New(streams)
+	buffer := New(streams, 4)
 	guard, err := buffer.Acquire(context.Background(), newTestQueryView("p_1v0", 50))
 	require.NoError(t, err)
 	defer guard.Release()
@@ -598,7 +598,7 @@ func TestBufferRegisterSegmentDrainsEntriesArrivingDuringCatchupBeforeLiveAttach
 
 func TestGuardWaitTransformVisibleUsesVChannelFrontier(t *testing.T) {
 	streams := newFakeStreamManager()
-	buffer := New(streams)
+	buffer := New(streams, 4)
 	guard, err := buffer.Acquire(context.Background(), newTestQueryView("v1", 50))
 	require.NoError(t, err)
 	defer guard.Release()
@@ -632,7 +632,7 @@ func TestGuardWaitTransformVisibleUsesVChannelFrontier(t *testing.T) {
 
 func TestGuardWaitTransformVisibleWaitsForLiveApply(t *testing.T) {
 	streams := newFakeStreamManager()
-	buffer := New(streams)
+	buffer := New(streams, 4)
 	guard, err := buffer.Acquire(context.Background(), newTestQueryView("v1", 50))
 	require.NoError(t, err)
 	defer guard.Release()
@@ -681,7 +681,7 @@ func TestGuardWaitTransformVisibleWaitsForLiveApply(t *testing.T) {
 
 func TestGuardWaitTransformVisibleReturnsScannerError(t *testing.T) {
 	streams := newFakeStreamManager()
-	buffer := New(streams)
+	buffer := New(streams, 4)
 	guard, err := buffer.Acquire(context.Background(), newTestQueryView("v1", 50))
 	require.NoError(t, err)
 	defer guard.Release()
@@ -701,7 +701,7 @@ func TestGuardWaitTransformVisibleReturnsScannerError(t *testing.T) {
 
 func TestBufferRegisterSegmentFailsWhenScannerFailsBeforeSyncUp(t *testing.T) {
 	streams := newFakeStreamManager()
-	buffer := New(streams)
+	buffer := New(streams, 4)
 	_, err := buffer.Acquire(context.Background(), newTestQueryView("v1", 50))
 	require.NoError(t, err)
 

--- a/internal/streamingnode/server/wal/vchannel/growingruntime/runtime_test.go
+++ b/internal/streamingnode/server/wal/vchannel/growingruntime/runtime_test.go
@@ -209,7 +209,7 @@ func newTestInsertDeleteTxnMessage(t *testing.T, vchannel string, segmentID int6
 
 func TestDrainDeleteReplayUsesSharedTransformLogStream(t *testing.T) {
 	ctx := context.Background()
-	manager := transformlog.NewStreamManager("p1")
+	manager := transformlog.NewStreamManager("p1", 4)
 	for _, vchannel := range []string{"v1", "v2"} {
 		log := transformlog.New(transformlog.Config{VChannel: vchannel})
 		log.SwitchIntoMetaAndData()

--- a/internal/streamingnode/server/wal/vchannel/manager.go
+++ b/internal/streamingnode/server/wal/vchannel/manager.go
@@ -20,6 +20,7 @@ import (
 	"github.com/milvus-io/milvus/pkg/v3/util/funcutil"
 	"github.com/milvus-io/milvus/pkg/v3/util/merr"
 	"github.com/milvus-io/milvus/pkg/v3/util/nodescheduler"
+	"github.com/milvus-io/milvus/pkg/v3/util/paramtable"
 	"github.com/milvus-io/milvus/pkg/v3/util/typeutil"
 )
 
@@ -78,8 +79,13 @@ func NewPChannelRecoveryManager(config PChannelManagerConfig) (*PChannelRecovery
 		segmentsByVChannel: segmentsByVChannel,
 		dirtyModules:       make(map[string]*VChannelRecoveryModule),
 		config:             config,
-		streamManager:      transformlog.NewStreamManager(config.PChannel),
-		queryDispatcher:    queryresource.NewDispatcher(4),
+		streamManager: transformlog.NewStreamManager(
+			config.PChannel,
+			paramtable.Get().StreamingCfg.TransformLogCatchupConcurrencyPerStream.GetAsInt(),
+		),
+		queryDispatcher: queryresource.NewDispatcher(
+			paramtable.Get().StreamingCfg.QueryViewLiveEventDispatchConcurrencyPerPChannel.GetAsInt(),
+		),
 	}
 	queryTransformLogStream, err := manager.streamManager.AcquireStream(context.Background(), config.PChannel)
 	if err != nil {

--- a/internal/streamingnode/server/wal/vchannel/queryresource/dispatcher.go
+++ b/internal/streamingnode/server/wal/vchannel/queryresource/dispatcher.go
@@ -2,8 +2,6 @@ package queryresource
 
 import "sync"
 
-const defaultLiveEventDispatchConcurrency = 4
-
 type Dispatcher struct {
 	tasks  chan *QueryRuntime
 	closed chan struct{}
@@ -13,7 +11,7 @@ type Dispatcher struct {
 
 func NewDispatcher(concurrency int) *Dispatcher {
 	if concurrency <= 0 {
-		concurrency = 1
+		panic("query resource dispatcher concurrency must be positive")
 	}
 	dispatcher := &Dispatcher{
 		tasks:  make(chan *QueryRuntime, 1024),

--- a/internal/streamingnode/server/wal/vchannel/queryresource/manager.go
+++ b/internal/streamingnode/server/wal/vchannel/queryresource/manager.go
@@ -208,7 +208,7 @@ func (m *Manager) startBuildLocked(meta *viewpb.QueryViewMeta, build ViewBuilder
 		m.scheduler = nodescheduler.Get()
 	}
 	if m.dispatcher == nil {
-		m.dispatcher = NewDispatcher(defaultLiveEventDispatchConcurrency)
+		panic("query resource dispatcher is nil")
 	}
 	runtime := newQueryRuntime(m.dispatcher, m.newModules()...)
 	task := newResourceBuildTask(func(ctx context.Context) (*QueryRuntime, error) {

--- a/internal/streamingnode/server/wal/vchannel/queryresource/manager_test.go
+++ b/internal/streamingnode/server/wal/vchannel/queryresource/manager_test.go
@@ -439,8 +439,11 @@ func TestManagerResolveLoadInfoAppliesLoadInfoAndIndexInfos(t *testing.T) {
 
 func TestManagerResolveLoadInfoFailureDelaysBuild(t *testing.T) {
 	scheduler := &capturedNodeScheduler{}
+	dispatcher := NewDispatcher(1)
+	defer dispatcher.Close()
 	manager := NewManager(Config{
-		Scheduler: scheduler,
+		Scheduler:  scheduler,
+		Dispatcher: dispatcher,
 		LoadInfoProvider: fakeLoadInfoProvider{
 			err: merr.WrapErrCollectionNotLoaded(1),
 		},

--- a/internal/streamingnode/server/wal/vchannel/transformlog/stream.go
+++ b/internal/streamingnode/server/wal/vchannel/transformlog/stream.go
@@ -12,8 +12,6 @@ import (
 	"github.com/milvus-io/milvus/pkg/v3/proto/streamingpb"
 )
 
-const defaultStreamCatchupWorkers = 4
-
 type streamLogProvider interface {
 	logForStream(vchannel string) *TransformLog
 	streamNotifyStateSince(seq uint64) (<-chan struct{}, uint64, []string)
@@ -22,8 +20,9 @@ type streamLogProvider interface {
 
 // StreamManager owns TransformLog streams for one pchannel.
 type StreamManager struct {
-	pchannel string
-	logs     map[string]*TransformLog
+	pchannel       string
+	logs           map[string]*TransformLog
+	catchupWorkers int
 
 	streamMu     sync.Mutex
 	streamNotify chan struct{}
@@ -32,17 +31,21 @@ type StreamManager struct {
 }
 
 // NewStreamManager creates a TransformLog stream manager for one pchannel.
-func NewStreamManager(pchannel string) *StreamManager {
+func NewStreamManager(pchannel string, catchupConcurrency int) *StreamManager {
+	if catchupConcurrency <= 0 {
+		panic("transform log catch-up concurrency must be positive")
+	}
 	return &StreamManager{
-		pchannel:     pchannel,
-		logs:         make(map[string]*TransformLog),
-		streamNotify: make(chan struct{}),
-		streamSeqByV: make(map[string]uint64),
+		pchannel:       pchannel,
+		logs:           make(map[string]*TransformLog),
+		catchupWorkers: catchupConcurrency,
+		streamNotify:   make(chan struct{}),
+		streamSeqByV:   make(map[string]uint64),
 	}
 }
 
 func (m *StreamManager) AcquireStream(ctx context.Context, pchannel string) (wal.TransformLogStream, error) {
-	return newTransformLogStream(ctx, m, pchannel)
+	return newTransformLogStream(ctx, m, pchannel, m.catchupWorkers)
 }
 
 func (m *StreamManager) Register(vchannel string, log *TransformLog) {
@@ -161,7 +164,7 @@ const (
 	subscriptionStateClosed
 )
 
-func newTransformLogStream(ctx context.Context, provider streamLogProvider, pchannel string) (wal.TransformLogStream, error) {
+func newTransformLogStream(ctx context.Context, provider streamLogProvider, pchannel string, catchupWorkers int) (wal.TransformLogStream, error) {
 	if err := provider.validatePChannel(pchannel); err != nil {
 		return nil, err
 	}
@@ -179,7 +182,7 @@ func newTransformLogStream(ctx context.Context, provider streamLogProvider, pcha
 		byVChannel:   make(map[string]map[int64]*streamSubscription),
 	}
 	_, stream.seenNotifySeq, _ = provider.streamNotifyStateSince(0)
-	for i := 0; i < defaultStreamCatchupWorkers; i++ {
+	for i := 0; i < catchupWorkers; i++ {
 		go stream.catchupWorker()
 	}
 	go stream.run()

--- a/internal/streamingnode/server/wal/vchannel/transformlog/stream_test.go
+++ b/internal/streamingnode/server/wal/vchannel/transformlog/stream_test.go
@@ -18,7 +18,7 @@ func TestTransformLogStreamManagerCatchupThenDispatch(t *testing.T) {
 	transformLog := New(Config{VChannel: "v1"})
 	require.True(t, transformLog.append(newTransformLogTestDeleteMessage(t, 10), appendOption{}).Appended)
 	require.True(t, transformLog.append(newTransformLogTestDeleteMessage(t, 20), appendOption{}).Appended)
-	manager := NewStreamManager("pchannel")
+	manager := NewStreamManager("pchannel", 4)
 	manager.Register("v1", transformLog)
 
 	stream, err := manager.AcquireStream(ctx, "pchannel")
@@ -65,7 +65,7 @@ func TestTransformLogStreamManagerBoundedReplayEmitsSyncUpAndCloses(t *testing.T
 	require.True(t, transformLog.append(newTransformLogTestDeleteMessage(t, 10), appendOption{}).Appended)
 	require.True(t, transformLog.append(newTransformLogTestDeleteMessage(t, 20), appendOption{}).Appended)
 	require.True(t, transformLog.append(newTransformLogTestDeleteMessage(t, 30), appendOption{}).Appended)
-	manager := NewStreamManager("pchannel")
+	manager := NewStreamManager("pchannel", 4)
 	manager.Register("v1", transformLog)
 
 	stream, err := manager.AcquireStream(ctx, "pchannel")
@@ -115,7 +115,7 @@ func TestTransformLogStreamManagerCatchupDrainsDeletesAppendedAfterSubscribe(t *
 			NextChunkId:        1,
 		},
 	})
-	manager := NewStreamManager("pchannel")
+	manager := NewStreamManager("pchannel", 4)
 	manager.Register("v1", transformLog)
 
 	stream, err := manager.AcquireStream(ctx, "pchannel")
@@ -149,7 +149,7 @@ func TestTransformLogStreamManagerCatchupDrainsDeletesAppendedAfterSubscribe(t *
 func TestTransformLogStreamManagerRemovesRegisteredLog(t *testing.T) {
 	ctx := context.Background()
 	transformLog := New(Config{VChannel: "v1"})
-	manager := NewStreamManager("pchannel")
+	manager := NewStreamManager("pchannel", 4)
 	manager.Register("v1", transformLog)
 	manager.Remove("v1")
 

--- a/internal/streamingnode/server/wal/vchannel/transformlog/transform_log_test.go
+++ b/internal/streamingnode/server/wal/vchannel/transformlog/transform_log_test.go
@@ -19,7 +19,7 @@ import (
 
 func TestReadSyncsInitialFrontierBeforeFutureUpdates(t *testing.T) {
 	transformLog := New(Config{VChannel: "v1"})
-	manager := NewStreamManager("p1")
+	manager := NewStreamManager("p1", 4)
 	manager.Register("v1", transformLog)
 	for timeTick := uint64(1); timeTick <= 20; timeTick++ {
 		require.True(t, transformLog.syncUp(timeTick).Appended)
@@ -125,7 +125,7 @@ func (n *recordingTransformLogNotifier) notify(vchannel string) {
 
 func TestReadStopsAtEndTimeTick(t *testing.T) {
 	transformLog := New(Config{VChannel: "v1"})
-	manager := NewStreamManager("p1")
+	manager := NewStreamManager("p1", 4)
 	manager.Register("v1", transformLog)
 	require.True(t, transformLog.append(newTransformLogTestDeleteMessage(t, 10), appendOption{}).Appended)
 	require.True(t, transformLog.append(newTransformLogTestDeleteMessage(t, 20), appendOption{}).Appended)
@@ -182,7 +182,7 @@ func TestNewKeepsRecoveredChunksColdUntilRead(t *testing.T) {
 			NextChunkId:        1,
 		},
 	})
-	manager := NewStreamManager("p1")
+	manager := NewStreamManager("p1", 4)
 	manager.Register("v1", transformLog)
 
 	assert.Equal(t, 0, store.readCount("v1", 0))
@@ -259,7 +259,7 @@ func TestTruncateLoadsRecoveredColdChunkToAdvanceFirstChunk(t *testing.T) {
 
 func TestFlushWhileScannerDrainsDoesNotDuplicateEntries(t *testing.T) {
 	transformLog := New(Config{VChannel: "v1", Store: newMemoryStore()})
-	manager := NewStreamManager("p1")
+	manager := NewStreamManager("p1", 4)
 	manager.Register("v1", transformLog)
 	for timeTick := uint64(1); timeTick <= 20; timeTick++ {
 		require.True(t, transformLog.append(newTransformLogTestDeleteMessage(t, timeTick), appendOption{}).Appended)

--- a/internal/views/coord/balancer/balancer.go
+++ b/internal/views/coord/balancer/balancer.go
@@ -9,6 +9,7 @@ import (
 
 	"github.com/milvus-io/milvus/internal/views/coord/coordview"
 	"github.com/milvus-io/milvus/internal/views/qviews"
+	"github.com/milvus-io/milvus/pkg/v3/util/paramtable"
 )
 
 const defaultTickerInterval = 10 * time.Second
@@ -120,6 +121,11 @@ func (b *DefaultBalancer) loop(ctx context.Context) {
 	defer ticker.Stop()
 
 	for {
+		interval := paramtable.Get().QueryCoordCfg.QueryViewFullReconsileInterval.GetAsDuration(time.Second)
+		if interval != b.tickerInterval {
+			b.tickerInterval = interval
+			ticker.Reset(interval)
+		}
 		select {
 		case <-ctx.Done():
 			return

--- a/internal/views/coord/balancer/balancer_test.go
+++ b/internal/views/coord/balancer/balancer_test.go
@@ -229,6 +229,7 @@ func TestBalancer_ReconcileFullScanDoesNotRestackPreparing(t *testing.T) {
 func TestBalancer_StartStop(t *testing.T) {
 	reg := emptyRegistry(t)
 	b := NewDefaultBalancer(nil, reg, nil)
+	assert.Equal(t, 10*time.Second, b.tickerInterval)
 	ctx, cancel := context.WithCancel(context.Background())
 	defer cancel()
 
@@ -237,4 +238,14 @@ func TestBalancer_StartStop(t *testing.T) {
 	time.Sleep(10 * time.Millisecond)
 	b.Stop()
 	b.Stop()
+}
+
+func TestBalancer_UsesConfiguredTickerInterval(t *testing.T) {
+	reg := emptyRegistry(t)
+	builder := NewSnapshotBuilder(nil, reg, nil, nil, &BalanceConfig{
+		TickerInterval: 5 * time.Minute,
+	})
+	b := NewDefaultBalancer(builder, reg, nil)
+
+	assert.Equal(t, 5*time.Minute, b.tickerInterval)
 }

--- a/pkg/util/paramtable/component_param.go
+++ b/pkg/util/paramtable/component_param.go
@@ -4091,6 +4091,10 @@ type queryNodeConfig struct {
 	ExternalCollectionSamplePerSegment ParamItem `refreshable:"true"`
 	ExternalCollectionSampleRows       ParamItem `refreshable:"true"`
 	ExternalCollectionRawDataFactor    ParamItem `refreshable:"true"`
+
+	// query view recovery
+	QueryViewSegmentCatchupConcurrency    ParamItem `refreshable:"false"`
+	QueryViewTransformLogDrainConcurrency ParamItem `refreshable:"false"`
 }
 
 func formatDurationWithMillisecondFallback(v string) string {
@@ -5592,6 +5596,36 @@ user-task-polling:
 		Export:       false,
 	}
 	p.ExternalCollectionRawDataFactor.Init(base.mgr)
+
+	p.QueryViewSegmentCatchupConcurrency = ParamItem{
+		Key:          "queryNode.queryView.segmentCatchupConcurrency",
+		Version:      "3.0.0",
+		DefaultValue: "4",
+		Doc:          "Maximum number of concurrent QueryView sealed segment TransformLog catch-up tasks on each QueryNode.",
+		Export:       true,
+		Formatter: func(v string) string {
+			if getAsInt(v) < 1 {
+				return "1"
+			}
+			return v
+		},
+	}
+	p.QueryViewSegmentCatchupConcurrency.Init(base.mgr)
+
+	p.QueryViewTransformLogDrainConcurrency = ParamItem{
+		Key:          "queryNode.queryView.transformLogDrainConcurrency",
+		Version:      "3.0.0",
+		DefaultValue: "4",
+		Doc:          "Maximum number of concurrent QueryView TransformLog backlog drain tasks on each QueryNode.",
+		Export:       true,
+		Formatter: func(v string) string {
+			if getAsInt(v) < 1 {
+				return "1"
+			}
+			return v
+		},
+	}
+	p.QueryViewTransformLogDrainConcurrency.Init(base.mgr)
 }
 
 // /////////////////////////////////////////////////////////////////////////////
@@ -8213,11 +8247,13 @@ type streamingConfig struct {
 	FlushL1CommitConcurrency ParamItem `refreshable:"true"`
 
 	// recovery configuration.
-	WALRecoveryPersistInterval           ParamItem `refreshable:"true"`
-	WALRecoveryMaxDirtyMessage           ParamItem `refreshable:"true"`
-	WALRecoveryGracefulCloseTimeout      ParamItem `refreshable:"true"`
-	WALRecoverySchemaExpirationTolerance ParamItem `refreshable:"true"`
-	WALRecoveryTaskConcurrency           ParamItem `refreshable:"true"`
+	WALRecoveryPersistInterval                       ParamItem `refreshable:"true"`
+	WALRecoveryMaxDirtyMessage                       ParamItem `refreshable:"true"`
+	WALRecoveryGracefulCloseTimeout                  ParamItem `refreshable:"true"`
+	WALRecoverySchemaExpirationTolerance             ParamItem `refreshable:"true"`
+	WALRecoveryTaskConcurrency                       ParamItem `refreshable:"true"`
+	TransformLogCatchupConcurrencyPerStream          ParamItem `refreshable:"false"`
+	QueryViewLiveEventDispatchConcurrencyPerPChannel ParamItem `refreshable:"false"`
 
 	// wal rate limit
 	WALRateLimitDefaultBurst                     ParamItem `refreshable:"true"`
@@ -8669,6 +8705,36 @@ If the schema is older than (the channel checkpoint - tolerance), it will be rem
 		Export:       false,
 	}
 	p.WALRecoverySchemaExpirationTolerance.Init(base.mgr)
+
+	p.QueryViewLiveEventDispatchConcurrencyPerPChannel = ParamItem{
+		Key:          "streaming.queryView.liveEventDispatchConcurrencyPerPChannel",
+		Version:      "3.0.0",
+		DefaultValue: "4",
+		Doc:          "Maximum number of QueryRuntimes dispatching live events concurrently on each PChannel.",
+		Export:       true,
+		Formatter: func(v string) string {
+			if getAsInt(v) < 1 {
+				return "1"
+			}
+			return v
+		},
+	}
+	p.QueryViewLiveEventDispatchConcurrencyPerPChannel.Init(base.mgr)
+
+	p.TransformLogCatchupConcurrencyPerStream = ParamItem{
+		Key:          "streaming.transformLog.catchupConcurrencyPerStream",
+		Version:      "3.0.0",
+		DefaultValue: "4",
+		Doc:          "Maximum number of TransformLog subscriptions catching up concurrently on each stream.",
+		Export:       true,
+		Formatter: func(v string) string {
+			if getAsInt(v) < 1 {
+				return "1"
+			}
+			return v
+		},
+	}
+	p.TransformLogCatchupConcurrencyPerStream.Init(base.mgr)
 
 	p.OldVersionLastConfirmedWindowSize = ParamItem{
 		Key:     "streaming.walScanner.oldVersionLastConfirmedWindowSize",

--- a/pkg/util/paramtable/component_param.go
+++ b/pkg/util/paramtable/component_param.go
@@ -3159,6 +3159,7 @@ type queryCoordConfig struct {
 	UpdateTargetNeedSegmentDataReady ParamItem `refreshable:"true"`
 
 	AutoWarmupForNonPKIsolationCollection ParamItem `refreshable:"false"`
+	QueryViewFullReconsileInterval        ParamItem `refreshable:"true"`
 }
 
 func (p *queryCoordConfig) init(base *BaseTable) {
@@ -3883,6 +3884,21 @@ Set to 0 to disable the penalty period.`,
 		Export:       false,
 	}
 	p.AutoWarmupForNonPKIsolationCollection.Init(base.mgr)
+
+	p.QueryViewFullReconsileInterval = ParamItem{
+		Key:          "queryCoord.queryView.fullReconsileInterval",
+		Version:      "3.0.0",
+		DefaultValue: "10",
+		Doc:          "Interval in seconds for periodic QueryView full reconciliation.",
+		Export:       true,
+		Formatter: func(v string) string {
+			if getAsInt(v) < 1 {
+				return "1"
+			}
+			return v
+		},
+	}
+	p.QueryViewFullReconsileInterval.Init(base.mgr)
 }
 
 // /////////////////////////////////////////////////////////////////////////////

--- a/pkg/util/paramtable/component_param_test.go
+++ b/pkg/util/paramtable/component_param_test.go
@@ -135,6 +135,32 @@ func TestComponentParam_StorageIopsParams(t *testing.T) {
 	}
 }
 
+func TestComponentParam_QueryViewConcurrency(t *testing.T) {
+	Init()
+	params := Get()
+	for _, test := range []struct {
+		name string
+		item *ParamItem
+	}{
+		{name: "segment catch-up", item: &params.QueryNodeCfg.QueryViewSegmentCatchupConcurrency},
+		{name: "transform log drain", item: &params.QueryNodeCfg.QueryViewTransformLogDrainConcurrency},
+		{name: "transform log stream catch-up", item: &params.StreamingCfg.TransformLogCatchupConcurrencyPerStream},
+		{name: "live event dispatch", item: &params.StreamingCfg.QueryViewLiveEventDispatchConcurrencyPerPChannel},
+	} {
+		t.Run(test.name, func(t *testing.T) {
+			key := test.item.Key
+			params.Reset(key)
+			t.Cleanup(func() { params.Reset(key) })
+
+			assert.Equal(t, 4, test.item.GetAsInt())
+			params.Save(key, "32")
+			assert.Equal(t, 32, test.item.GetAsInt())
+			params.Save(key, "0")
+			assert.Equal(t, 1, test.item.GetAsInt())
+		})
+	}
+}
+
 func TestComponentParam(t *testing.T) {
 	Init()
 	params := Get()

--- a/pkg/util/paramtable/component_param_test.go
+++ b/pkg/util/paramtable/component_param_test.go
@@ -161,6 +161,23 @@ func TestComponentParam_QueryViewConcurrency(t *testing.T) {
 	}
 }
 
+func TestComponentParam_QueryViewFullReconsileInterval(t *testing.T) {
+	Init()
+	params := Get()
+	item := &params.QueryCoordCfg.QueryViewFullReconsileInterval
+	params.Reset(item.Key)
+	t.Cleanup(func() { params.Reset(item.Key) })
+
+	assert.Equal(t, "queryCoord.queryView.fullReconsileInterval", item.Key)
+	assert.Equal(t, "10", item.DefaultValue)
+	assert.True(t, item.Export)
+	assert.Equal(t, 10*time.Second, item.GetAsDuration(time.Second))
+	params.Save(item.Key, "300")
+	assert.Equal(t, 5*time.Minute, item.GetAsDuration(time.Second))
+	params.Save(item.Key, "0")
+	assert.Equal(t, time.Second, item.GetAsDuration(time.Second))
+}
+
 func TestComponentParam(t *testing.T) {
 	Init()
 	params := Get()


### PR DESCRIPTION
## What changed

- Add QueryNode configuration for QueryView segment catch-up and TransformLog drain concurrency.
- Add StreamingNode configuration for TransformLog catch-up per stream and live-event dispatch per PChannel.
- Pass concurrency explicitly through worker-pool constructors and keep production defaults in ParamTable.
- Require QueryResource managers to use the shared per-PChannel dispatcher instead of creating a fixed fallback dispatcher.
- Add QueryCoord configuration for the QueryView full reconciliation interval while preserving the existing 10-second default.
- Mark the reconciliation interval refreshable and reset the active balancer ticker when the configured value changes. Non-positive values are normalized to one second.

## Verification

- ParamTable concurrency and full reconciliation interval tests pass.
- Diff whitespace and conflict-marker checks pass.
- QueryNode, StreamingNode, and Balancer package tests could not compile in the current environment because the local Milvus C++ pkg-config dependencies are unavailable.