### PR TITLE
fix: stop recovery close when cleanup cannot advance

### DIFF
--- a/internal/streamingnode/server/wal/recovery/recovery_background_task.go
+++ b/internal/streamingnode/server/wal/recovery/recovery_background_task.go
@@ -76,23 +76,58 @@ func (rs *recoveryStorageImpl) persistDritySnapshotWhenClosing() error {
 	ctx, cancel := context.WithTimeout(context.Background(), rs.cfg.gracefulTimeout)
 	defer cancel()
 
+	persistIfAny := func() (bool, error) {
+		if rs.pendingPersistSnapshot == nil {
+			rs.pendingPersistSnapshot = rs.consumeDirtySnapshot()
+		}
+		// Cleanup candidates may remain pending until a future physical
+		// checkpoint passes their tombstone. They are safe to leave for the
+		// next WAL owner when no persistable snapshot can be produced.
+		if rs.pendingPersistSnapshot == nil {
+			return false, nil
+		}
+		if err := rs.persistDirtySnapshot(ctx, mlog.InfoLevel); err != nil {
+			return false, err
+		}
+		return true, nil
+	}
+
 	for {
-		if rs.taskScheduler != nil {
-			if err := rs.taskScheduler.WaitIdle(ctx); err != nil {
-				return err
-			}
-		}
-		for rs.isDirty() {
-			if err := rs.persistDirtySnapshot(ctx, mlog.InfoLevel); err != nil {
-				return err
-			}
+		if err := ctx.Err(); err != nil {
+			return err
 		}
 		if rs.taskScheduler != nil {
 			if err := rs.taskScheduler.WaitIdle(ctx); err != nil {
 				return err
 			}
+		}
+		persisted, err := persistIfAny()
+		if err != nil {
+			return err
+		}
+		if persisted {
+			continue
+		}
+
+		// Wait once more before declaring no progress, so a task submitted
+		// concurrently with the first idle observation can still publish its
+		// final dirty state.
+		if rs.taskScheduler != nil {
+			if err := rs.taskScheduler.WaitIdle(ctx); err != nil {
+				return err
+			}
+		}
+		if err := ctx.Err(); err != nil {
+			return err
 		}
 		if !rs.isDirty() {
+			break
+		}
+		persisted, err = persistIfAny()
+		if err != nil {
+			return err
+		}
+		if !persisted {
 			break
 		}
 	}

--- a/internal/streamingnode/server/wal/recovery/recovery_storage_impl_test.go
+++ b/internal/streamingnode/server/wal/recovery/recovery_storage_impl_test.go
@@ -16,6 +16,7 @@ import (
 	"github.com/milvus-io/milvus/internal/streamingnode/server/wal/utility"
 	"github.com/milvus-io/milvus/internal/streamingnode/server/wal/vchannel"
 	"github.com/milvus-io/milvus/pkg/v3/proto/streamingpb"
+	"github.com/milvus-io/milvus/pkg/v3/proto/viewpb"
 	"github.com/milvus-io/milvus/pkg/v3/streaming/util/message"
 	"github.com/milvus-io/milvus/pkg/v3/streaming/util/types"
 	"github.com/milvus-io/milvus/pkg/v3/streaming/walimpls"
@@ -104,6 +105,63 @@ func TestRecoveryStorageCloseDrainsPendingCleanup(t *testing.T) {
 	defer consumeMock.UnPatch()
 	require.NoError(t, storage.persistDritySnapshotWhenClosing())
 	assert.Equal(t, 1, consumed)
+}
+
+func TestRecoveryStorageCloseLeavesCleanupBlockedByPhysicalCheckpoint(t *testing.T) {
+	storage := newTestRecoveryStorage(t, &utility.WALCheckpoint{
+		MessageID: walimplstest.NewTestMessageID(10),
+		TimeTick:  100,
+		DataCheckpoint: &utility.WALConsumeCheckpoint{
+			MessageID: walimplstest.NewTestMessageID(10),
+			TimeTick:  100,
+		},
+	})
+	vchannelMeta := newRecoveryTestVChannelMeta("v1", 100)
+	vchannelMeta.SegmentDataVersionSummary = &viewpb.DataVersion{StreamingVersion: 2}
+	manager, err := vchannel.NewPChannelRecoveryManager(vchannel.PChannelManagerConfig{
+		PChannel:      "test-pchannel",
+		VChannelMetas: map[string]*streamingpb.VChannelMeta{"v1": vchannelMeta},
+		Segments: map[int64]*streamingpb.SegmentAssignmentMeta{
+			101: {
+				SegmentId:              101,
+				CollectionId:           100,
+				Vchannel:               "v1",
+				State:                  streamingpb.SegmentAssignmentState_SEGMENT_ASSIGNMENT_STATE_TOMBSTONED,
+				CheckpointTimeTick:     100,
+				DataCheckpointTimeTick: 100,
+				TombstoneTimeTick:      100,
+				SealedAtDataVersion:    &viewpb.DataVersion{StreamingVersion: 2},
+				Stat:                   &streamingpb.SegmentAssignmentStat{},
+			},
+		},
+		NodeScheduler: storage.nodeScheduler,
+		Runtime: moduleapi.Runtime{
+			Scheduler: storage.taskScheduler,
+			Notifier:  storage,
+		},
+	})
+	require.NoError(t, err)
+	t.Cleanup(manager.Close)
+	storage.vchannelManager = manager
+
+	require.True(t, manager.HasPendingCleanup())
+	require.Empty(t, manager.ConsumeCleanupSnapshots(moduleapi.CleanupContext{
+		MetaPhysicalTimeTick: 100,
+		DataPhysicalTimeTick: 100,
+	}))
+
+	done := make(chan error, 1)
+	go func() {
+		done <- storage.persistDritySnapshotWhenClosing()
+	}()
+	select {
+	case err := <-done:
+		require.NoError(t, err)
+	case <-time.After(time.Second):
+		t.Fatal("recovery storage close did not stop after cleanup made no progress")
+	}
+	assert.True(t, storage.gracefulClosed)
+	assert.True(t, manager.HasPendingCleanup())
 }
 
 func (b *recordingRecoveryStreamBuilder) WALName() message.WALName {


### PR DESCRIPTION
issue: milvus-io/milvus#40451

### What changed

- stop graceful recovery close when pending cleanup cannot produce a persistable snapshot
- check the close context explicitly while preserving the second scheduler idle observation
- add a regression test with a tombstoned segment blocked by equal physical checkpoints

### Why

Pending segment cleanup can remain valid while both persisted physical checkpoints equal the tombstone timetick. Treating that candidate as mandatory dirty state causes the close loop to repeatedly consume no snapshot without observing its timeout.

The close path now drains every persistable snapshot and leaves cleanup that cannot yet advance for the next WAL owner.

### Verification

- recovery close cleanup tests
- full `internal/streamingnode/server/wal/recovery` package tests
- gofumpt v0.5.0
- git diff check