### PR TITLE
enhance: skip redundant collection index meta updates

### DIFF
--- a/internal/datacoord/services.go
+++ b/internal/datacoord/services.go
@@ -17,9 +17,11 @@
 package datacoord
 
 import (
+	"cmp"
 	"context"
 	"fmt"
 	"math"
+	"slices"
 	"strconv"
 	"time"
 
@@ -1292,7 +1294,7 @@ func (s *Server) queryViewCollectionIndexInfos(collectionID int64) []*indexpb.In
 }
 
 func packQueryViewCollectionIndexInfos(indexes []*model.Index) []*indexpb.IndexInfo {
-	return lo.Map(indexes, func(index *model.Index, _ int) *indexpb.IndexInfo {
+	infos := lo.Map(indexes, func(index *model.Index, _ int) *indexpb.IndexInfo {
 		return &indexpb.IndexInfo{
 			CollectionID:    index.CollectionID,
 			FieldID:         index.FieldID,
@@ -1304,6 +1306,10 @@ func packQueryViewCollectionIndexInfos(indexes []*model.Index) []*indexpb.IndexI
 			UserIndexParams: index.UserIndexParams,
 		}
 	})
+	slices.SortFunc(infos, func(left, right *indexpb.IndexInfo) int {
+		return cmp.Compare(left.GetIndexID(), right.GetIndexID())
+	})
+	return infos
 }
 
 func (s *Server) packQueryViewSegmentLoadInfo(segment *datapb.SegmentInfo, indexInfos []*indexpb.IndexInfo, segmentIndexes map[int64]*model.SegmentIndex) *querypb.SegmentLoadInfo {

--- a/internal/datacoord/services_test.go
+++ b/internal/datacoord/services_test.go
@@ -73,6 +73,20 @@ type ServerSuite struct {
 	mockMixCoord *mocks2.MixCoord
 }
 
+func TestPackQueryViewCollectionIndexInfosUsesDeterministicOrder(t *testing.T) {
+	indexes := []*model.Index{
+		{CollectionID: 1, FieldID: 103, IndexID: 30, IndexName: "third"},
+		{CollectionID: 1, FieldID: 101, IndexID: 10, IndexName: "first"},
+		{CollectionID: 1, FieldID: 102, IndexID: 20, IndexName: "second"},
+	}
+
+	infos := packQueryViewCollectionIndexInfos(indexes)
+
+	require.Equal(t, []int64{10, 20, 30}, lo.Map(infos, func(info *indexpb.IndexInfo, _ int) int64 {
+		return info.GetIndexID()
+	}))
+}
+
 func (s *ServerSuite) SetupSuite() {
 	snmanager.ResetStreamingNodeManager()
 	b := mock_balancer.NewMockBalancer(s.T())

--- a/internal/querynodev2/segments/collection.go
+++ b/internal/querynodev2/segments/collection.go
@@ -421,6 +421,21 @@ func (c *Collection) updateIndexMeta(meta *segcorepb.CollectionIndexMeta) error 
 // UpdateIndexMeta updates the native collection index metadata while keeping
 // it in the same transition epoch as schema changes.
 func (c *Collection) UpdateIndexMeta(meta *segcorepb.CollectionIndexMeta) error {
+	if meta == nil {
+		return nil
+	}
+
+	c.mu.RLock()
+	if c.ccollection == nil {
+		c.mu.RUnlock()
+		return merr.WrapErrServiceInternal("update index meta on released collection")
+	}
+	unchanged := proto.Equal(c.ccollection.IndexMeta(), meta)
+	c.mu.RUnlock()
+	if unchanged {
+		return nil
+	}
+
 	c.lockSchemaTransitionForUpdate()
 	defer c.unlockSchemaTransitionForUpdate()
 

--- a/internal/querynodev2/segments/collection_test.go
+++ b/internal/querynodev2/segments/collection_test.go
@@ -20,6 +20,7 @@ import (
 	"fmt"
 	"runtime"
 	"sync"
+	"sync/atomic"
 	"testing"
 	"time"
 
@@ -388,6 +389,94 @@ func (s *CollectionManagerSuite) TestCollectionUpdateIndexMeta() {
 
 	s.Require().NoError(coll.UpdateIndexMeta(indexMeta))
 	s.True(proto.Equal(indexMeta, coll.GetCCollection().IndexMeta()))
+}
+
+func (s *CollectionManagerSuite) TestCollectionUpdateIndexMetaUnchangedBypassesSchemaTransition() {
+	coll := s.cm.Get(1)
+	s.Require().NotNil(coll)
+	indexMeta := proto.Clone(coll.GetCCollection().IndexMeta()).(*segcorepb.CollectionIndexMeta)
+
+	releaseReader := holdInsertSchemaTransition(s.T(), coll)
+	defer releaseReader()
+
+	done := make(chan error, 1)
+	go func() {
+		done <- coll.UpdateIndexMeta(indexMeta)
+	}()
+
+	select {
+	case err := <-done:
+		s.Require().NoError(err)
+	case <-time.After(time.Second):
+		s.T().Fatal("unchanged index meta waited for the schema transition lock")
+	}
+}
+
+func (s *CollectionManagerSuite) TestCollectionUpdateIndexMetaChangeWaitsForSchemaTransition() {
+	coll := s.cm.Get(1)
+	s.Require().NotNil(coll)
+	indexMeta := proto.Clone(coll.GetCCollection().IndexMeta()).(*segcorepb.CollectionIndexMeta)
+	indexMeta.MaxIndexRowCount++
+
+	releaseReader := holdInsertSchemaTransition(s.T(), coll)
+	defer releaseReader()
+
+	done := make(chan error, 1)
+	go func() {
+		done <- coll.UpdateIndexMeta(indexMeta)
+	}()
+	waitForSchemaTransitionWriter(s.T(), coll)
+
+	select {
+	case err := <-done:
+		s.Require().NoError(err)
+		s.T().Fatal("changed index meta bypassed the schema transition lock")
+	default:
+	}
+
+	releaseReader()
+	s.Require().NoError(<-done)
+}
+
+func (s *CollectionManagerSuite) TestCollectionConcurrentIndexMetaChangeUpdatesNativeOnce() {
+	coll := s.cm.Get(1)
+	s.Require().NotNil(coll)
+	indexMeta := proto.Clone(coll.GetCCollection().IndexMeta()).(*segcorepb.CollectionIndexMeta)
+	indexMeta.MaxIndexRowCount++
+
+	var calls atomic.Int32
+	var origin func(*segcore.CCollection, *segcorepb.CollectionIndexMeta) error
+	patch := mockey.Mock((*segcore.CCollection).UpdateIndexMeta).
+		To(func(collection *segcore.CCollection, meta *segcorepb.CollectionIndexMeta) error {
+			calls.Add(1)
+			return origin(collection, meta)
+		}).
+		Origin(&origin).
+		Build()
+	s.T().Cleanup(func() {
+		patch.UnPatch()
+	})
+
+	const concurrency = 10
+	start := make(chan struct{})
+	errs := make(chan error, concurrency)
+	var wg sync.WaitGroup
+	wg.Add(concurrency)
+	for range concurrency {
+		go func() {
+			defer wg.Done()
+			<-start
+			errs <- coll.UpdateIndexMeta(indexMeta)
+		}()
+	}
+	close(start)
+	wg.Wait()
+	close(errs)
+
+	for err := range errs {
+		s.Require().NoError(err)
+	}
+	s.Equal(int32(1), calls.Load())
 }
 
 func (s *CollectionManagerSuite) TestPutOrRefUpdateIndexMetaWaitsForCollectionNativeLock() {


### PR DESCRIPTION
## What this PR does

- Sort DataCoord collection index metadata by index ID so equivalent QueryView snapshots have deterministic protobuf ordering.
- Skip schema transition serialization when QueryNode already holds identical collection index metadata.
- Preserve schema transition serialization and the locked equality recheck for actual or concurrent metadata changes.

## Test Plan

- `go test -v -count=1 -tags dynamic,test -gcflags="all=-N -l" ./internal/datacoord -run "^TestPackQueryViewCollectionIndexInfosUsesDeterministicOrder$" -timeout 300s`
- `go test -v -count=10 -tags dynamic,test -gcflags="all=-N -l" ./internal/querynodev2/segments -run "^TestCollectionManager/(TestCollectionUpdateIndexMetaUnchangedBypassesSchemaTransition|TestCollectionUpdateIndexMetaChangeWaitsForSchemaTransition|TestCollectionConcurrentIndexMetaChangeUpdatesNativeOnce)$" -timeout 300s`
- `git diff --check`